### PR TITLE
Updated to use str2bool from pip instead of distutils that was removed from python 3.12.

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -17,7 +17,7 @@ try:
     import re
     import math
     import sys
-    import distutils.util
+    import str2bool
     import asyncio
     from guessit import guessit
     import ntpath
@@ -2772,7 +2772,7 @@ class Prep():
                         else:
                             pass
                     elif key == 'personalrelease':
-                        meta[key] = bool(distutils.util.strtobool(str(value.get(key, 'False'))))
+                        meta[key] = bool(str2bool(str(value.get(key, 'False'))))
                     elif key == 'template':
                         meta['desc_template'] = value.get(key)
                     else:

--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 from src.trackers.COMMON import COMMON
@@ -207,7 +207,7 @@ class ACM():
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         acm_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/AITHER.py
+++ b/src/trackers/AITHER.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import json
 import os
 import platform
@@ -39,7 +39,7 @@ class AITHER():
         type_id = await self.get_type_id(meta['type'])
         resolution_id = await self.get_res_id(meta['resolution'])
         name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -3,7 +3,7 @@
 import os
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import platform
 from pymediainfo import MediaInfo
 
@@ -68,7 +68,7 @@ class ANT():
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)
         flags = await self.get_flags(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) is False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) is False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import urllib
 import os
 import platform
@@ -39,7 +39,7 @@ class BHD():
         tags = await self.get_tags(meta)
         custom, edition = await self.get_edition(meta, tags)
         bhd_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1
@@ -263,7 +263,7 @@ class BHD():
 
     async def get_live(self, meta): 
         draft = self.config['TRACKERS'][self.tracker]['draft_default'].strip()
-        draft = bool(distutils.util.strtobool(str(draft))) #0 for send to draft, 1 for live
+        draft = bool(str2bool(str(draft))) #0 for send to draft, 1 for live
         if draft:
             draft_int = 0
         else:

--- a/src/trackers/BHDTV.py
+++ b/src/trackers/BHDTV.py
@@ -4,7 +4,7 @@ import asyncio
 from torf import Torrent
 import requests
 from src.console import console
-import distutils.util
+import str2bool
 from pprint import pprint
 import os
 import traceback
@@ -54,7 +54,7 @@ class BHDTV():
         # region_id = await common.unit3d_region_ids(meta.get('region'))
         # distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         if meta['anon'] == 0 and bool(
-                distutils.util.strtobool(self.config['TRACKERS'][self.tracker].get('anon', "False"))) == False:
+                str2bool(self.config['TRACKERS'][self.tracker].get('anon', "False"))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -49,7 +49,7 @@ class BLU():
         resolution_id = await self.get_res_id(meta['resolution'])
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/CBR.py
+++ b/src/trackers/CBR.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -40,7 +40,7 @@ class CBR():
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/FL.py
+++ b/src/trackers/FL.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 import os
 from pathlib import Path
-import distutils.util
+import str2bool
 import json
 import glob
 import pickle
@@ -161,7 +161,7 @@ class FL():
             if int(meta.get('imdb_id', '').replace('tt', '')) != 0:
                 data['imdbid'] = meta.get('imdb_id', '').replace('tt', '')
                 data['description'] = meta['imdb_info'].get('genres', '')
-            if self.uploader_name not in ("", None) and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+            if self.uploader_name not in ("", None) and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
                 data['epenis'] = self.uploader_name
             if has_ro_audio:
                 data['materialro'] = 'on'

--- a/src/trackers/FNP.py
+++ b/src/trackers/FNP.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -82,7 +82,7 @@ class FNP():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/HDT.py
+++ b/src/trackers/HDT.py
@@ -6,7 +6,6 @@ import json
 import glob
 import cli_ui
 import pickle
-import distutils
 from pathlib import Path
 from bs4 import BeautifulSoup
 from unidecode import unidecode
@@ -173,7 +172,7 @@ class HDT():
                 data['season'] = 'false'
             
             # Anonymous check
-            if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+            if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
                 data['anonymous'] = 'false'
             else:
                 data['anonymous'] = 'true'

--- a/src/trackers/HP.py
+++ b/src/trackers/HP.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -78,7 +78,7 @@ class HP():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import os
 import re
 import platform
@@ -37,7 +37,7 @@ class HUNO():
         cat_id = await self.get_cat_id(meta['category'])
         type_id = await self.get_type_id(meta)
         resolution_id = await self.get_res_id(meta['resolution'])
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(self.config['TRACKERS']['HUNO'].get('anon', "False"))) == False:
+        if meta['anon'] == 0 and bool(str2bool(self.config['TRACKERS']['HUNO'].get('anon', "False"))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/JPTV.py
+++ b/src/trackers/JPTV.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -92,7 +92,7 @@ class JPTV():
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         jptv_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/LCD.py
+++ b/src/trackers/LCD.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -40,7 +40,7 @@ class LCD():
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -87,7 +87,7 @@ class LST():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -88,7 +88,7 @@ class LT():
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
         lt_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -8,7 +8,7 @@ import os
 import cli_ui
 import pickle
 import re
-import distutils.util
+import str2bool
 from pathlib import Path
 from src.trackers.COMMON import COMMON
 
@@ -75,7 +75,7 @@ class MTV():
         mtv_name = await self.edit_name(meta)
 
         # anon
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/NBL.py
+++ b/src/trackers/NBL.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 from guessit import guessit 
 

--- a/src/trackers/OE.py
+++ b/src/trackers/OE.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import json
 import os
 import platform
@@ -37,7 +37,7 @@ class OE():
         type_id = await self.get_type_id(meta['type'], meta.get('tv_pack', 0), meta.get('video_codec'), meta.get('category', ""))
         resolution_id = await self.get_res_id(meta['resolution'])
         oe_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -82,7 +82,7 @@ class OTW():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/PTER.py
+++ b/src/trackers/PTER.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import traceback
 import json
 import glob
-import distutils.util
+import str2bool
 import cli_ui
 import pickle
 from unidecode import unidecode
@@ -288,7 +288,7 @@ class PTER():
         return image_list
 
     async def get_anon(self, anon):
-        if anon == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if anon == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 'no'
         else:
             anon = 'yes'

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -2,7 +2,7 @@ import cli_ui
 import requests
 import asyncio
 import re
-import distutils.util
+import str2bool
 import os
 from pathlib import Path
 import time
@@ -33,7 +33,7 @@ class PTP():
         self.announce_url = config['TRACKERS']['PTP'].get('announce_url', '').strip() 
         self.username = config['TRACKERS']['PTP'].get('username', '').strip() 
         self.password = config['TRACKERS']['PTP'].get('password', '').strip()
-        self.web_source = distutils.util.strtobool(str(config['TRACKERS']['PTP'].get('add_web_source_to_desc', True))) 
+        self.web_source = str2bool(str(config['TRACKERS']['PTP'].get('add_web_source_to_desc', True))) 
         self.user_agent = f'Upload Assistant/2.1 ({platform.system()} {platform.release()})'
         self.banned_groups = ['aXXo',  'BMDru', 'BRrip', 'CM8', 'CrEwSaDe', 'CTFOH', 'd3g', 'DNL', 'FaNGDiNG0', 'HD2DVD', 'HDTime', 'ION10', 'iPlanet',
                               'KiNGDOM', 'mHD', 'mSD', 'nHD', 'nikt0', 'nSD', 'NhaNc3', 'OFT', 'PRODJi', 'SANTi', 'SPiRiT', 'STUTTERSHIT', 'ViSION', 'VXT',

--- a/src/trackers/R4E.py
+++ b/src/trackers/R4E.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import json
 import tmdbsimple as tmdb
 import os
@@ -36,7 +36,7 @@ class R4E():
         type_id = await self.get_type_id(meta['resolution'])
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS']['R4E'].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS']['R4E'].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/RF.py
+++ b/src/trackers/RF.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -41,7 +41,7 @@ class RF():
         type_id = await self.get_type_id(meta['type'])
         resolution_id = await self.get_res_id(meta['resolution'])
         stt_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -2,7 +2,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import json
 import os
 import platform
@@ -36,7 +36,7 @@ class STC():
         type_id = await self.get_type_id(meta['type'], meta.get('tv_pack', 0), meta.get('sd', 0), meta.get('category', ""))
         resolution_id = await self.get_res_id(meta['resolution'])
         stc_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/STT.py
+++ b/src/trackers/STT.py
@@ -3,7 +3,7 @@
 import asyncio
 import requests
 from difflib import SequenceMatcher
-import distutils.util
+import str2bool
 import json
 import os
 import platform
@@ -37,7 +37,7 @@ class STT():
         type_id = await self.get_type_id(meta['type'])
         resolution_id = await self.get_res_id(meta['resolution'])
         stt_name = await self.edit_name(meta)
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/TDC.py
+++ b/src/trackers/TDC.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 
 from src.trackers.COMMON import COMMON
@@ -77,7 +77,7 @@ class TDC():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/TTG.py
+++ b/src/trackers/TTG.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import traceback
 import json
-import distutils.util
+import str2bool
 import cli_ui
 from unidecode import unidecode
 from urllib.parse import urlparse, quote
@@ -104,7 +104,7 @@ class TTG():
         return type_id
 
     async def get_anon(self, anon):
-        if anon == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if anon == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 'no'
         else:
             anon = 'yes'

--- a/src/trackers/UNIT3D_TEMPLATE.py
+++ b/src/trackers/UNIT3D_TEMPLATE.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -82,7 +82,7 @@ class UNIT3D_TEMPLATE():
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1

--- a/src/trackers/UTP.py
+++ b/src/trackers/UTP.py
@@ -2,7 +2,7 @@
 # import discord
 import asyncio
 import requests
-import distutils.util
+import str2bool
 import os
 import platform
 
@@ -37,7 +37,7 @@ class UTP():
         resolution_id = await self.get_res_id(meta['resolution'])
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and bool(distutils.util.strtobool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
+        if meta['anon'] == 0 and bool(str2bool(str(self.config['TRACKERS'][self.tracker].get('anon', "False")))) == False:
             anon = 0
         else:
             anon = 1


### PR DESCRIPTION
Updated to use str2bool from pip instead of distutils that was removed from python 3.12.

	modified:   src/prep.py
	modified:   src/trackers/ACM.py
	modified:   src/trackers/AITHER.py
	modified:   src/trackers/ANT.py
	modified:   src/trackers/BHD.py
	modified:   src/trackers/BHDTV.py
	modified:   src/trackers/BLU.py
	modified:   src/trackers/CBR.py
	modified:   src/trackers/FL.py
	modified:   src/trackers/FNP.py
	modified:   src/trackers/HDT.py
	modified:   src/trackers/HP.py
	modified:   src/trackers/HUNO.py
	modified:   src/trackers/JPTV.py
	modified:   src/trackers/LCD.py
	modified:   src/trackers/LST.py
	modified:   src/trackers/LT.py
	modified:   src/trackers/MTV.py
	modified:   src/trackers/NBL.py
	modified:   src/trackers/OE.py
	modified:   src/trackers/OTW.py
	modified:   src/trackers/PTER.py
	modified:   src/trackers/PTP.py
	modified:   src/trackers/R4E.py
	modified:   src/trackers/RF.py
	modified:   src/trackers/STC.py
	modified:   src/trackers/STT.py
	modified:   src/trackers/TDC.py
	modified:   src/trackers/TTG.py
	modified:   src/trackers/UNIT3D_TEMPLATE.py
	modified:   src/trackers/UTP.py