### PR TITLE
Allow piece size > 16 MiB

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -158,7 +158,6 @@ async def do_the_thing(base_dir):
             console.print(f"[red]There was an issue with your input. If you think this was not an issue, please make a report that includes the full command used.")
             exit()
 
-
     base_meta = {k: v for k, v in meta.items()}
     for path in queue:
         meta = {k: v for k, v in base_meta.items()}
@@ -207,11 +206,11 @@ async def do_the_thing(base_dir):
                 if reuse_torrent != None:
                     prep.create_base_from_existing_torrent(reuse_torrent, meta['base_dir'], meta['uuid'])
             if meta['nohash'] == False and reuse_torrent == None:
-                prep.create_torrent(meta, Path(meta['path']), "BASE", meta.get('piece_size_max', 0))
+                prep.create_torrent(meta, Path(meta['path']), "BASE")
             if meta['nohash']:
                 meta['client'] = "none"
         elif os.path.exists(os.path.abspath(f"{meta['base_dir']}/tmp/{meta['uuid']}/BASE.torrent")) and meta.get('rehash', False) == True and meta['nohash'] == False:
-            prep.create_torrent(meta, Path(meta['path']), "BASE", meta.get('piece_size_max', 0))
+            prep.create_torrent(meta, Path(meta['path']), "BASE")
         if int(meta.get('randomized', 0)) >= 1:
             prep.create_random_torrents(meta['base_dir'], meta['uuid'], meta['randomized'], meta['path'])
             
@@ -244,8 +243,6 @@ async def do_the_thing(base_dir):
         if meta.get('manual', False):
             trackers.insert(0, "MANUAL")
         
-
-
         ####################################
         #######  Upload to Trackers  #######
         ####################################


### PR DESCRIPTION
ANT has realistic piece count + .torrent size requirements for uploaded .torrents, this code change respects those requirements.

Existing torrent hashes are not affected by this change, but all newly created torrents and torrents needed for ANT will use the following constraints:

```Piece count between 1000 & 2000 pieces with a .torrent size < 100 KiB.```

Perhaps in the future I might add an argument allowing override.