### PR TITLE
define service_longname when service specified

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -606,6 +606,9 @@ class Prep():
         meta['source'], meta['type'] = self.get_source(meta['type'], video, meta['path'], meta['is_disc'], meta)
         if meta.get('service', None) in (None, ''):
             meta['service'], meta['service_longname'] = self.get_service(video, meta.get('tag', ''), meta['audio'], meta['filename'])
+        elif meta.get('service'):
+            services = self.get_service(get_services_only=True)
+            meta['service_longname'] = max((k for k, v in services.items() if v == meta['service']), key=len, default=meta['service'])
         meta['uhd'] = self.get_uhd(meta['type'], guessit(meta['path']), meta['resolution'], meta['path'])
         meta['hdr'] = self.get_hdr(mi, bdinfo)
         meta['distributor'] = self.get_distributor(meta['distributor'])
@@ -3004,8 +3007,7 @@ class Prep():
 
         return meta
 
-    def get_service(self, video, tag, audio, guess_title):
-        service = guessit(video).get('streaming_service', "")
+    def get_service(self, video=None, tag=None, audio=None, guess_title=None, get_services_only=False):
         services = {
             '9NOW': '9NOW', '9Now': '9NOW', 'AE': 'AE', 'A&E': 'AE', 'AJAZ': 'AJAZ', 'Al Jazeera English': 'AJAZ',
             'ALL4': 'ALL4', 'Channel 4': 'ALL4', 'AMBC': 'AMBC', 'ABC': 'AMBC', 'AMC': 'AMC', 'AMZN': 'AMZN',
@@ -3052,6 +3054,10 @@ class Prep():
             'W Network': 'WNET', 'WWEN': 'WWEN', 'WWE Network': 'WWEN', 'XBOX': 'XBOX', 'Xbox Video': 'XBOX', 'YHOO': 'YHOO', 'Yahoo': 'YHOO',
             'YT': 'YT', 'ZDF': 'ZDF', 'iP': 'iP', 'BBC iPlayer': 'iP', 'iQIYI': 'iQIYI', 'iT': 'iT', 'iTunes': 'iT'
         }
+
+        if get_services_only:
+            return services
+        service = guessit(video).get('streaming_service', "")
 
         video_name = re.sub(r"[.()]", " ", video.replace(tag, '').replace(guess_title, ''))
         if "DTS-HD MA" in audio:


### PR DESCRIPTION
fixes https://github.com/Audionut/Upload-Assistant/issues/56

If --service is argumented, service_longname is not set in the meta causing error https://github.com/Audionut/Upload-Assistant/blob/69c0bce2a025444a538eddeccb281c3e5b4529ba/src/trackers/MTV.py#L372

I'm really lost as to what the intended purpose was here. If I just keyed like the existing logic, it would key from the first key, and  just use CR, being the first key, instead of the services long name, Crunchy Roll, (since every service long_name key is duplicated from an abbreviated service key).

If I manually set --service "Crunchy Roll", then it would use "Crunchy Roll" for both the service and service_longname meta.

What on earth was the purpose of service_longname if it's just set as the abbreviated service name.......And if you service the longname, why didn't it use the abbreviated service name for the service meta.

This PR sets the service longname to the actual service longname when the argument --service is used.