### PR TITLE
HUNO web type fix

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -221,11 +221,12 @@ class HUNO():
     async def get_type_id(self, meta):
         basename = self.get_basename(meta)
         type = meta['type']
+        video_encode = meta['video_encode']
 
         if type == 'REMUX':
             return '2'
         elif type in ('WEBDL', 'WEBRIP'):
-            return '15' if 'x265' in basename else '3'
+            return '15' if 'x265' in video_encode else '3'
         elif type in ('ENCODE', 'HDTV'):
             return '15'
         elif type == 'DISC':

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -219,7 +219,6 @@ class HUNO():
         return category_id
 
     async def get_type_id(self, meta):
-        basename = self.get_basename(meta)
         type = meta['type']
         video_encode = meta['video_encode']
 


### PR DESCRIPTION
Web encodes used to get labelled as 'WEB' even when forced `-type encode` was passed.
Now, it checks `video_encode` gathered by [prep.py](https://github.com/Audionut/Upload-Assistant/blob/master/src/prep.py), instead of `basename`, which is more accurate.
Removed redundant `basename` declaration.