### PR TITLE
Adding thumbsize and screenheader options

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -24,6 +24,10 @@ config = {
 
 
         "screens": "6",
+        # Providing the option to change the size of the thumbnails where supported, default is 350
+        "thumbnail_size": "350"
+        # Providing the option to add a header, in bbcode, above the screenshot section where supported
+        # "screenshot_header": "[centers] SCREENSHOTS [/center]"
         # Enable lossless PNG Compression (True/False)
         "optimize_images": True,
 

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -23,6 +23,7 @@ class COMMON():
                     new_torrent.metainfo.pop(each, None)
             new_torrent.metainfo['announce'] = self.config['TRACKERS'][tracker].get('announce_url', "https://fake.tracker").strip()
             new_torrent.metainfo['info']['source'] = source_flag
+            new_torrent.metainfo['comment'] = 'Uploaded to ' + tracker
             Torrent.copy(new_torrent).write(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}]{meta['clean_name']}.torrent", overwrite=True)
 
     # used to add tracker url, comment and source flag to torrent file

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -69,6 +69,18 @@ class COMMON():
             descfile.write(desc)
             images = meta['image_list']
             if len(images) > 0:
+                try:
+                    thumbsize = self.config['DEFAULT']['thumbnail_size']
+                except:
+                    thumbsize = "350"
+                
+                try:
+                    screenheader = self.config['DEFAULT']['screenshot_header']
+                except:
+                    screenheader = None
+                if screenheader is not None:
+                    descfile.write(screenheader + '\n')
+
                 descfile.write("[center]")
                 for each in range(len(images[:int(meta['screens'])])):
                     web_url = images[each]['web_url']

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -73,7 +73,7 @@ class COMMON():
                 for each in range(len(images[:int(meta['screens'])])):
                     web_url = images[each]['web_url']
                     raw_url = images[each]['raw_url']
-                    descfile.write(f"[url={web_url}][img=350]{raw_url}[/img][/url]")
+                    descfile.write(f"[url={web_url}][img=350]{raw_url}[/img][/url] ")
                 descfile.write("[/center]")
 
             if signature is not None:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -71,12 +71,12 @@ class COMMON():
             if len(images) > 0:
                 try:
                     thumbsize = self.config['DEFAULT']['thumbnail_size']
-                except:
+                except Exception:
                     thumbsize = "350"
                 
                 try:
                     screenheader = self.config['DEFAULT']['screenshot_header']
-                except:
+                except Exception:
                     screenheader = None
                 if screenheader is not None:
                     descfile.write(screenheader + '\n')


### PR DESCRIPTION
Added these 2 options into the config file to allow users to adjust the thumbnail size and add a header above the screenshot section if desired from the config file rather than editing COMMON.py

Also added spacing between the screenshots for a better viewing experience, so it doesn't look like they are rendered as one

Fixed the bare except in COMMON.py