### PR TITLE
option to limit thread usage during optimize_images

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -27,6 +27,8 @@ config = {
         # Enable lossless PNG Compression (True/False)
         "optimize_images": True,
 
+        # Use only half available CPU cores to avoid memory allocation errors
+        "shared_seedbox": False,
 
         # The name of your default torrent client, set in the torrent client sections below
         "default_torrent_client": "Client1",

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -22,12 +22,14 @@ config = {
         "img_host_6": "ptscreens",
         "img_host_7": "oeimg",
 
-
+        # Number of screenshots to capture
         "screens": "6",
+
         # Enable lossless PNG Compression (True/False)
         "optimize_images": True,
 
         # Use only half available CPU cores to avoid memory allocation errors
+        # Only when usig lossless compression
         "shared_seedbox": False,
 
         # The name of your default torrent client, set in the torrent client sections below

--- a/src/prep.py
+++ b/src/prep.py
@@ -1494,10 +1494,10 @@ class Prep():
             if self.config['DEFAULT'].get('shared_seedbox', True) is True:
                 # Get number of CPU cores
                 num_cores = multiprocessing.cpu_count()
-                # Limit the number of threads based half available cores
+                # Limit the number of threads based on half available cores
                 max_threads = num_cores // 2
                 # Set cores for oxipng usage
-                os.environ['RAYON_NUM_THREADS'] = str(max_threads)  
+                os.environ['RAYON_NUM_THREADS'] = str(max_threads)
             if os.path.exists(image):
                 try:
                     pyver = platform.python_version_tuple()

--- a/src/prep.py
+++ b/src/prep.py
@@ -1491,6 +1491,13 @@ class Prep():
 
     def optimize_images(self, image):
         if self.config['DEFAULT'].get('optimize_images', True) is True:
+            if self.config['DEFAULT'].get('shared_seedbox', True) is True:
+                # Get number of CPU cores
+                num_cores = multiprocessing.cpu_count()
+                # Limit the number of threads based half available cores
+                max_threads = num_cores // 2
+                # Set cores for oxipng usage
+                os.environ['RAYON_NUM_THREADS'] = str(max_threads)  
             if os.path.exists(image):
                 try:
                     pyver = platform.python_version_tuple()


### PR DESCRIPTION
Fix for: https://github.com/Audionut/Upload-Assistant/issues/88

- Limits to half of available CPU cores when optimizing images with oxipng
- adds new option to the config called "shared_seedbox" to enable this feature as it slows down speed of which screenshots are taken.