### PR TITLE
Update dupe checking

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - dupe-checking
   workflow_dispatch:
 
 env:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -376,10 +376,11 @@ class COMMON():
         return ptgen
 
     async def filter_dupes(self, dupes, meta):
-        if meta['debug']:
-            console.log("[cyan]Pre-filtered dupes")
-            console.log(dupes)
+        console.log("[cyan]Pre-filtered dupes")
+        console.log(dupes)
         new_dupes = []
+        types_to_check = {'REMUX', 'WEBDL', 'WEBRip', 'HDTV'}
+        file_type_present = {t for t in types_to_check if t in meta['type']}
         for each in dupes:
             if meta.get('sd', 0) == 1:
                 remove_set = set()
@@ -418,6 +419,17 @@ class COMMON():
                     'in': meta['type']
                 }
             ]
+
+            dupe_type_matches = {t for t in types_to_check if t in each.upper()}
+            if file_type_present:
+                if not file_type_present.intersection(dupe_type_matches):
+                    console.log(f"[yellow]Excluding result due to type mismatch: {each}")
+                    continue
+            else:
+                if dupe_type_matches:
+                    console.log(f"[red]Excluding extra result with new type match: {each}")
+                    continue
+
             for s in search_combos:
                 if s.get('search_for') not in (None, ''):
                     if any(re.search(x, s['search'], flags=re.IGNORECASE) for x in s['search_for']):

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -376,8 +376,9 @@ class COMMON():
         return ptgen
 
     async def filter_dupes(self, dupes, meta):
-        console.log("[cyan]Pre-filtered dupes")
-        console.log(dupes)
+        if meta['debug']:
+            console.log("[cyan]Pre-filtered dupes")
+            console.log(dupes)
         new_dupes = []
         types_to_check = {'REMUX', 'WEBDL', 'WEBRip', 'HDTV'}
 
@@ -428,8 +429,6 @@ class COMMON():
                     'in': meta['type']
                 }
             ]
-            # console.log(f"Meta type: {normalized_meta_type}")
-            # console.log(f"Each type: {normalized_each_type}")
             # Check if the type of the dupe matches or is sufficiently similar
             dupe_type_matches = {t for t in types_to_check if t in normalized_each_type}
 
@@ -439,13 +438,16 @@ class COMMON():
                     console.log(f"[green]Allowing result we will catch later: {each}")
                 # Allow based on matching resolution, HDR, and audio despite type mismatch
                 elif meta['resolution'] in each and meta['hdr'] in each and meta['audio'] in each:
-                    console.log(f"[green]Allowing result we will catch later: {each}")
+                    if meta['debug']:
+                        console.log(f"[green]Allowing result we will catch later: {each}")
                 else:
-                    console.log(f"[yellow]Excluding result due to type mismatch: {each}")
+                    if meta['debug']:
+                        console.log(f"[yellow]Excluding result due to type mismatch: {each}")
                     continue
             else:
                 if dupe_type_matches:
-                    console.log(f"[red]Excluding extra result with new type match: {each}")
+                    if meta['debug']:
+                        console.log(f"[red]Excluding extra result with new type match: {each}")
                     continue
 
             for s in search_combos:


### PR DESCRIPTION
Some API's don't return type, which means remux will match as dupe against non-remux, web against bluray, etc, etc.

This PR attempts to add some extra checking to filter out these clear false results from the dupe check.

Existing:
``` python
Searching for existing torrents on site...
[09:47:36] Pre-filtered dupes                                                                                                                                                        COMMON.py:380
           [                                                                                                                                                                         COMMON.py:381
               'Training.Day.2001.PROPER.576p.BluRay.x264.AC3.5.1-TBB.mkv',
               'Training.Day.2001.1080p.UHD.BluRay.DDP7.1.HDR10.x265-c0kE.mkv',
               'Training.Day.2001.1080p.BluRay.DDP7.1.x264-c0kE.mkv',
               'Training.Day.2001.720p.BluRay.x264.AC3.5.1-TBB.mkv',
               'Training.Day.2001.1080p.BluRay.DTS.x264.D-Z0N3.mkv',
               'Training Day.2001.2160p.UHD.BluRay.HDR.TrueHD 7.1.Atmos.x265-SPHD.mkv',
               'training.day.2001.hdr.2160p.web.h265-slot.mkv',
               'Training.Day.2001.UHD.BluRay.2160p.TrueHD.Atmos.7.1.HEVC.REMUX-FraMeSToR.mkv',
               'Training.Day.2001.Remaster.BluRay.1080p.TrueHD.Atmos.7.1.AVC.REMUX-FraMeSToR.mkv',
               'Training.Day.2001.BluRay.1080p.DD.5.1.VC-1.REMUX-FraMeSToR.mkv'
           ]


Check if these are actually dupes!
-----------------------------------

Training.Day.2001.1080p.BluRay.DDP7.1.x264-c0kE.mkv
Training.Day.2001.1080p.BluRay.DTS.x264.D-Z0N3.mkv
Training.Day.2001.Remaster.BluRay.1080p.TrueHD.Atmos.7.1.AVC.REMUX-FraMeSToR.mkv
Training.Day.2001.BluRay.1080p.DD.5.1.VC-1.REMUX-FraMeSToR.mkv
```

vs:
``` python
Searching for existing torrents on site...
[10:38:54] Pre-filtered dupes                                                                                                                                                        COMMON.py:379
           [                                                                                                                                                                         COMMON.py:380
               'Training.Day.2001.PROPER.576p.BluRay.x264.AC3.5.1-TBB.mkv',
               'Training.Day.2001.1080p.UHD.BluRay.DDP7.1.HDR10.x265-c0kE.mkv',
               'Training.Day.2001.1080p.BluRay.DDP7.1.x264-c0kE.mkv',
               'Training.Day.2001.720p.BluRay.x264.AC3.5.1-TBB.mkv',
               'Training.Day.2001.1080p.BluRay.DTS.x264.D-Z0N3.mkv',
               'Training Day.2001.2160p.UHD.BluRay.HDR.TrueHD 7.1.Atmos.x265-SPHD.mkv',
               'training.day.2001.hdr.2160p.web.h265-slot.mkv',
               'Training.Day.2001.UHD.BluRay.2160p.TrueHD.Atmos.7.1.HEVC.REMUX-FraMeSToR.mkv',
               'Training.Day.2001.Remaster.BluRay.1080p.TrueHD.Atmos.7.1.AVC.REMUX-FraMeSToR.mkv',
               'Training.Day.2001.BluRay.1080p.DD.5.1.VC-1.REMUX-FraMeSToR.mkv'
           ]
           Excluding extra result with new type match: Training.Day.2001.UHD.BluRay.2160p.TrueHD.Atmos.7.1.HEVC.REMUX-FraMeSToR.mkv                                                  COMMON.py:430
           Excluding extra result with new type match: Training.Day.2001.Remaster.BluRay.1080p.TrueHD.Atmos.7.1.AVC.REMUX-FraMeSToR.mkv                                              COMMON.py:430
           Excluding extra result with new type match: Training.Day.2001.BluRay.1080p.DD.5.1.VC-1.REMUX-FraMeSToR.mkv                                                                COMMON.py:430


Check if these are actually dupes!
-----------------------------------

Training.Day.2001.1080p.BluRay.DDP7.1.x264-c0kE.mkv
Training.Day.2001.1080p.BluRay.DTS.x264.D-Z0N3.mkv
```