### PR TITLE
Add-Shebang-Support

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import requests
 from src.args import Args
 from src.clients import Clients


### PR DESCRIPTION
Adding in Shebang support, This removes the need to declare python3 when running the script on Linux or in docker.

 `#!/usr/bin/env python3`

It a minor change but saves a small bit of typing.