### PR TITLE
Improved handling of daily TV episodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data/cookies/*.pickle
 __pycache__/
 tmp/*
 .wdm/
+.DS_Store

--- a/src/prep.py
+++ b/src/prep.py
@@ -3549,6 +3549,8 @@ class Prep():
                 generic.write(f"IMDb: https://www.imdb.com/title/tt{meta['imdb_id']}\n")
             if meta['tvdb_id'] != "0":
                 generic.write(f"TVDB: https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series\n")
+            if meta['tvmaze_id'] != "0":
+                generic.write(f"TVMaze: https://www.tvmaze.com/shows/{meta['tvmaze_id']}\n")
             poster_img = f"{meta['base_dir']}/tmp/{meta['uuid']}/POSTER.png"
             if meta.get('poster', None) not in ['', None] and not os.path.exists(poster_img):
                 if meta.get('rehosted_poster', None) is None:

--- a/src/prep.py
+++ b/src/prep.py
@@ -3132,7 +3132,7 @@ class Prep():
                         if meta.get('manual_date') is None and daily_match is not None:
                             meta['manual_date'] = daily_match.group().replace('.', '-')
                         is_daily = True
-                        guess_date = meta.get('manual_date', guessit(video)['date']) if meta.get('manual_date') else guessit(video)['date']
+                        guess_date = meta.get('manual_date', guessit(video).get('date')) if meta.get('manual_date') else guessit(video).get('date')
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
 
                         season = f"S{str(season_int).zfill(2)}"
@@ -3140,7 +3140,7 @@ class Prep():
                         # For daily shows, pass the supplied date as the episode title
                         # Season and episode will be stripped later to conform with standard daily episode naming format
                         meta['episode_title'] = meta.get('manual_date')
-                        
+
                     else:
                         try:
                             guess_year = guessit(video)['year']

--- a/src/prep.py
+++ b/src/prep.py
@@ -3026,6 +3026,10 @@ class Prep():
                 year = meta['year']
             else:
                 year = ""
+            if meta.get('manual_date'):
+                # Ignore season and year for --daily flagged shows, just use manual date stored in episode_name
+                season = ''
+                episode = ''
         if meta.get('no_season', False) is True:
             season = ''
         if meta.get('no_year', False) is True:
@@ -3125,9 +3129,7 @@ class Prep():
                         guess_date = meta.get('manual_date', guessit(video)['date']) if meta.get('manual_date') else guessit(video)['date']
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
 
-                        # For --daily flagged shows, always use the supplied date as the episode title
-                        season = ""
-                        episode = ""
+                        # For --daily flagged shows, pass the supplied date as the episode title
                         meta['episode_title'] = meta.get('manual_date')
                         
                     else:

--- a/src/prep.py
+++ b/src/prep.py
@@ -3130,6 +3130,8 @@ class Prep():
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
 
                         # For --daily flagged shows, pass the supplied date as the episode title
+                        season = f"S{str(season_int).zfill(2)}"
+                        episode = f"E{str(episode_int).zfill(2)}"                        
                         meta['episode_title'] = meta.get('manual_date')
                         
                     else:

--- a/src/prep.py
+++ b/src/prep.py
@@ -3121,13 +3121,15 @@ class Prep():
             if meta['anime'] is False:
                 try:
                     if meta.get('manual_date'):
+                        is_daily = True
                         guess_date = meta.get('manual_date', guessit(video)['date']) if meta.get('manual_date') else guessit(video)['date']
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
-                        season = f"S{str(season_int).zfill(2)}"
-                        episode = f"E{str(episode_int).zfill(2)}"
-                        # season = str(guess_date)
-                        # episode = ""
-                        is_daily = True
+
+                        # For --daily flagged shows, always use the supplied date as the episode title
+                        season = ""
+                        episode = ""
+                        meta['episode_title'] = meta.get('manual_date')
+                        
                     else:
                         try:
                             guess_year = guessit(video)['year']

--- a/src/prep.py
+++ b/src/prep.py
@@ -3124,14 +3124,21 @@ class Prep():
             is_daily = False
             if meta['anime'] is False:
                 try:
-                    if meta.get('manual_date'):
+                    daily_match = re.search(r"\d{4}[-\.]\d{2}[-\.]\d{2}", video)
+                    if meta.get('manual_date') or daily_match:
+                        # Handle daily episodes
+                        # The user either provided the --daily argument or a date was found in the filename
+
+                        if meta.get('manual_date') is None and daily_match is not None:
+                            meta['manual_date'] = daily_match.group().replace('.', '-')
                         is_daily = True
                         guess_date = meta.get('manual_date', guessit(video)['date']) if meta.get('manual_date') else guessit(video)['date']
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
 
-                        # For --daily flagged shows, pass the supplied date as the episode title
                         season = f"S{str(season_int).zfill(2)}"
-                        episode = f"E{str(episode_int).zfill(2)}"                        
+                        episode = f"E{str(episode_int).zfill(2)}"
+                        # For daily shows, pass the supplied date as the episode title
+                        # Season and episode will be stripped later to conform with standard daily episode naming format
                         meta['episode_title'] = meta.get('manual_date')
                         
                     else:

--- a/src/prep.py
+++ b/src/prep.py
@@ -3121,35 +3121,34 @@ class Prep():
             if meta['anime'] is False:
                 try:
                     if meta.get('manual_date'):
-                        raise ManualDateException  # noqa: F405
-                    try:
-                        guess_year = guessit(video)['year']
-                    except Exception:
-                        guess_year = ""
-                    if guessit(video)["season"] == guess_year:
-                        if f"s{guessit(video)['season']}" in video.lower():
-                            season_int = str(guessit(video)["season"])
-                            season = "S" + season_int.zfill(2)
-                        else:
-                            season_int = "1"
-                            season = "S01"
-                    else:
-                        season_int = str(guessit(video)["season"])
-                        season = "S" + season_int.zfill(2)
-
-                except Exception:
-                    try:
                         guess_date = meta.get('manual_date', guessit(video)['date']) if meta.get('manual_date') else guessit(video)['date']
                         season_int, episode_int = self.daily_to_tmdb_season_episode(meta.get('tmdb'), guess_date)
-                        # season = f"S{season_int.zfill(2)}"
-                        # episode = f"E{episode_int.zfill(2)}"
-                        season = str(guess_date)
-                        episode = ""
+                        season = f"S{str(season_int).zfill(2)}"
+                        episode = f"E{str(episode_int).zfill(2)}"
+                        # season = str(guess_date)
+                        # episode = ""
                         is_daily = True
-                    except Exception:
-                        console.print_exception()
-                        season_int = "1"
-                        season = "S01"
+                    else:
+                        try:
+                            guess_year = guessit(video)['year']
+                        except Exception:
+                            guess_year = ""
+                        if guessit(video)["season"] == guess_year:
+                            if f"s{guessit(video)['season']}" in video.lower():
+                                season_int = str(guessit(video)["season"])
+                                season = "S" + season_int.zfill(2)
+                            else:
+                                season_int = "1"
+                                season = "S01"
+                        else:
+                            season_int = str(guessit(video)["season"])
+                            season = "S" + season_int.zfill(2)
+
+                except Exception:
+                    console.print_exception()
+                    season_int = "1"
+                    season = "S01"
+
                 try:
                     if is_daily is not True:
                         episodes = ""
@@ -3172,6 +3171,7 @@ class Prep():
                     episode = ""
                     episode_int = "0"
                     meta['tv_pack'] = 1
+
             else:
                 # If Anime
                 parsed = anitopy.parse(Path(video).name)
@@ -3648,17 +3648,17 @@ class Prep():
     def daily_to_tmdb_season_episode(self, tmdbid, date):
         show = tmdb.TV(tmdbid)
         seasons = show.info().get('seasons')
-        season = '1'
-        episode = '1'
+        season = 1
+        episode = 1
         date = datetime.fromisoformat(str(date))
         for each in seasons:
             air_date = datetime.fromisoformat(each['air_date'])
             if air_date <= date:
-                season = str(each['season_number'])
+                season = int(each['season_number'])
         season_info = tmdb.TV_Seasons(tmdbid, season).info().get('episodes')
         for each in season_info:
-            if str(each['air_date']) == str(date):
-                episode = str(each['episode_number'])
+            if str(each['air_date']) == str(date.date()):
+                episode = int(each['episode_number'])
                 break
         else:
             console.print(f"[yellow]Unable to map the date ([bold yellow]{str(date)}[/bold yellow]) to a Season/Episode number")

--- a/upload.py
+++ b/upload.py
@@ -530,6 +530,8 @@ def get_confirmation(meta):
         cli_ui.info(f"IMDB: https://www.imdb.com/title/tt{meta['imdb_id']}")
     if int(meta.get('tvdb_id', '0')) != 0:
         cli_ui.info(f"TVDB: https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series")
+    if int(meta.get('tvmaze_id', '0')) != 0:
+        cli_ui.info(f"TVMaze: https://www.tvmaze.com/shows/{meta['tvmaze_id']}")
     if int(meta.get('mal_id', 0)) != 0:
         cli_ui.info(f"MAL : https://myanimelist.net/anime/{meta['mal_id']}")
     console.print()


### PR DESCRIPTION
This PR should address a few issues:

1. Added a regular expression check that will treat all uploads with YYYY.XX.XX or YYYY-XX-XX in the filename as if that date has been supplied to the --daily argument
2. Corrected small bug in tmdb season/episode matching against air date
3. When generating the torrent name, daily episodes will drop the SXX EXX format, and instead use the air date from step one above. Season and episode are still sent to the tracker and therefore used in the UI, just not included in the torrent title/name.
4. (Tangentially related) Display the TVmaze ID during the upload confirmation

Overall, these changes should provide flexibility when uploading daily episodes, depending on the preferences of the trackers.

On gazelle-based trackers, or for UNIT3D sites where the show is still displayed by season:
- simply use `upload.py My.Daily.Episode.2024.10.12.mkv`, and the metadata will handle everything

For UNIT3D sites when the show is bucketed by year rather than season:
- On BLU: `upload.py My.Daily.Episode.2024.10.12.mkv --year 2024 --episode 10` will lump this episode into a monthly bucket, based on the site's preference
- On ATH: `upload.py My.Daily.Episode.2024.10.12.mkv --year 2024 --episode 20241012`