### PR TITLE
UNIT3D set ID to none if 0

### DIFF
--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -479,6 +479,10 @@ class COMMON():
                 mal = attributes.get('mal_id')
                 imdb = attributes.get('imdb_id')
                 infohash = attributes.get('info_hash')
+                tmdb = None if tmdb == 0 else tmdb
+                tvdb = None if tvdb == 0 else tvdb
+                mal = None if mal == 0 else mal
+                imdb = None if imdb == 0 else imdb
             else:
                 # Handle response when searching by ID
                 if id and not data:
@@ -492,7 +496,10 @@ class COMMON():
                     mal = attributes.get('mal_id')
                     imdb = attributes.get('imdb_id')
                     infohash = attributes.get('info_hash')
-
+                    tmdb = None if tmdb == 0 else tmdb
+                    tvdb = None if tvdb == 0 else tvdb
+                    mal = None if mal == 0 else mal
+                    imdb = None if imdb == 0 else imdb
                     # Handle file name extraction
                     files = attributes.get('files', [])
                     if files:


### PR DESCRIPTION
The required string conversion for IMDB ID because unit3d has dorky imdb handling, means this can return a string of 0's instead of None, which set the IMDB meta as a string of 0's.

fixes: https://github.com/Audionut/Upload-Assistant/issues/185