### PR TITLE
Added some spaces between screenshots in description

### DIFF
--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -388,12 +388,12 @@ class BHD():
                     web_url = images[each]['web_url']
                     img_url = images[each]['img_url']
                     if (each == len(images) - 1):
-                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]")
+                        desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]")
                     elif (each + 1) % 2 == 0:
-                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]\n")
-                       desc.write("\n")
+                        desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]\n")
+                        desc.write("\n")
                     else:
-                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url] ")
+                        desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url] ")
                 desc.write("[/align]")
             desc.write(self.signature)
             desc.close()

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -383,12 +383,18 @@ class BHD():
             else:
                 images = meta['image_list']
             if len(images) > 0:
-                desc.write("[center]")
+                desc.write("[align=center]")
                 for each in range(len(images[:int(meta['screens'])])):
                     web_url = images[each]['web_url']
                     img_url = images[each]['img_url']
-                    desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]")
-                desc.write("[/center]")
+                    if (each == len(images) - 1):
+                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]")
+                    elif (each + 1) % 2 == 0:
+                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]\n")
+                       desc.write("\n")
+                    else:
+                       desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url] ")
+                desc.write("[/align]")
             desc.write(self.signature)
             desc.close()
         return


### PR DESCRIPTION
Adds some spaces for screenshots in description so they looks like [this](https://imgbox.com/cyR7TFGj), instead of [this](https://imgbox.com/jSIWjlxg). I only updated BHD config, I'd imagine it'd be similar on other trackers that uses BBCode (if other trackers prefer this format). This works well in *x2 format (any number of rows and 2 columns), which most uploads use.

I used [align=center] instead of [center], so that if preferred left/right-aligned, the alignment can be changed in one place (as opposed to changing both opening and closing tag.