### PR TITLE
Identify streaming services for SubsPlease releases

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -693,7 +693,14 @@ class Prep():
                 meta['tag'] = f"-{meta['tag']}"
         meta = await self.get_season_episode(video, meta)
         meta = await self.tag_override(meta)
-
+        if meta.get('tag') == "-SubsPlease": # SubsPlease-specific
+            tracks = meta.get('mediainfo').get('media', {}).get('track', []) # Get all tracks
+            bitrate = tracks[1].get('BitRate', '') # Get video bitrate
+            bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') # For old MediaInfo (< 24.x where video bitrate is empty, use 'OverallBitRate' instead)
+            if bitrate == "8000000" or bitrate_oldMediaInfo >= "8000000": 
+                meta['service'] = "CR"
+            else:
+                meta['service'] = "HIDI"
         meta['video'] = video
         meta['audio'], meta['channels'], meta['has_commentary'] = self.get_audio_v2(mi, meta, bdinfo)
         if meta['tag'][1:].startswith(meta['channels']):

--- a/src/prep.py
+++ b/src/prep.py
@@ -693,11 +693,11 @@ class Prep():
                 meta['tag'] = f"-{meta['tag']}"
         meta = await self.get_season_episode(video, meta)
         meta = await self.tag_override(meta)
-        if meta.get('tag') == "-SubsPlease": # SubsPlease-specific
-            tracks = meta.get('mediainfo').get('media', {}).get('track', []) # Get all tracks
+        if meta.get('tag') == "-SubsPlease":  # SubsPlease-specific
+            tracks = meta.get('mediainfo').get('media', {}).get('track', [])  # Get all tracks
             bitrate = tracks[1].get('BitRate', '') if len(tracks) > 1 else ''  # Get video bitrate if available
             bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') if len(tracks) > 0 else ''  # For old MediaInfo (< 24.x where video bitrate is empty, use 'OverallBitRate' instead)
-            if (bitrate.isdigit() and int(bitrate) >= 8000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000): 
+            if (bitrate.isdigit() and int(bitrate) >= 8000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000):
                 meta['service'] = "CR"
             elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()):  # Only assign if at least one bitrate is present, otherwise leave it to user
                 meta['service'] = "HIDI"

--- a/src/prep.py
+++ b/src/prep.py
@@ -695,11 +695,11 @@ class Prep():
         meta = await self.tag_override(meta)
         if meta.get('tag') == "-SubsPlease": # SubsPlease-specific
             tracks = meta.get('mediainfo').get('media', {}).get('track', []) # Get all tracks
-            bitrate = tracks[1].get('BitRate', '') # Get video bitrate
-            bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') # For old MediaInfo (< 24.x where video bitrate is empty, use 'OverallBitRate' instead)
-            if bitrate == "8000000" or bitrate_oldMediaInfo >= "8000000": 
+            bitrate = tracks[1].get('BitRate', '') if len(tracks) > 1 else ''  # Get video bitrate if available
+            bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') if len(tracks) > 0 else ''  # For old MediaInfo (< 24.x where video bitrate is empty, use 'OverallBitRate' instead)
+            if (bitrate.isdigit() and int(bitrate) >= 8000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000): 
                 meta['service'] = "CR"
-            else:
+            elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()):  # Only assign if at least one bitrate is present, otherwise leave it to user
                 meta['service'] = "HIDI"
         meta['video'] = video
         meta['audio'], meta['channels'], meta['has_commentary'] = self.get_audio_v2(mi, meta, bdinfo)


### PR DESCRIPTION
Uses the following logic:

- If the file has video bitrate (or overall bitrate for old versions of MediaInfo) of **8000kbps** (higher for overall), it’s WEB-DL from CR (CR always encode 1080p releases with rc=2pass and constant video bitrate of **8000kbps**)

- If the file has video bitrate lower than 8000kbps (same `rc=2pass` with constant video bitrate **~5000kbps**, varies between shows, no higher than **5372kbps**), it’s WEB-DL from HIDI

- SP only grab releases from CR or HIDI.

Caveat: Identifying streaming services for **720p** SP releases isn't implemented as I don't see any demand for that resolution (and to keep things simple). Similar logic with lower resolution and halved video bitrate.
