### PR TITLE
Add -met/--manual-episode-title to set episode title, allow to set empty episode title

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -40,7 +40,7 @@ class Args():
         parser.add_argument('-edition', '--edition', '--repack', nargs='*', required=False, help="Edition/Repack String e.g.(Director's Cut, Uncut, Hybrid, REPACK, REPACK3)", type=str, dest='manual_edition', default=None)
         parser.add_argument('-season', '--season', nargs='*', required=False, help="Season (number)", type=str)
         parser.add_argument('-episode', '--episode', nargs='*', required=False, help="Episode (number)", type=str)
-        parser.add_argument('-met', '--manual-episode-title', nargs=1, required=False, help="Set episode title, empty = empty", type=datetime.date.fromisoformat, dest="manual_episode_title")
+        parser.add_argument('-met', '--manual-episode-title', nargs=1, required=False, help="Set episode title, empty = empty", type=str, dest="manual_episode_title")
         parser.add_argument('-daily', '--daily', nargs=1, required=False, help="Air date of this episode (YYYY-MM-DD)", type=datetime.date.fromisoformat, dest="manual_date")
         parser.add_argument('--no-season', dest='no_season', action='store_true', required=False, help="Remove Season from title")
         parser.add_argument('--no-year', dest='no_year', action='store_true', required=False, help="Remove Year from title")
@@ -243,8 +243,10 @@ class Args():
                 meta[key] = 100
             elif key in ("tag") and value == []:
                 meta[key] = ""
+            elif key in ["manual_episode_title"] and value == []:
+                meta[key] = ""
             elif key in ["manual_episode_title"]:
-                meta[key] = value if value else ""
+                meta[key] = value
             else:
                 meta[key] = meta.get(key, None)
             if key in ('trackers'):

--- a/src/args.py
+++ b/src/args.py
@@ -40,6 +40,7 @@ class Args():
         parser.add_argument('-edition', '--edition', '--repack', nargs='*', required=False, help="Edition/Repack String e.g.(Director's Cut, Uncut, Hybrid, REPACK, REPACK3)", type=str, dest='manual_edition', default=None)
         parser.add_argument('-season', '--season', nargs='*', required=False, help="Season (number)", type=str)
         parser.add_argument('-episode', '--episode', nargs='*', required=False, help="Episode (number)", type=str)
+        parser.add_argument('-met', '--manual-episode-title', nargs=1, required=False, help="Set episode title, empty = empty", type=datetime.date.fromisoformat, dest="manual_episode_title")
         parser.add_argument('-daily', '--daily', nargs=1, required=False, help="Air date of this episode (YYYY-MM-DD)", type=datetime.date.fromisoformat, dest="manual_date")
         parser.add_argument('--no-season', dest='no_season', action='store_true', required=False, help="Remove Season from title")
         parser.add_argument('--no-year', dest='no_year', action='store_true', required=False, help="Remove Year from title")
@@ -242,6 +243,8 @@ class Args():
                 meta[key] = 100
             elif key in ("tag") and value == []:
                 meta[key] = ""
+            elif key in ["manual_episode_title"]:
+                meta[key] = value if value else ""
             else:
                 meta[key] = meta.get(key, None)
             if key in ('trackers'):

--- a/src/prep.py
+++ b/src/prep.py
@@ -3725,13 +3725,13 @@ class Prep():
             #     meta['season'] = "COMPLETE"
             meta['season_int'] = season_int
             meta['episode_int'] = episode_int
-            
+
             # Manual episode title
             if meta['manual_episode_title'] == "":
                 meta['episode_title_storage'] = meta.get('manual_episode_title')
             else:
                 meta['episode_title_storage'] = guessit(video, {"excludes": "part"}).get('episode_title', '')
-                
+
             if meta['season'] == "S00" or meta['episode'] == "E00":
                 meta['episode_title'] = meta['episode_title_storage']
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -3725,8 +3725,13 @@ class Prep():
             #     meta['season'] = "COMPLETE"
             meta['season_int'] = season_int
             meta['episode_int'] = episode_int
-
-            meta['episode_title_storage'] = guessit(video, {"excludes": "part"}).get('episode_title', '')
+            
+            # Manual episode title
+            if meta['manual_episode_title'] == "":
+                meta['episode_title_storage'] = meta.get('manual_episode_title')
+            else:
+                meta['episode_title_storage'] = guessit(video, {"excludes": "part"}).get('episode_title', '')
+                
             if meta['season'] == "S00" or meta['episode'] == "E00":
                 meta['episode_title'] = meta['episode_title_storage']
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -3414,7 +3414,10 @@ class Prep():
         source = meta.get('source', "")
         uhd = meta.get('uhd', "")
         hdr = meta.get('hdr', "")
-        episode_title = meta.get('episode_title', '')
+        if meta.get('manual_episode_title'):
+            episode_title = meta.get('manual_episode_title')
+        else:
+            episode_title = meta.get('episode_title', '')
         if meta.get('is_disc', "") == "BDMV":  # Disk
             video_codec = meta.get('video_codec', "")
             region = meta.get('region', "")

--- a/src/prep.py
+++ b/src/prep.py
@@ -697,6 +697,7 @@ class Prep():
             tracks = meta.get('mediainfo').get('media', {}).get('track', [])  # Get all tracks
             bitrate = tracks[1].get('BitRate', '') if len(tracks) > 1 else ''  # Get video bitrate if available
             bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') if len(tracks) > 0 else ''  # For old MediaInfo (< 24.x where video bitrate is empty, use 'OverallBitRate' instead)
+            meta['episode_title'] = ""
             if (bitrate.isdigit() and int(bitrate) >= 8000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000):
                 meta['service'] = "CR"
             elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()):  # Only assign if at least one bitrate is present, otherwise leave it to user


### PR DESCRIPTION
SP releases never have episode title and titles are mistaken as episode title in some cases so don’t try to guess it. Simple addition to existing SP tag check. 

PS: Maybe a flag to skip episode title guess would be better since some other groups’ releases don’t have episode titles and the flag would prevent `guessit` from getting it wrong altogether.