### PR TITLE
Dupe checking refactor

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -86,6 +86,11 @@ config = {
         # Needs a 5 second wait to ensure the API is updated
         "get_permalink": False,
 
+        # How many trackers need to pass successfull checking to continue with the upload process
+        # Default = 1. If 1 (or more) tracker/s pass banned_group and dupe checking, uploading will continue
+        # If less than the number of trackers pass the checking, exit immediately.
+        "tracker_pass_checks": "1",
+
     },
 
     "TRACKERS": {

--- a/src/prep.py
+++ b/src/prep.py
@@ -761,7 +761,7 @@ class Prep():
                     tracker_status[tracker_name]['banned'] = True
                     continue
 
-                if tracker_name not in {"THR", "PTP", "MANUAL"}:
+                if tracker_name not in {"THR", "PTP"}:
                     dupes = await tracker_class.search_existing(meta, disctype)
                 elif tracker_name == "PTP":
                     dupes = await ptp.search_existing(groupID, meta, disctype)
@@ -782,6 +782,9 @@ class Prep():
                     console.print(f"[green]Tracker '{tracker_name}' passed all checks.[/green]")
                     tracker_status[tracker_name]['upload'] = True
                     successful_trackers += 1
+        else:
+            if tracker_name == "MANUAL":
+                successful_trackers += 1
 
         meta['tracker_status'] = tracker_status
 
@@ -4183,7 +4186,7 @@ class Prep():
                 generic.write(f"IMDb: https://www.imdb.com/title/tt{meta['imdb_id']}\n")
             if meta['tvdb_id'] != "0":
                 generic.write(f"TVDB: https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series\n")
-            if meta['tvmaze_id'] != "0":
+            if "tvmaze_id" in meta and meta['tvmaze_id'] != "0":
                 generic.write(f"TVMaze: https://www.tvmaze.com/shows/{meta['tvmaze_id']}\n")
             poster_img = f"{meta['base_dir']}/tmp/{meta['uuid']}/POSTER.png"
             if meta.get('poster', None) not in ['', None] and not os.path.exists(poster_img):

--- a/src/prep.py
+++ b/src/prep.py
@@ -729,7 +729,7 @@ class Prep():
 
             if tracker_name in tracker_class_map:
                 tracker_class = tracker_class_map[tracker_name](config=config)
-                tracker_status[tracker_name] = {'banned': False, 'skipped': False, 'dupe': False}
+                tracker_status[tracker_name] = {'banned': False, 'skipped': False, 'dupe': False, 'upload': False}
 
                 if tracker_setup.check_banned_group(tracker_class.tracker, tracker_class.banned_groups, meta):
                     console.print(f"[red]Tracker '{tracker_name}' is banned. Skipping.[/red]")
@@ -749,15 +749,20 @@ class Prep():
 
                 if not tracker_status[tracker_name]['banned'] and not tracker_status[tracker_name]['skipped'] and not tracker_status[tracker_name]['dupe']:
                     console.print(f"[green]Tracker '{tracker_name}' passed both checks.[/green]")
+                    tracker_status[tracker_name]['upload'] = True
                     successful_trackers += 1
+
+        meta['tracker_status'] = tracker_status
+
         if meta['debug']:
             console.print("\n[bold]Tracker Processing Summary:[/bold]")
         for t_name, status in tracker_status.items():
             banned_status = 'Yes' if status['banned'] else 'No'
             skipped_status = 'Yes' if status['skipped'] else 'No'
             dupe_status = 'Yes' if status['dupe'] else 'No'
+            upload_status = 'Yes' if status['upload'] else 'No'
             if meta['debug']:
-                console.print(f"Tracker: {t_name} | Banned: {banned_status} | Skipped: {skipped_status} | Dupe: {dupe_status}")
+                console.print(f"Tracker: {t_name} | Banned: {banned_status} | Skipped: {skipped_status} | Dupe: {dupe_status} | [yellow]Upload:[/yellow] {upload_status}")
         if meta['debug']:
             console.print(f"\n[bold]Trackers Passed all Checks:[/bold] {successful_trackers}")
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -750,7 +750,7 @@ class Prep():
                 meta['skipping'] = None
 
                 if not tracker_status[tracker_name]['banned'] and not tracker_status[tracker_name]['skipped'] and not tracker_status[tracker_name]['dupe']:
-                    console.print(f"[green]Tracker '{tracker_name}' passed both checks.[/green]")
+                    console.print(f"[green]Tracker '{tracker_name}' passed all checks.[/green]")
                     tracker_status[tracker_name]['upload'] = True
                     successful_trackers += 1
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -2501,14 +2501,26 @@ class Prep():
 
     def get_tag(self, video, meta):
         try:
-            tag = guessit(video)['release_group']
-            tag = f"-{tag}"
-        except Exception:
+            parsed = guessit(video)
+            release_group = parsed.get('release_group')
+
+            if meta['is_disc'] == "BDMV":
+                if release_group:
+                    if f"-{release_group}" not in video:
+                        if meta['debug']:
+                            console.print(f"[warning] Invalid release group format: {release_group}")
+                        release_group = None
+
+            tag = f"-{release_group}" if release_group else ""
+        except Exception as e:
+            console.print(f"Error while parsing: {e}")
             tag = ""
+
         if tag == "-":
             tag = ""
-        if tag[1:].lower() in ["nogroup", 'nogrp']:
+        if tag[1:].lower() in ["nogroup", "nogrp"]:
             tag = ""
+
         return tag
 
     def get_source(self, type, video, path, is_disc, meta, folder_id, base_dir):

--- a/src/prep.py
+++ b/src/prep.py
@@ -773,6 +773,8 @@ class Prep():
             console.print(f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]")
             return
 
+        meta['we_are_uploading'] = True
+
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
             json.dump(meta, f, indent=4)
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -645,6 +645,8 @@ class Prep():
         # Search tvmaze
         if meta['category'] == "TV":
             meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await self.search_tvmaze(filename, meta['search_year'], meta.get('imdb_id', '0'), meta.get('tvdb_id', 0), meta)
+        else:
+            meta.setdefault('tvmaze_id', '0')
         # If no imdb, search for it
         if meta.get('imdb_id', None) is None:
             meta['imdb_id'] = await self.search_imdb(filename, meta['search_year'])

--- a/src/prep.py
+++ b/src/prep.py
@@ -688,6 +688,8 @@ class Prep():
         if meta.get('is_disc', None) == "BDMV":  # Blu-ray Specific
             meta['region'] = self.get_region(bdinfo, meta.get('region', None))
             meta['video_codec'] = self.get_video_codec(bdinfo)
+            if meta['tag'][1:].startswith(meta['region']):
+                meta['tag'] = meta['tag'].replace(f"-{meta['region']}", '')
         else:
             meta['video_encode'], meta['video_codec'], meta['has_encode_settings'], meta['bit_depth'] = self.get_video_encode(mi, meta['type'], bdinfo)
         if meta.get('no_edition') is False:

--- a/src/prep.py
+++ b/src/prep.py
@@ -768,6 +768,9 @@ class Prep():
             )
             return
 
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
+            json.dump(meta, f, indent=4)
+
         if 'manual_frames' not in meta:
             meta['manual_frames'] = {}
         manual_frames = meta['manual_frames']

--- a/src/prep.py
+++ b/src/prep.py
@@ -761,6 +761,13 @@ class Prep():
         if meta['debug']:
             console.print(f"\n[bold]Trackers Passed all Checks:[/bold] {successful_trackers}")
 
+        meta['skip_uploading'] = int(self.config['DEFAULT'].get('tracker_pass_checks', 1))
+        if successful_trackers <= meta['skip_uploading']:
+            console.print(
+                f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]"
+            )
+            return
+
         if 'manual_frames' not in meta:
             meta['manual_frames'] = {}
         manual_frames = meta['manual_frames']

--- a/src/prep.py
+++ b/src/prep.py
@@ -643,7 +643,8 @@ class Prep():
         else:
             meta = await self.tmdb_other_meta(meta)
         # Search tvmaze
-        meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await self.search_tvmaze(filename, meta['search_year'], meta.get('imdb_id', '0'), meta.get('tvdb_id', 0), meta)
+        if meta['category'] == "TV":
+            meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await self.search_tvmaze(filename, meta['search_year'], meta.get('imdb_id', '0'), meta.get('tvdb_id', 0), meta)
         # If no imdb, search for it
         if meta.get('imdb_id', None) is None:
             meta['imdb_id'] = await self.search_imdb(filename, meta['search_year'])
@@ -654,7 +655,8 @@ class Prep():
         else:
             if not meta['tag'].startswith('-') and meta['tag'] != "":
                 meta['tag'] = f"-{meta['tag']}"
-        meta = await self.get_season_episode(video, meta)
+        if meta['category'] == "TV":
+            meta = await self.get_season_episode(video, meta)
         meta = await self.tag_override(meta)
         if meta.get('tag') == "-SubsPlease":  # SubsPlease-specific
             tracks = meta.get('mediainfo').get('media', {}).get('track', [])  # Get all tracks

--- a/src/prep.py
+++ b/src/prep.py
@@ -620,6 +620,7 @@ class Prep():
         else:
             console.print("Skipping existing search as meta already populated")
 
+        console.print("[yellow]Building meta data.....")
         meta['tmdb'] = meta.get('tmdb_manual', None)
         meta['type'] = self.get_type(video, meta['scene'], meta['is_disc'], meta)
         if meta.get('category', None) is None:
@@ -767,10 +768,8 @@ class Prep():
             console.print(f"\n[bold]Trackers Passed all Checks:[/bold] {successful_trackers}")
 
         meta['skip_uploading'] = int(self.config['DEFAULT'].get('tracker_pass_checks', 1))
-        if successful_trackers <= meta['skip_uploading']:
-            console.print(
-                f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]"
-            )
+        if successful_trackers < meta['skip_uploading']:
+            console.print(f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]")
             return
 
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:

--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -269,7 +269,7 @@ class ACM():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on ACM...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdb': meta['tmdb'],

--- a/src/trackers/AITHER.py
+++ b/src/trackers/AITHER.py
@@ -227,7 +227,7 @@ class AITHER():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on Aither...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/AL.py
+++ b/src/trackers/AL.py
@@ -162,7 +162,7 @@ class AL():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on AL...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -147,7 +147,7 @@ class ANT():
             meta['skipping'] = "ANT"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on ANT...")
         params = {
             'apikey': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             't': 'search',

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -410,7 +410,7 @@ class BHD():
             meta['skipping'] = "BHD"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on BHD...")
         category = meta['category']
         if category == 'MOVIE':
             tmdbID = "movie"

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -208,7 +208,7 @@ class BLU():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on BLU...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/FNP.py
+++ b/src/trackers/FNP.py
@@ -154,7 +154,7 @@ class FNP():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on FNP...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -320,7 +320,7 @@ class HDB():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on HDB...")
         url = "https://hdbits.org/api/torrents"
         data = {
             'username': self.username,

--- a/src/trackers/HP.py
+++ b/src/trackers/HP.py
@@ -143,7 +143,7 @@ class HP():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on HP...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -297,7 +297,7 @@ class HUNO():
             meta['skipping'] = "HUNO"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on HUNO...")
 
         params = {
             'api_token': self.config['TRACKERS']['HUNO']['api_key'].strip(),

--- a/src/trackers/JPTV.py
+++ b/src/trackers/JPTV.py
@@ -150,7 +150,7 @@ class JPTV():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on JPTV...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdb': meta['tmdb'],

--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -199,7 +199,7 @@ class LST():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on LST...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -619,7 +619,7 @@ class MTV():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on MTV...")
         params = {
             't': 'search',
             'apikey': self.config['TRACKERS'][self.tracker]['api_key'].strip(),

--- a/src/trackers/NBL.py
+++ b/src/trackers/NBL.py
@@ -85,7 +85,7 @@ class NBL():
             meta['skipping'] = "NBL"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on NBL...")
         if int(meta.get('tvmaze_id', 0)) != 0:
             search_term = {'tvmaze': int(meta['tvmaze_id'])}
         elif int(meta.get('imdb_id', '0').replace('tt', '')) == 0:

--- a/src/trackers/OE.py
+++ b/src/trackers/OE.py
@@ -279,7 +279,6 @@ class OE():
                 else:
                     console.print("[red]No media information available in meta.[/red]")
 
-            # Existing disc metadata handling
             bbcode = BBCODE()
             if meta.get('discs', []) != []:
                 discs = meta['discs']
@@ -322,7 +321,7 @@ class OE():
             meta['skipping'] = "OE"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on OE...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -154,7 +154,7 @@ class OTW():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on OTW...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/PSS.py
+++ b/src/trackers/PSS.py
@@ -156,7 +156,7 @@ class PSS():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on PSS...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/R4E.py
+++ b/src/trackers/R4E.py
@@ -150,7 +150,7 @@ class R4E():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on R4E...")
         url = "https://racing4everyone.eu/api/torrents/filter"
         params = {
             'api_token': self.config['TRACKERS']['R4E']['api_key'].strip(),

--- a/src/trackers/RF.py
+++ b/src/trackers/RF.py
@@ -172,7 +172,7 @@ class RF():
             meta['skipping'] = "RF"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on RF...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/RTF.py
+++ b/src/trackers/RTF.py
@@ -100,7 +100,7 @@ class RTF():
             meta['skipping'] = "RTF"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on RTF...")
         headers = {
             'accept': 'application/json',
             'Authorization': self.config['TRACKERS'][self.tracker]['api_key'].strip(),

--- a/src/trackers/SHRI.py
+++ b/src/trackers/SHRI.py
@@ -154,7 +154,7 @@ class SHRI():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on SHRI...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/SN.py
+++ b/src/trackers/SN.py
@@ -123,7 +123,7 @@ class SN():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on SN...")
 
         params = {
             'api_key': self.config['TRACKERS'][self.tracker]['api_key'].strip()

--- a/src/trackers/SPD.py
+++ b/src/trackers/SPD.py
@@ -125,7 +125,7 @@ class SPD():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on SPD...")
         headers = {
             'accept': 'application/json',
             'Authorization': self.config['TRACKERS'][self.tracker]['api_key'].strip(),

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -170,7 +170,7 @@ class STC():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on STC...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/STT.py
+++ b/src/trackers/STT.py
@@ -148,7 +148,7 @@ class STT():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on STT...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/TIK.py
+++ b/src/trackers/TIK.py
@@ -569,7 +569,7 @@ class TIK():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on TIK...")
         disctype = meta.get('disctype', None)
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),

--- a/src/trackers/TVC.py
+++ b/src/trackers/TVC.py
@@ -292,7 +292,7 @@ class TVC():
         # https://tvchaosuk.com/api/torrents/filter?api_token=<API_key>&tmdb=138108
 
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on TVC...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdb': meta['tmdb'],

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -159,7 +159,7 @@ class ULCX():
             meta['skipping'] = "ULCX"
             return
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on ULCX...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/UTP.py
+++ b/src/trackers/UTP.py
@@ -151,7 +151,7 @@ class UTP():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on UTP...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackers/YOINK.py
+++ b/src/trackers/YOINK.py
@@ -154,7 +154,7 @@ class YOINK():
 
     async def search_existing(self, meta, disctype):
         dupes = []
-        console.print("[yellow]Searching for existing torrents on site...")
+        console.print("[yellow]Searching for existing torrents on YOINK...")
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1,0 +1,118 @@
+from src.trackers.HUNO import HUNO
+from src.trackers.BLU import BLU
+from src.trackers.BHD import BHD
+from src.trackers.AITHER import AITHER
+from src.trackers.STC import STC
+from src.trackers.R4E import R4E
+from src.trackers.THR import THR
+from src.trackers.STT import STT
+from src.trackers.HP import HP
+from src.trackers.PTP import PTP
+from src.trackers.SN import SN
+from src.trackers.ACM import ACM
+from src.trackers.HDB import HDB
+from src.trackers.LCD import LCD
+from src.trackers.TTG import TTG
+from src.trackers.LST import LST
+from src.trackers.FL import FL
+from src.trackers.LT import LT
+from src.trackers.NBL import NBL
+from src.trackers.ANT import ANT
+from src.trackers.PTER import PTER
+from src.trackers.MTV import MTV
+from src.trackers.JPTV import JPTV
+from src.trackers.TL import TL
+from src.trackers.HDT import HDT
+from src.trackers.RF import RF
+from src.trackers.OE import OE
+from src.trackers.BHDTV import BHDTV
+from src.trackers.RTF import RTF
+from src.trackers.OTW import OTW
+from src.trackers.FNP import FNP
+from src.trackers.CBR import CBR
+from src.trackers.UTP import UTP
+from src.trackers.AL import AL
+from src.trackers.SHRI import SHRI
+from src.trackers.TIK import TIK
+from src.trackers.TVC import TVC
+from src.trackers.PSS import PSS
+from src.trackers.ULCX import ULCX
+from src.trackers.SPD import SPD
+from src.trackers.YOINK import YOINK
+import cli_ui
+from src.console import console
+
+
+class TRACKER_SETUP:
+    def __init__(self, config):
+        self.config = config
+        # Add initialization details here
+        pass
+
+    def trackers_enabled(self, meta):
+        from data.config import config
+        if meta.get('trackers', None) is not None:
+            trackers = meta['trackers']
+        else:
+            trackers = config['TRACKERS']['default_trackers']
+        if "," in trackers:
+            trackers = trackers.split(',')
+
+        if isinstance(trackers, str):
+            trackers = trackers.split(',')
+        trackers = [s.strip().upper() for s in trackers]
+        if meta.get('manual', False):
+            trackers.insert(0, "MANUAL")
+        return trackers
+
+    def check_banned_group(self, tracker, banned_group_list, meta):
+        if meta['tag'] == "":
+            return False
+        else:
+            q = False
+            for tag in banned_group_list:
+                if isinstance(tag, list):
+                    if meta['tag'][1:].lower() == tag[0].lower():
+                        console.print(f"[bold yellow]{meta['tag'][1:]}[/bold yellow][bold red] was found on [bold yellow]{tracker}'s[/bold yellow] list of banned groups.")
+                        console.print(f"[bold red]NOTE: [bold yellow]{tag[1]}")
+                        q = True
+                else:
+                    if meta['tag'][1:].lower() == tag.lower():
+                        console.print(f"[bold yellow]{meta['tag'][1:]}[/bold yellow][bold red] was found on [bold yellow]{tracker}'s[/bold yellow] list of banned groups.")
+                        q = True
+            if q:
+                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
+                    if not cli_ui.ask_yes_no(cli_ui.red, "Upload Anyways?", default=False):
+                        return True
+                else:
+                    return True
+        return False
+
+
+tracker_class_map = {
+    'ACM': ACM, 'AITHER': AITHER, 'AL': AL, 'ANT': ANT, 'BHD': BHD, 'BHDTV': BHDTV, 'BLU': BLU, 'CBR': CBR,
+    'FNP': FNP, 'FL': FL, 'HDB': HDB, 'HDT': HDT, 'HP': HP, 'HUNO': HUNO, 'JPTV': JPTV, 'LCD': LCD,
+    'LST': LST, 'LT': LT, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PSS': PSS, 'PTP': PTP, 'PTER': PTER,
+    'R4E': R4E, 'RF': RF, 'RTF': RTF, 'SHRI': SHRI, 'SN': SN, 'SPD': SPD, 'STC': STC, 'STT': STT, 'THR': THR,
+    'TIK': TIK, 'TL': TL, 'TVC': TVC, 'TTG': TTG, 'ULCX': ULCX, 'UTP': UTP, 'YOINK': YOINK,
+}
+
+tracker_capabilities = {
+    'AITHER': {'mod_q': True, 'draft': False},
+    'BHD': {'draft_live': True},
+    'BLU': {'mod_q': True, 'draft': False},
+    'LST': {'mod_q': True, 'draft': True}
+}
+
+api_trackers = {
+    'ACM', 'AITHER', 'AL', 'BHD', 'BLU', 'CBR', 'FNP', 'HUNO', 'JPTV', 'LCD', 'LST', 'LT',
+    'OE', 'OTW', 'PSS', 'RF', 'R4E', 'SHRI', 'STC', 'STT', 'TIK', 'ULCX', 'UTP', 'YOINK'
+}
+
+other_api_trackers = {
+    'ANT', 'BHDTV', 'NBL', 'RTF', 'SN', 'SPD', 'TL', 'TVC'
+}
+
+http_trackers = {
+    'FL', 'HDB', 'HDT', 'MTV', 'PTER', 'TTG'
+}

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -1,0 +1,119 @@
+import cli_ui
+from rich.console import Console
+from data.config import config
+
+console = Console()
+
+
+class UploadHelper:
+    def dupe_check(self, dupes, meta):
+        if not dupes:
+            console.print("[green]No dupes found")
+            meta['upload'] = True
+            return meta
+        else:
+            console.print()
+            dupe_text = "\n".join([d['name'] if isinstance(d, dict) else d for d in dupes])
+            console.print()
+            cli_ui.info_section(cli_ui.bold, "Check if these are actually dupes!")
+            cli_ui.info(dupe_text)
+            if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
+                if meta.get('dupe', False) is False:
+                    upload = cli_ui.ask_yes_no("Upload Anyways?", default=False)
+                else:
+                    upload = True
+            else:
+                if meta.get('dupe', False) is False:
+                    console.print("[red]Found potential dupes. Aborting. If this is not a dupe, or you would like to upload anyways, pass --skip-dupe-check")
+                    upload = False
+                else:
+                    console.print("[yellow]Found potential dupes. --skip-dupe-check was passed. Uploading anyways")
+                    upload = True
+            console.print()
+            if upload is False:
+                meta['upload'] = False
+            else:
+                meta['upload'] = True
+                for each in dupes:
+                    each_name = each['name'] if isinstance(each, dict) else each
+                    if each_name == meta['name']:
+                        meta['name'] = f"{meta['name']} DUPE?"
+
+            return meta
+
+    def get_confirmation(self, meta):
+        if meta['debug'] is True:
+            console.print("[bold red]DEBUG: True")
+        console.print(f"Prep material saved to {meta['base_dir']}/tmp/{meta['uuid']}")
+        console.print()
+        console.print("[bold yellow]Database Info[/bold yellow]")
+        console.print(f"[bold]Title:[/bold] {meta['title']} ({meta['year']})")
+        console.print()
+        console.print(f"[bold]Overview:[/bold] {meta['overview']}")
+        console.print()
+        console.print(f"[bold]Category:[/bold] {meta['category']}")
+        if int(meta.get('tmdb', 0)) != 0:
+            console.print(f"[bold]TMDB:[/bold] https://www.themoviedb.org/{meta['category'].lower()}/{meta['tmdb']}")
+        if int(meta.get('imdb_id', '0')) != 0:
+            console.print(f"[bold]IMDB:[/bold] https://www.imdb.com/title/tt{meta['imdb_id']}")
+        if int(meta.get('tvdb_id', '0')) != 0:
+            console.print(f"[bold]TVDB:[/bold] https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series")
+        if int(meta.get('tvmaze_id', '0')) != 0:
+            console.print(f"[bold]TVMaze:[/bold] https://www.tvmaze.com/shows/{meta['tvmaze_id']}")
+        if int(meta.get('mal_id', 0)) != 0:
+            console.print(f"[bold]MAL:[/bold] https://myanimelist.net/anime/{meta['mal_id']}")
+        console.print()
+        if int(meta.get('freeleech', '0')) != 0:
+            console.print(f"[bold]Freeleech:[/bold] {meta['freeleech']}")
+        tag = "" if meta['tag'] == "" else f" / {meta['tag'][1:]}"
+        res = meta['source'] if meta['is_disc'] == "DVD" else meta['resolution']
+        console.print(f"{res} / {meta['type']}{tag}")
+        if meta.get('personalrelease', False) is True:
+            console.print("[bold green]Personal Release![/bold green]")
+        console.print()
+        if meta.get('unattended', False) is False:
+            self.get_missing(meta)
+            ring_the_bell = "\a" if config['DEFAULT'].get("sfx_on_prompt", True) is True else ""
+            if ring_the_bell:
+                console.print(ring_the_bell)
+
+            if meta.get('is disc', False) is True:
+                meta['keep_folder'] = False
+
+            if meta.get('keep_folder') and meta['isdir']:
+                console.print("[bold yellow]Uploading with --keep-folder[/bold yellow]")
+                kf_confirm = input("You specified --keep-folder. Uploading in folders might not be allowed. Proceed? [y/N]: ").strip().lower()
+                if kf_confirm != 'y':
+                    console.print("[bold red]Aborting...[/bold red]")
+                    exit()
+
+            console.print("[bold yellow]Is this correct?[/bold yellow]")
+            console.print(f"[bold]Name:[/bold] {meta['name']}")
+            confirm = input("Correct? [y/N]: ").strip().lower() == 'y'
+        else:
+            console.print(f"[bold]Name:[/bold] {meta['name']}")
+            confirm = True
+
+        return confirm
+
+    def get_missing(self, meta):
+        info_notes = {
+            'edition': 'Special Edition/Release',
+            'description': "Please include Remux/Encode Notes if possible",
+            'service': "WEB Service e.g.(AMZN, NF)",
+            'region': "Disc Region",
+            'imdb': 'IMDb ID (tt1234567)',
+            'distributor': "Disc Distributor e.g.(BFI, Criterion)"
+        }
+        missing = []
+        if meta.get('imdb_id', '0') == '0':
+            meta['imdb_id'] = '0'
+            meta['potential_missing'].append('imdb_id')
+        for each in meta['potential_missing']:
+            if str(meta.get(each, '')).strip() in ["", "None", "0"]:
+                missing.append(f"--{each} | {info_notes.get(each, '')}")
+        if missing:
+            cli_ui.info_section(cli_ui.yellow, "Potentially missing information:")
+            for each in missing:
+                cli_ui.info(each)
+        console.print()

--- a/upload.py
+++ b/upload.py
@@ -4,48 +4,8 @@ import requests
 from src.args import Args
 from src.clients import Clients
 from src.trackers.COMMON import COMMON
-from src.trackers.HUNO import HUNO
-from src.trackers.BLU import BLU
-from src.trackers.BHD import BHD
-from src.trackers.AITHER import AITHER
-from src.trackers.STC import STC
-from src.trackers.R4E import R4E
 from src.trackers.THR import THR
-from src.trackers.STT import STT
-from src.trackers.HP import HP
 from src.trackers.PTP import PTP
-from src.trackers.SN import SN
-from src.trackers.ACM import ACM
-from src.trackers.HDB import HDB
-from src.trackers.LCD import LCD
-from src.trackers.TTG import TTG
-from src.trackers.LST import LST
-from src.trackers.FL import FL
-from src.trackers.LT import LT
-from src.trackers.NBL import NBL
-from src.trackers.ANT import ANT
-from src.trackers.PTER import PTER
-from src.trackers.MTV import MTV
-from src.trackers.JPTV import JPTV
-from src.trackers.TL import TL
-from src.trackers.HDT import HDT
-from src.trackers.RF import RF
-from src.trackers.OE import OE
-from src.trackers.BHDTV import BHDTV
-from src.trackers.RTF import RTF
-from src.trackers.OTW import OTW
-from src.trackers.FNP import FNP
-from src.trackers.CBR import CBR
-from src.trackers.UTP import UTP
-from src.trackers.AL import AL
-from src.trackers.SHRI import SHRI
-from src.trackers.TIK import TIK
-from src.trackers.TVC import TVC
-from src.trackers.PSS import PSS
-from src.trackers.ULCX import ULCX
-from src.trackers.SPD import SPD
-from src.trackers.YOINK import YOINK
-from src.trackers.PTT import PTT
 import json
 from pathlib import Path
 import asyncio
@@ -58,6 +18,7 @@ import cli_ui
 import traceback
 import click
 import re
+from src.trackersetup import TRACKER_SETUP, tracker_class_map, api_trackers, other_api_trackers, http_trackers, tracker_capabilities
 
 from src.console import console
 from rich.markdown import Markdown
@@ -500,59 +461,13 @@ async def do_the_thing(base_dir):
         console.print(f"[green]Gathering info for {os.path.basename(path)}")
         await process_meta(meta, base_dir)
         prep = Prep(screens=meta['screens'], img_host=meta['imghost'], config=config)
-        if meta.get('trackers', None) is not None:
-            trackers = meta['trackers']
-        else:
-            trackers = config['TRACKERS']['default_trackers']
-        if "," in trackers:
-            trackers = trackers.split(',')
-        confirm = get_confirmation(meta)
-        while confirm is False:
-            editargs = cli_ui.ask_string("Input args that need correction e.g. (--tag NTb --category tv --tmdb 12345)")
-            editargs = (meta['path'],) + tuple(editargs.split())
-            if meta.get('debug', False):
-                editargs += ("--debug",)
-            meta, help, before_args = parser.parse(editargs, meta)
-            meta['edit'] = True
-            meta = await prep.gather_prep(meta=meta, mode='cli')
-            with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
-                json.dump(meta, f, indent=4)
-            meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await prep.get_name(meta)
-            confirm = get_confirmation(meta)
 
-        if isinstance(trackers, str):
-            trackers = trackers.split(',')
-        trackers = [s.strip().upper() for s in trackers]
-        if meta.get('manual', False):
-            trackers.insert(0, "MANUAL")
         ####################################
         #######  Upload to Trackers  #######  # noqa #F266
         ####################################
         common = COMMON(config=config)
-        api_trackers = [
-            'ACM', 'AITHER', 'AL', 'BHD', 'BLU', 'CBR', 'FNP', 'HUNO', 'JPTV', 'LCD', 'LST', 'LT',
-            'OE', 'OTW', 'PSS', 'RF', 'R4E', 'SHRI', 'STC', 'STT', 'TIK', 'ULCX', 'UTP', 'YOINK', 'PTT'
-        ]
-        other_api_trackers = [
-            'ANT', 'BHDTV', 'NBL', 'RTF', 'SN', 'SPD', 'TL', 'TVC'
-        ]
-        http_trackers = [
-            'FL', 'HDB', 'HDT', 'MTV', 'PTER', 'TTG'
-        ]
-        tracker_class_map = {
-            'ACM': ACM, 'AITHER': AITHER, 'AL': AL, 'ANT': ANT, 'BHD': BHD, 'BHDTV': BHDTV, 'BLU': BLU, 'CBR': CBR,
-            'FNP': FNP, 'FL': FL, 'HDB': HDB, 'HDT': HDT, 'HP': HP, 'HUNO': HUNO, 'JPTV': JPTV, 'LCD': LCD,
-            'LST': LST, 'LT': LT, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PSS': PSS, 'PTP': PTP, 'PTER': PTER,
-            'R4E': R4E, 'RF': RF, 'RTF': RTF, 'SHRI': SHRI, 'SN': SN, 'SPD': SPD, 'STC': STC, 'STT': STT, 'THR': THR,
-            'TIK': TIK, 'TL': TL, 'TVC': TVC, 'TTG': TTG, 'ULCX': ULCX, 'UTP': UTP, 'YOINK': YOINK, 'PTT': PTT,
-        }
-
-        tracker_capabilities = {
-            'AITHER': {'mod_q': True, 'draft': False},
-            'BHD': {'draft_live': True},
-            'BLU': {'mod_q': True, 'draft': False},
-            'LST': {'mod_q': True, 'draft': True}
-        }
+        tracker_setup = TRACKER_SETUP(config=config)
+        enabled_trackers = tracker_setup.trackers_enabled(meta)
 
         async def check_mod_q_and_draft(tracker_class, meta, debug, disctype):
             modq, draft = None, None
@@ -575,7 +490,7 @@ async def do_the_thing(base_dir):
 
             return modq, draft
 
-        for tracker in trackers:
+        for tracker in enabled_trackers:
             disctype = meta.get('disctype', None)
             tracker = tracker.replace(" ", "").upper().strip()
             if meta['name'].endswith('DUPE?'):
@@ -588,124 +503,77 @@ async def do_the_thing(base_dir):
 
             if tracker in api_trackers:
                 tracker_class = tracker_class_map[tracker](config=config)
+                tracker_status = meta.get('tracker_status', {})
+                for tracker, status in tracker_status.items():
+                    upload_status = status.get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                if meta['unattended']:
-                    upload_to_tracker = True
-                else:
-                    try:
-                        upload_to_tracker = cli_ui.ask_yes_no(
-                            f"Upload to {tracker_class.tracker}? {debug}",
-                            default=meta['unattended']
-                        )
-                    except (KeyboardInterrupt, EOFError):
-                        sys.exit(1)  # Exit immediately
+                    if upload_status:
+                        # Get mod_q, draft, or draft/live depending on the tracker
+                        modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
 
-                if upload_to_tracker:
-                    # Get mod_q, draft, or draft/live depending on the tracker
-                    modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
+                        # Print mod_q and draft info if relevant
+                        if modq is not None:
+                            console.print(f"(modq: {modq})")
+                        if draft is not None:
+                            console.print(f"(draft: {draft})")
 
-                    # Print mod_q and draft info if relevant
-                    if modq is not None:
-                        console.print(f"(modq: {modq})")
-                    if draft is not None:
-                        console.print(f"(draft: {draft})")
+                        console.print(f"Uploading to {tracker_class.tracker}")
 
-                    console.print(f"Uploading to {tracker_class.tracker}")
-
-                    # Check if the group is banned for the tracker
-                    if check_banned_group(tracker_class.tracker, tracker_class.banned_groups, meta):
-                        continue
-
-                    dupes = await tracker_class.search_existing(meta, disctype)
-                    if 'skipping' not in meta or meta['skipping'] is None:
-                        dupes = await common.filter_dupes(dupes, meta)
-                        meta = dupe_check(dupes, meta)
-
-                        # Proceed with upload if the meta is set to upload
-                        if meta.get('upload', False):
-                            await tracker_class.upload(meta, disctype)
-                            perm = config['DEFAULT'].get('get_permalink', False)
-                            if perm:
-                                # need a wait so we don't race the api
-                                await asyncio.sleep(5)
-                                await tracker_class.search_torrent_page(meta, disctype)
-                                await asyncio.sleep(0.5)
-                            await client.add_to_client(meta, tracker_class.tracker)
-                    meta['skipping'] = None
+                        await tracker_class.upload(meta, disctype)
+                        await asyncio.sleep(0.5)
+                        perm = config['DEFAULT'].get('get_permalink', False)
+                        if perm:
+                            # need a wait so we don't race the api
+                            await asyncio.sleep(5)
+                            await tracker_class.search_torrent_page(meta, disctype)
+                            await asyncio.sleep(0.5)
+                        await client.add_to_client(meta, tracker_class.tracker)
 
             if tracker in other_api_trackers:
                 tracker_class = tracker_class_map[tracker](config=config)
+                tracker_status = meta.get('tracker_status', {})
+                for tracker, status in tracker_status.items():
+                    upload_status = status.get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                if meta['unattended']:
-                    upload_to_tracker = True
-                else:
-                    try:
-                        upload_to_tracker = cli_ui.ask_yes_no(
-                            f"Upload to {tracker_class.tracker}? {debug}",
-                            default=meta['unattended']
-                        )
-                    except (KeyboardInterrupt, EOFError):
-                        sys.exit(1)  # Exit immediately
+                    if upload_status:
+                        # Get mod_q, draft, or draft/live depending on the tracker
+                        modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
 
-                if upload_to_tracker:
-                    # Get mod_q, draft, or draft/live depending on the tracker
-                    modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
+                        # Print mod_q and draft info if relevant
+                        if modq is not None:
+                            console.print(f"(modq: {modq})")
+                        if draft is not None:
+                            console.print(f"(draft: {draft})")
 
-                    # Print mod_q and draft info if relevant
-                    if modq is not None:
-                        console.print(f"(modq: {modq})")
-                    if draft is not None:
-                        console.print(f"(draft: {draft})")
+                        console.print(f"Uploading to {tracker_class.tracker}")
 
-                    console.print(f"Uploading to {tracker_class.tracker}")
-
-                    # Check if the group is banned for the tracker
-                    if check_banned_group(tracker_class.tracker, tracker_class.banned_groups, meta):
-                        continue
-
-                    # Perform the existing checks for dupes except TL
-                    if tracker != "TL":
-                        if tracker == "RTF":
-                            await tracker_class.api_test(meta)
-
-                        dupes = await tracker_class.search_existing(meta, disctype)
-                        if 'skipping' not in meta or meta['skipping'] is None:
-                            dupes = await common.filter_dupes(dupes, meta)
-                            meta = dupe_check(dupes, meta)
-
-                    if 'skipping' not in meta or meta['skipping'] is None:
-                        # Proceed with upload if the meta is set to upload
-                        if tracker == "TL" or meta.get('upload', False):
-                            await tracker_class.upload(meta, disctype)
-                            if tracker == 'SN':
-                                await asyncio.sleep(16)
-                            await client.add_to_client(meta, tracker_class.tracker)
-                    meta['skipping'] = None
+                        # Perform the existing checks for dupes except TL
+                        if tracker != "TL":
+                            if tracker == "RTF":
+                                await tracker_class.api_test(meta)
+                            # Proceed with upload if the meta is set to upload
+                            if tracker == "TL" or upload_status:
+                                await tracker_class.upload(meta, disctype)
+                                if tracker == 'SN':
+                                    await asyncio.sleep(16)
+                                await asyncio.sleep(0.5)
+                                await client.add_to_client(meta, tracker_class.tracker)
 
             if tracker in http_trackers:
                 tracker_class = tracker_class_map[tracker](config=config)
+                tracker_status = meta.get('tracker_status', {})
+                for tracker, status in tracker_status.items():
+                    upload_status = status.get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                if meta['unattended']:
-                    upload_to_tracker = True
-                else:
-                    try:
-                        upload_to_tracker = cli_ui.ask_yes_no(
-                            f"Upload to {tracker_class.tracker}? {debug}",
-                            default=meta['unattended']
-                        )
-                    except (KeyboardInterrupt, EOFError):
-                        sys.exit(1)  # Exit immediately
+                    if upload_status:
+                        console.print(f"Uploading to {tracker}")
 
-                if upload_to_tracker:
-                    console.print(f"Uploading to {tracker}")
-                    if check_banned_group(tracker_class.tracker, tracker_class.banned_groups, meta):
-                        continue
-                    if await tracker_class.validate_credentials(meta) is True:
-                        dupes = await tracker_class.search_existing(meta, disctype)
-                        dupes = await common.filter_dupes(dupes, meta)
-                        meta = dupe_check(dupes, meta)
-                        if meta['upload'] is True:
+                        if await tracker_class.validate_credentials(meta) is True:
                             await tracker_class.upload(meta, disctype)
+                            await asyncio.sleep(0.5)
                             await client.add_to_client(meta, tracker_class.tracker)
 
             if tracker == "MANUAL":
@@ -714,7 +582,7 @@ async def do_the_thing(base_dir):
                 else:
                     do_manual = cli_ui.ask_yes_no("Get files for manual upload?", default=True)
                 if do_manual:
-                    for manual_tracker in trackers:
+                    for manual_tracker in enabled_trackers:
                         if manual_tracker != 'MANUAL':
                             manual_tracker = manual_tracker.replace(" ", "").upper().strip()
                             tracker_class = tracker_class_map[manual_tracker](config=config)
@@ -730,83 +598,66 @@ async def do_the_thing(base_dir):
                         console.print(f"[green]Files can be found at: [yellow]{url}[/yellow]")
 
             if tracker == "THR":
-                if meta['unattended']:
-                    upload_to_thr = True
-                else:
-                    try:
-                        upload_to_ptp = cli_ui.ask_yes_no(
-                            f"Upload to THR? {debug}",
-                            default=meta['unattended']
-                        )
-                    except (KeyboardInterrupt, EOFError):
-                        sys.exit(1)  # Exit immediately
-                if upload_to_thr:
-                    console.print("Uploading to THR")
-                    # nable to get IMDB id/Youtube Link
-                    if meta.get('imdb_id', '0') == '0':
-                        imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
-                        meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
-                    if meta.get('youtube', None) is None:
-                        youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)")
-                        meta['youtube'] = youtube
-                    thr = THR(config=config)
-                    try:
-                        with requests.Session() as session:
-                            console.print("[yellow]Logging in to THR")
-                            session = thr.login(session)
-                            console.print("[yellow]Searching for Dupes")
-                            dupes = thr.search_existing(session, disctype, meta.get('imdb_id'))
-                            dupes = await common.filter_dupes(dupes, meta)
-                            meta = dupe_check(dupes, meta)
-                            if meta['upload'] is True:
+                tracker_status = meta.get('tracker_status', {})
+                for tracker, status in tracker_status.items():
+                    upload_status = status.get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
+
+                    if upload_status:
+                        console.print("Uploading to THR")
+                        # nable to get IMDB id/Youtube Link
+                        if meta.get('imdb_id', '0') == '0':
+                            imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
+                            meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
+                        if meta.get('youtube', None) is None:
+                            youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)")
+                            meta['youtube'] = youtube
+                        thr = THR(config=config)
+                        try:
+                            with requests.Session() as session:
+                                console.print("[yellow]Logging in to THR")
+                                session = thr.login(session)
                                 await thr.upload(session, meta, disctype)
+                                await asyncio.sleep(0.5)
                                 await client.add_to_client(meta, "THR")
-                    except Exception:
-                        console.print(traceback.format_exc())
+                        except Exception:
+                            console.print(traceback.format_exc())
 
             if tracker == "PTP":
-                if meta['unattended']:
-                    upload_to_ptp = True
-                else:
-                    try:
-                        upload_to_ptp = cli_ui.ask_yes_no(
-                            f"Upload to {tracker}? {debug}",
-                            default=meta['unattended']
-                        )
-                    except (KeyboardInterrupt, EOFError):
-                        sys.exit(1)  # Exit immediately
+                tracker_status = meta.get('tracker_status', {})
+                for tracker, status in tracker_status.items():
+                    upload_status = status.get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                if upload_to_ptp:  # Ensure the variable is defined before this check
-                    console.print(f"Uploading to {tracker}")
-                    if meta.get('imdb_id', '0') == '0':
-                        imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
-                        meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
-                    ptp = PTP(config=config)
-                    if check_banned_group("PTP", ptp.banned_groups, meta):
-                        continue
-                    try:
-                        console.print("[yellow]Searching for Group ID")
-                        groupID = await ptp.get_group_by_imdb(meta['imdb_id'])
-                        if groupID is None:
-                            console.print("[yellow]No Existing Group found")
-                            if meta.get('youtube', None) is None or "youtube" not in str(meta.get('youtube', '')):
-                                youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)", default="")
-                                meta['youtube'] = youtube
-                            meta['upload'] = True
-                        else:
-                            console.print("[yellow]Searching for Existing Releases")
-                            dupes = await ptp.search_existing(groupID, meta, disctype)
-                            dupes = await common.filter_dupes(dupes, meta)
-                            meta = dupe_check(dupes, meta)
-                        if meta.get('imdb_info', {}) == {}:
-                            meta['imdb_info'] = await prep.get_imdb_info(meta['imdb_id'], meta)
-                        if meta['upload'] is True:
-                            ptpUrl, ptpData = await ptp.fill_upload_form(groupID, meta)
-                            await ptp.upload(meta, ptpUrl, ptpData, disctype)
-                            await asyncio.sleep(5)
-                            await client.add_to_client(meta, "PTP")
-                    except Exception:
-                        console.print(traceback.format_exc())
+                    if upload_status:
+                        console.print(f"Uploading to {tracker}")
+                        if meta.get('imdb_id', '0') == '0':
+                            imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
+                            meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
+                        ptp = PTP(config=config)
+                        try:
+                            console.print("[yellow]Searching for Group ID")
+                            groupID = await ptp.get_group_by_imdb(meta['imdb_id'])
+                            if groupID is None:
+                                console.print("[yellow]No Existing Group found")
+                                if meta.get('youtube', None) is None or "youtube" not in str(meta.get('youtube', '')):
+                                    youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)", default="")
+                                    meta['youtube'] = youtube
+                                meta['upload'] = True
+                            else:
+                                console.print("[yellow]Searching for Existing Releases")
+                                dupes = await ptp.search_existing(groupID, meta, disctype)
+                                dupes = await common.filter_dupes(dupes, meta)
+
+                            if meta.get('imdb_info', {}) == {}:
+                                meta['imdb_info'] = await prep.get_imdb_info(meta['imdb_id'], meta)
+                            if meta['upload'] is True:
+                                ptpUrl, ptpData = await ptp.fill_upload_form(groupID, meta)
+                                await ptp.upload(meta, ptpUrl, ptpData, disctype)
+                                await asyncio.sleep(5)
+                                await client.add_to_client(meta, "PTP")
+                        except Exception:
+                            console.print(traceback.format_exc())
 
         if meta.get('queue') is not None:
             processed_files_count += 1
@@ -814,164 +665,6 @@ async def do_the_thing(base_dir):
             if not meta['debug']:
                 if log_file:
                     save_processed_file(log_file, path)
-
-
-def get_confirmation(meta):
-    if meta['debug'] is True:
-        console.print("[bold red]DEBUG: True")
-    console.print(f"Prep material saved to {meta['base_dir']}/tmp/{meta['uuid']}")
-    console.print()
-    console.print("[bold yellow]Database Info[/bold yellow]")
-    console.print(f"[bold]Title:[/bold] {meta['title']} ({meta['year']})")
-    console.print()
-    console.print(f"[bold]Overview:[/bold] {meta['overview']}")
-    console.print()
-    console.print(f"[bold]Category:[/bold] {meta['category']}")
-    if int(meta.get('tmdb', 0)) != 0:
-        console.print(f"[bold]TMDB:[/bold] https://www.themoviedb.org/{meta['category'].lower()}/{meta['tmdb']}")
-    if int(meta.get('imdb_id', '0')) != 0:
-        console.print(f"[bold]IMDB:[/bold] https://www.imdb.com/title/tt{meta['imdb_id']}")
-    if int(meta.get('tvdb_id', '0')) != 0:
-        console.print(f"[bold]TVDB:[/bold] https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series")
-    if int(meta.get('tvmaze_id', '0')) != 0:
-        console.print(f"[bold]TVMaze:[/bold] https://www.tvmaze.com/shows/{meta['tvmaze_id']}")
-    if int(meta.get('mal_id', 0)) != 0:
-        console.print(f"[bold]MAL:[/bold] https://myanimelist.net/anime/{meta['mal_id']}")
-    console.print()
-    if int(meta.get('freeleech', '0')) != 0:
-        console.print(f"[bold]Freeleech:[/bold] {meta['freeleech']}")
-    if meta['tag'] == "":
-        tag = ""
-    else:
-        tag = f" / {meta['tag'][1:]}"
-    if meta['is_disc'] == "DVD":
-        res = meta['source']
-    else:
-        res = meta['resolution']
-
-    console.print(f"{res} / {meta['type']}{tag}")
-    if meta.get('personalrelease', False) is True:
-        console.print("[bold green]Personal Release![/bold green]")
-    console.print()
-    if meta.get('unattended', False) is False:
-        get_missing(meta)
-        ring_the_bell = "\a" if config['DEFAULT'].get("sfx_on_prompt", True) is True else ""  # \a rings the bell
-        if ring_the_bell:
-            console.print(ring_the_bell)
-
-        # Handle the 'keep_folder' logic based on 'is disc' and 'isdir'
-        if meta.get('is disc', False) is True:
-            meta['keep_folder'] = False  # Ensure 'keep_folder' is False if 'is disc' is True
-
-        if meta.get('keep_folder'):
-            if meta['isdir']:
-                console.print("[bold yellow]Uploading with --keep-folder[/bold yellow]")
-                kf_confirm = input("You specified --keep-folder. Uploading in folders might not be allowed. Are you sure you want to proceed? [y/N]: ").strip().lower()
-                if kf_confirm != 'y':
-                    console.print("[bold red]Aborting...[/bold red]")
-                    exit()
-
-        console.print("[bold yellow]Is this correct?[/bold yellow]")
-        console.print(f"[bold]Name:[/bold] {meta['name']}")
-        confirm_input = input("Correct? [y/N]: ").strip().lower()
-        confirm = confirm_input == 'y'
-
-    else:
-        console.print(f"[bold]Name:[/bold] {meta['name']}")
-        confirm = True
-
-    return confirm
-
-
-def dupe_check(dupes, meta):
-    if not dupes:
-        console.print("[green]No dupes found")
-        meta['upload'] = True
-        return meta
-    else:
-        console.print()
-        dupe_text = "\n".join(dupes)
-        console.print()
-        cli_ui.info_section(cli_ui.bold, "Check if these are actually dupes!")
-        cli_ui.info(dupe_text)
-        if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
-            if meta.get('dupe', False) is False:
-                upload = cli_ui.ask_yes_no("Upload Anyways?", default=False)
-            else:
-                upload = True
-        else:
-            if meta.get('dupe', False) is False:
-                console.print("[red]Found potential dupes. Aborting. If this is not a dupe, or you would like to upload anyways, pass --skip-dupe-check")
-                upload = False
-            else:
-                console.print("[yellow]Found potential dupes. --skip-dupe-check was passed. Uploading anyways")
-                upload = True
-        console.print()
-        if upload is False:
-            meta['upload'] = False
-        else:
-            meta['upload'] = True
-            for each in dupes:
-                if each == meta['name']:
-                    meta['name'] = f"{meta['name']} DUPE?"
-
-        return meta
-
-
-# Return True if banned group
-def check_banned_group(tracker, banned_group_list, meta):
-    if meta['tag'] == "":
-        return False
-    else:
-        q = False
-        for tag in banned_group_list:
-            if isinstance(tag, list):
-                if meta['tag'][1:].lower() == tag[0].lower():
-                    console.print(f"[bold yellow]{meta['tag'][1:]}[/bold yellow][bold red] was found on [bold yellow]{tracker}'s[/bold yellow] list of banned groups.")
-                    console.print(f"[bold red]NOTE: [bold yellow]{tag[1]}")
-                    q = True
-            else:
-                if meta['tag'][1:].lower() == tag.lower():
-                    console.print(f"[bold yellow]{meta['tag'][1:]}[/bold yellow][bold red] was found on [bold yellow]{tracker}'s[/bold yellow] list of banned groups.")
-                    q = True
-        if q:
-            if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
-                if not cli_ui.ask_yes_no(cli_ui.red, "Upload Anyways?", default=False):
-                    return True
-            else:
-                return True
-    return False
-
-
-def get_missing(meta):
-    info_notes = {
-        'edition': 'Special Edition/Release',
-        'description': "Please include Remux/Encode Notes if possible (either here or edit your upload)",
-        'service': "WEB Service e.g.(AMZN, NF)",
-        'region': "Disc Region",
-        'imdb': 'IMDb ID (tt1234567)',
-        'distributor': "Disc Distributor e.g.(BFI, Criterion, etc)"
-    }
-    missing = []
-    if meta.get('imdb_id', '0') == '0':
-        meta['imdb_id'] = '0'
-        meta['potential_missing'].append('imdb_id')
-    if len(meta['potential_missing']) > 0:
-        for each in meta['potential_missing']:
-            if str(meta.get(each, '')).replace(' ', '') in ["", "None", "0"]:
-                if each == "imdb_id":
-                    each = 'imdb'
-                missing.append(f"--{each} | {info_notes.get(each)}")
-    if missing != []:
-        cli_ui.info_section(cli_ui.yellow, "Potentially missing information:")
-        for each in missing:
-            if each.split('|')[0].replace('--', '').strip() in ["imdb"]:
-                cli_ui.info(cli_ui.red, each)
-            else:
-                cli_ui.info(each)
-
-    console.print()
-    return
 
 
 if __name__ == '__main__':

--- a/upload.py
+++ b/upload.py
@@ -599,65 +599,33 @@ async def do_the_thing(base_dir):
 
                 if tracker == "THR":
                     tracker_status = meta.get('tracker_status', {})
-                    for tracker, status in tracker_status.items():
-                        upload_status = status.get('upload', False)
-                        print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
+                    upload_status = tracker_status.get(tracker, {}).get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                        if upload_status:
-                            console.print("Uploading to THR")
-                            # nable to get IMDB id/Youtube Link
-                            if meta.get('imdb_id', '0') == '0':
-                                imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
-                                meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
-                            if meta.get('youtube', None) is None:
-                                youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)")
-                                meta['youtube'] = youtube
-                            thr = THR(config=config)
-                            try:
-                                with requests.Session() as session:
-                                    console.print("[yellow]Logging in to THR")
-                                    session = thr.login(session)
-                                    await thr.upload(session, meta, disctype)
-                                    await asyncio.sleep(0.5)
-                                    await client.add_to_client(meta, "THR")
-                            except Exception:
-                                console.print(traceback.format_exc())
+                    if upload_status:
+                        thr = THR(config=config)
+                        try:
+                            with requests.Session() as session:
+                                console.print("[yellow]Logging in to THR")
+                                session = thr.login(session)
+                                await thr.upload(session, meta, disctype)
+                                await asyncio.sleep(0.5)
+                                await client.add_to_client(meta, "THR")
+                        except Exception:
+                            console.print(traceback.format_exc())
 
                 if tracker == "PTP":
                     tracker_status = meta.get('tracker_status', {})
-                    for tracker, status in tracker_status.items():
-                        upload_status = status.get('upload', False)
-                        print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
+                    upload_status = tracker_status.get(tracker, {}).get('upload', False)
+                    print(f"Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}")
 
-                        if upload_status:
-                            console.print(f"Uploading to {tracker}")
-                            if meta.get('imdb_id', '0') == '0':
-                                imdb_id = cli_ui.ask_string("Unable to find IMDB id, please enter e.g.(tt1234567)")
-                                meta['imdb_id'] = imdb_id.replace('tt', '').zfill(7)
-                            ptp = PTP(config=config)
-                            try:
-                                console.print("[yellow]Searching for Group ID")
-                                groupID = await ptp.get_group_by_imdb(meta['imdb_id'])
-                                if groupID is None:
-                                    console.print("[yellow]No Existing Group found")
-                                    if meta.get('youtube', None) is None or "youtube" not in str(meta.get('youtube', '')):
-                                        youtube = cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)", default="")
-                                        meta['youtube'] = youtube
-                                    meta['upload'] = True
-                                else:
-                                    console.print("[yellow]Searching for Existing Releases")
-                                    dupes = await ptp.search_existing(groupID, meta, disctype)
-                                    dupes = await common.filter_dupes(dupes, meta)
-
-                                if meta.get('imdb_info', {}) == {}:
-                                    meta['imdb_info'] = await prep.get_imdb_info(meta['imdb_id'], meta)
-                                if meta['upload'] is True:
-                                    ptpUrl, ptpData = await ptp.fill_upload_form(groupID, meta)
-                                    await ptp.upload(meta, ptpUrl, ptpData, disctype)
-                                    await asyncio.sleep(5)
-                                    await client.add_to_client(meta, "PTP")
-                            except Exception:
-                                console.print(traceback.format_exc())
+                    if upload_status:
+                        ptp = PTP(config=config)
+                        groupID = meta['ptp_groupID']
+                        ptpUrl, ptpData = await ptp.fill_upload_form(groupID, meta)
+                        await ptp.upload(meta, ptpUrl, ptpData, disctype)
+                        await asyncio.sleep(5)
+                        await client.add_to_client(meta, "PTP")
 
             if meta.get('queue') is not None:
                 processed_files_count += 1

--- a/upload.py
+++ b/upload.py
@@ -520,92 +520,61 @@ async def do_the_thing(base_dir):
                 if tracker in api_trackers:
                     tracker_class = tracker_class_map[tracker](config=config)
                     tracker_status = meta.get('tracker_status', {})
-                    upload_to_tracker = cli_ui.ask_yes_no(
-                        f"Upload to {tracker_class.tracker}? {debug}",
-                        default=meta['unattended']
-                    )
-                    if upload_to_tracker:
-                        for tracker, status in tracker_status.items():
-                            upload_status = status.get('upload', False)
-                            console.print(f"[red]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/red]")
+                    upload_status = tracker_status.get(tracker, {}).get('upload', False)
+                    console.print(f"[red]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/red]")
 
-                            if upload_status:
-                                # Get mod_q, draft, or draft/live depending on the tracker
-                                modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
+                    if upload_status:
+                        modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
 
-                                # Print mod_q and draft info if relevant
-                                if modq is not None:
-                                    console.print(f"(modq: {modq})")
-                                if draft is not None:
-                                    console.print(f"(draft: {draft})")
+                        if modq is not None:
+                            console.print(f"(modq: {modq})")
+                        if draft is not None:
+                            console.print(f"(draft: {draft})")
 
-                                console.print(f"Uploading to {tracker_class.tracker}")
+                        console.print(f"Uploading to {tracker_class.tracker}")
 
-                                await tracker_class.upload(meta, disctype)
-                                await asyncio.sleep(0.5)
-                                perm = config['DEFAULT'].get('get_permalink', False)
-                                if perm:
-                                    # need a wait so we don't race the api
-                                    await asyncio.sleep(5)
-                                    await tracker_class.search_torrent_page(meta, disctype)
-                                    await asyncio.sleep(0.5)
-                                await client.add_to_client(meta, tracker_class.tracker)
+                        await tracker_class.upload(meta, disctype)
+                        await asyncio.sleep(0.5)
+                        perm = config['DEFAULT'].get('get_permalink', False)
+                        if perm:
+                            # need a wait so we don't race the api
+                            await asyncio.sleep(5)
+                            await tracker_class.search_torrent_page(meta, disctype)
+                            await asyncio.sleep(0.5)
+                        await client.add_to_client(meta, tracker_class.tracker)
 
                 if tracker in other_api_trackers:
                     tracker_class = tracker_class_map[tracker](config=config)
                     tracker_status = meta.get('tracker_status', {})
-                    upload_to_tracker = cli_ui.ask_yes_no(
-                        f"Upload to {tracker_class.tracker}? {debug}",
-                        default=meta['unattended']
-                    )
-                    if upload_to_tracker:
-                        for tracker, status in tracker_status.items():
-                            upload_status = status.get('upload', False)
-                            console.print(f"[yellow]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/yellow]")
+                    upload_status = tracker_status.get(tracker, {}).get('upload', False)
+                    console.print(f"[yellow]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/yellow]")
 
-                            if upload_status:
-                                # Get mod_q, draft, or draft/live depending on the tracker
-                                modq, draft = await check_mod_q_and_draft(tracker_class, meta, debug, disctype)
+                    if upload_status:
+                        console.print(f"Uploading to {tracker_class.tracker}")
 
-                                # Print mod_q and draft info if relevant
-                                if modq is not None:
-                                    console.print(f"(modq: {modq})")
-                                if draft is not None:
-                                    console.print(f"(draft: {draft})")
-
-                                console.print(f"Uploading to {tracker_class.tracker}")
-
-                                # Perform the existing checks for dupes except TL
-                                if tracker != "TL":
-                                    if tracker == "RTF":
-                                        await tracker_class.api_test(meta)
-                                    # Proceed with upload if the meta is set to upload
-                                    if tracker == "TL" or upload_status:
-                                        await tracker_class.upload(meta, disctype)
-                                        if tracker == 'SN':
-                                            await asyncio.sleep(16)
-                                        await asyncio.sleep(0.5)
-                                        await client.add_to_client(meta, tracker_class.tracker)
+                        if tracker != "TL":
+                            if tracker == "RTF":
+                                await tracker_class.api_test(meta)
+                            if tracker == "TL" or upload_status:
+                                await tracker_class.upload(meta, disctype)
+                                if tracker == 'SN':
+                                    await asyncio.sleep(16)
+                                await asyncio.sleep(0.5)
+                                await client.add_to_client(meta, tracker_class.tracker)
 
                 if tracker in http_trackers:
                     tracker_class = tracker_class_map[tracker](config=config)
                     tracker_status = meta.get('tracker_status', {})
-                    upload_to_tracker = cli_ui.ask_yes_no(
-                        f"Upload to {tracker_class.tracker}? {debug}",
-                        default=meta['unattended']
-                    )
-                    if upload_to_tracker:
-                        for tracker, status in tracker_status.items():
-                            upload_status = status.get('upload', False)
-                            console.print(f"[blue]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/blue]")
+                    upload_status = tracker_status.get(tracker, {}).get('upload', False)
+                    console.print(f"[blue]Tracker: {tracker}, Upload: {'Yes' if upload_status else 'No'}[/blue]")
 
-                            if upload_status:
-                                console.print(f"Uploading to {tracker}")
+                    if upload_status:
+                        console.print(f"Uploading to {tracker}")
 
-                                if await tracker_class.validate_credentials(meta) is True:
-                                    await tracker_class.upload(meta, disctype)
-                                    await asyncio.sleep(0.5)
-                                    await client.add_to_client(meta, tracker_class.tracker)
+                        if await tracker_class.validate_credentials(meta) is True:
+                            await tracker_class.upload(meta, disctype)
+                            await asyncio.sleep(0.5)
+                            await client.add_to_client(meta, tracker_class.tracker)
 
                 if tracker == "MANUAL":
                     if meta['unattended']:


### PR DESCRIPTION
This PR refactors the dupe checking to occur before screens are processed.

It creates all of the meta > prompts for correct name > runs dupe checking > processes screens > uploads

A new config option `"tracker_pass_checks": "1"`

If the number of successful trackers that pass allowed content, banned group and dupe checking is less than the number specified in "tracker_pass_checks", then it fails there, without processing screens or uploading to _**ANY**_ tracker.

The default option is 1, meaning that if any tracker passes checks, it will upload to all trackers that pass checks. This can be thought of as the previous behavior, except you get asked whether to upload before processing screens.

You could set "tracker_pass_checks" to 3 for example, meaning that if less that 3 trackers would accept the upload, then it will not process screens and fail instead.

### todo:
- [x] fix tracker caps
- [x] fix ptp
- [x] probably thr broken
- [x] probably manual broken
- [x] stop trackers processing more than once