### PR TITLE
Update LT.py

### DIFF
--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -95,7 +95,7 @@ class LT():
                 audio for audio in meta['mediainfo']['media']['track'][2:]
                 if audio.get('@type') == 'Audio'
                 and audio.get('Language') in {'es-419', 'es'}
-                and "commentary" not in audio.get('Title').lower()
+                and "commentary" not in str(audio.get('Title', '')).lower()
                 ]
             if len(audios) > 0:  # If there is at least 1 audio spanish
                 lt_name = lt_name


### PR DESCRIPTION
Fix
When audio track has not title it will be a empty dic "Title": {}, and will fail trying to .lower() it