### PR TITLE
Fix/seedpool source and categories

### DIFF
--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -30,20 +30,15 @@ class SP():
         self.banned_groups = [""]
         pass
 
-    async def get_cat_id(self, meta_or_category):
-        # Determine if we received the full meta dictionary or just the category string
-        if isinstance(meta_or_category, dict):
-            category_name = meta_or_category.get('category', '').upper()
-            release_title = meta_or_category.get('name', '')
-            mal_id = meta_or_category.get('mal_id', 0)
-            tv_pack = meta_or_category.get('tv_pack', 0)
-        elif isinstance(meta_or_category, str):
-            category_name = meta_or_category.upper()
-            release_title = ''
-            mal_id = 0
-            tv_pack = 0
-        else:
-            raise TypeError("Expected 'meta_or_category' to be a dictionary or string.")
+   # Change from base: Requires the full meta dictionary to determine category
+    async def get_cat_id(self, meta):
+        if not isinstance(meta, dict):
+            raise TypeError('meta must be a dict when passed to Seedpool get_cat_id')
+
+        category_name = meta.get('category', '').upper()
+        release_title = meta.get('name', '')
+        mal_id = meta.get('mal_id', 0)
+        tv_pack = meta.get('tv_pack', 0)
 
         # Custom SEEDPOOL category logic
         if mal_id != 0:
@@ -106,7 +101,7 @@ class SP():
     async def upload(self, meta, disctype):
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)
-        cat_id = await self.get_cat_id(meta['category'])
+        cat_id = await self.get_cat_id(meta)
         type_id = await self.get_type_id(meta['type'])
         resolution_id = await self.get_res_id(meta['resolution'])
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
@@ -190,7 +185,7 @@ class SP():
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
             'tmdbId': meta['tmdb'],
-            'categories[]': await self.get_cat_id(meta['category']),
+            'categories[]': await self.get_cat_id(meta),
             'types[]': await self.get_type_id(meta['type']),
             'resolutions[]': await self.get_res_id(meta['resolution']),
             'name': ""

--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -44,11 +44,11 @@ class SP():
         if mal_id != 0:
             return '6'  # Anime
 
-        if category_name == 'TV':
-            if tv_pack != 0:
-                return '13'  # Boxset
-            if self.contains_sports_patterns(release_title):
-                return '8'  # Sports
+        if tv_pack != 0:
+            return '13'  # Boxset
+
+        if self.contains_sports_patterns(release_title):
+            return '8'  # Sports
 
         # Default category logic
         category_id = {

--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -22,7 +22,7 @@ class SP():
     def __init__(self, config):
         self.config = config
         self.tracker = 'SP'
-        self.source_flag = 'Seedpool.org'
+        self.source_flag = 'seedpool.org'
         self.upload_url = 'https://seedpool.org/api/torrents/upload'
         self.search_url = 'https://seedpool.org/api/torrents/filter'
         self.torrent_url = 'https://seedpool.org/torrents'

--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -30,7 +30,7 @@ class SP():
         self.banned_groups = [""]
         pass
 
-   # Change from base: Requires the full meta dictionary to determine category
+    # Change from base: Requires the full meta dictionary to determine category
     async def get_cat_id(self, meta):
         if not isinstance(meta, dict):
             raise TypeError('meta must be a dict when passed to Seedpool get_cat_id')
@@ -41,14 +41,17 @@ class SP():
         tv_pack = meta.get('tv_pack', 0)
 
         # Custom SEEDPOOL category logic
+        # Anime
         if mal_id != 0:
-            return '6'  # Anime
+            return '6'
 
+        # Boxset
         if tv_pack != 0:
-            return '13'  # Boxset
+            return '13'
 
+        # Sports
         if self.contains_sports_patterns(release_title):
-            return '8'  # Sports
+            return '8'
 
         # Default category logic
         category_id = {


### PR DESCRIPTION
Fix some issue with the newly added SP definitions.

1. Source should be all lowercase
2. category mapping requires the full meta dictionary, there is no need for checking for string vs dictionary as only category string will not map anime/boxset/sports correctly