### PR TITLE
adding blank comment to any uploaded torrent created from BASE.torrent

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -220,13 +220,13 @@ class Clients():
                     # Piece size and count validations
                     if not meta.get('prefer_small_pieces', False):
                         if reuse_torrent.pieces >= 8000 and reuse_torrent.piece_size < 8388608:
-                            console.print("[bold red]Too many pieces detected, Torrent needs to have less than 8000 pieces to be valid")
+                            console.print("[bold red]Torrent needs to have less than 8000 pieces with a 8 MiB piece size, regenerating")
                             valid = False
                         elif reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4194304:
-                            console.print("[bold red]Too many pieces detected, Torrent needs to have less than 5000 pieces to be valid")
+                            console.print("[bold red]Torrent needs to have less than 5000 pieces with a 4 MiB piece size, regenerating")
                             valid = False
                     elif reuse_torrent.pieces >= 12000:
-                        console.print("[bold red]Too many pieces detected, Torrent needs to have less than 12000 pieces to be valid")
+                        console.print("[bold red]Torrent needs to have less than 12000 pieces to be valid, regenerating")
                         valid = False
                     elif reuse_torrent.piece_size < 32768:
                         console.print("[bold red]Piece size too small to reuse")
@@ -235,7 +235,7 @@ class Clients():
                         console.print("[bold red]Torrent file size exceeds 250 KiB")
                         valid = False
                     elif wrong_file:
-                        console.print("[bold red] Provided .torrent has files that were not expected")
+                        console.print("[bold red]Provided .torrent has files that were not expected")
                         valid = False
                     else:
                         console.print(f"[bold green]REUSING .torrent with infohash: [bold yellow]{torrenthash}")

--- a/src/clients.py
+++ b/src/clients.py
@@ -220,19 +220,19 @@ class Clients():
                     # Piece size and count validations
                     if not meta.get('prefer_small_pieces', False):
                         if reuse_torrent.pieces >= 8000 and reuse_torrent.piece_size < 8388608:
-                            console.print("[bold yellow]Too many pieces detected")
+                            console.print("[bold red]Too many pieces detected, Torrent needs to have less than 8000 pieces to be valid")
                             valid = False
                         elif reuse_torrent.pieces >= 5000 and reuse_torrent.piece_size < 4194304:
-                            console.print("[bold yellow]Too many pieces detected")
+                            console.print("[bold red]Too many pieces detected, Torrent needs to have less than 5000 pieces to be valid")
                             valid = False
                     elif reuse_torrent.pieces >= 12000:
-                        console.print("[bold yellow]Too many pieces detected")
+                        console.print("[bold red]Too many pieces detected, Torrent needs to have less than 12000 pieces to be valid")
                         valid = False
                     elif reuse_torrent.piece_size < 32768:
-                        console.print("[bold yellow]Piece size too small to reuse")
+                        console.print("[bold red]Piece size too small to reuse")
                         valid = False
                     elif torrent_file_size_kib > 250:
-                        console.print("[bold yellow]Torrent file size exceeds 250 KiB")
+                        console.print("[bold red]Torrent file size exceeds 250 KiB")
                         valid = False
                     elif wrong_file:
                         console.print("[bold red] Provided .torrent has files that were not expected")

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -28,6 +28,8 @@ class COMMON():
                     new_torrent.metainfo.pop(each, None)
             new_torrent.metainfo['announce'] = self.config['TRACKERS'][tracker].get('announce_url', "https://fake.tracker").strip()
             new_torrent.metainfo['info']['source'] = source_flag
+            # setting comment as blank as if BASE.torrent is manually created then it can result in private info such as download link being exposed.
+            new_torrent.metainfo['comment'] = ''
             Torrent.copy(new_torrent).write(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}]{meta['clean_name']}.torrent", overwrite=True)
 
     # used to add tracker url, comment and source flag to torrent file


### PR DESCRIPTION
this prevents exposing private info that could be in a comment when BASE.torrent is created manually.

adding a bit more info to torrent piece size verification to help with selection if you have multiple torrents to reuse. Changing output to RED to make it easier to see why passed torrent failed verification.