### PR TITLE
save reuploaded images

### DIFF
--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -9,6 +9,7 @@ import bencodepy
 import glob
 import httpx
 import re
+import json
 from urllib.parse import urlparse
 from src.trackers.COMMON import COMMON
 from src.console import console
@@ -54,6 +55,33 @@ class BHD():
         }
 
         approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb', 'pixhost', 'bhd', 'bam']
+        reuploaded_images_path = os.path.join(meta['base_dir'], "tmp", meta['uuid'], "reuploaded_images.json")
+        reuploaded_images = []
+
+        if os.path.exists(reuploaded_images_path):
+            try:
+                with open(reuploaded_images_path, 'r') as f:
+                    reuploaded_images = json.load(f)
+            except Exception as e:
+                console.print(f"[red]Failed to load reuploaded images: {e}")
+
+        valid_reuploaded_images = []
+        for image in reuploaded_images:
+            raw_url = image['raw_url']
+            parsed_url = urlparse(raw_url)
+            hostname = parsed_url.netloc
+            mapped_host = self.match_host(hostname, url_host_mapping.keys())
+            mapped_host = url_host_mapping.get(mapped_host, mapped_host)
+
+            if mapped_host in approved_image_hosts:
+                valid_reuploaded_images.append(image)
+            elif meta['debug']:
+                console.print(f"[red]URL '{raw_url}' from reuploaded_images.json is not recognized as an approved host.")
+
+        if valid_reuploaded_images:
+            meta['image_list'] = valid_reuploaded_images
+            console.print("[green]Using valid images from reuploaded_images.json.")
+            return meta['image_list'], False, False
 
         for image in meta['image_list']:
             raw_url = image['raw_url']
@@ -67,15 +95,13 @@ class BHD():
                 else:
                     console.print(f"[red]URL '{raw_url}' is not recognized as part of an approved host.")
 
-        if all(
+        if not all(
             url_host_mapping.get(
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
             ) in approved_image_hosts
             for image in meta['image_list']
         ):
-            image_list = meta['image_list']
-        else:
             images_reuploaded = False
             while img_host_index <= len(approved_image_hosts):
                 image_list, retry_mode, images_reuploaded = await self.handle_image_upload(meta, img_host_index, approved_image_hosts)
@@ -331,6 +357,31 @@ class BHD():
                 ) in approved_image_hosts
                 for image in meta[new_images_key]
             ):
+
+                if new_images_key in meta and isinstance(meta[new_images_key], list):
+                    output_file = os.path.join(screenshots_dir, "reuploaded_images.json")
+                    existing_data = []
+                    if os.path.exists(output_file):
+                        try:
+                            with open(output_file, 'r') as f:
+                                existing_data = json.load(f)
+                                if not isinstance(existing_data, list):
+                                    console.print(f"[red]Existing data in {output_file} is not a list. Resetting to an empty list.")
+                                    existing_data = []
+                        except Exception as e:
+                            console.print(f"[red]Failed to load existing data from {output_file}: {e}")
+
+                    updated_data = existing_data + meta[new_images_key]
+                    updated_data = [dict(s) for s in {tuple(d.items()) for d in updated_data}]
+
+                    try:
+                        with open(output_file, 'w') as f:
+                            json.dump(updated_data, f, indent=4)
+                        console.print(f"[green]Successfully updated reuploaded images in {output_file}.")
+                    except Exception as e:
+                        console.print(f"[red]Failed to save reuploaded images: {e}")
+                else:
+                    console.print("[red]new_images_key is not a valid key in meta or is not a list.")
 
                 return meta[new_images_key], False, images_reuploaded
         else:

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -9,6 +9,7 @@ import os
 import cli_ui
 import pickle
 import re
+import json
 from pathlib import Path
 from src.trackers.COMMON import COMMON
 from datetime import datetime
@@ -105,6 +106,34 @@ class MTV():
             "imgbox.com": "imgbox",
         }
 
+        reuploaded_images_path = os.path.join(meta['base_dir'], "tmp", meta['uuid'], "reuploaded_images.json")
+        reuploaded_images = []
+
+        if os.path.exists(reuploaded_images_path):
+            try:
+                with open(reuploaded_images_path, 'r') as f:
+                    reuploaded_images = json.load(f)
+            except Exception as e:
+                console.print(f"[red]Failed to load reuploaded images: {e}")
+
+        valid_reuploaded_images = []
+        for image in reuploaded_images:
+            raw_url = image['raw_url']
+            parsed_url = urlparse(raw_url)
+            hostname = parsed_url.netloc
+            mapped_host = self.match_host(hostname, url_host_mapping.keys())
+            mapped_host = url_host_mapping.get(mapped_host, mapped_host)
+
+            if mapped_host in approved_image_hosts:
+                valid_reuploaded_images.append(image)
+            elif meta['debug']:
+                console.print(f"[red]URL '{raw_url}' from reuploaded_images.json is not recognized as an approved host.")
+
+        if valid_reuploaded_images:
+            meta['image_list'] = valid_reuploaded_images
+            console.print("[green]Using valid images from reuploaded_images.json.")
+            return meta['image_list'], False, False
+
         for image in meta['image_list']:
             raw_url = image['raw_url']
             parsed_url = urlparse(raw_url)
@@ -117,16 +146,13 @@ class MTV():
                 else:
                     console.print(f"[red]URL '{raw_url}' is not recognized as part of an approved host.")
 
-        if all(
+        if not all(
             url_host_mapping.get(
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
             ) in approved_image_hosts
             for image in meta['image_list']
         ):
-            image_list = meta['image_list']
-
-        else:
             images_reuploaded = False
             while img_host_index <= len(approved_image_hosts):
                 image_list, retry_mode, images_reuploaded = await self.handle_image_upload(meta, img_host_index, approved_image_hosts)
@@ -335,6 +361,31 @@ class MTV():
                 ) in approved_image_hosts
                 for image in meta[new_images_key]
             ):
+
+                if new_images_key in meta and isinstance(meta[new_images_key], list):
+                    output_file = os.path.join(screenshots_dir, "reuploaded_images.json")
+                    existing_data = []
+                    if os.path.exists(output_file):
+                        try:
+                            with open(output_file, 'r') as f:
+                                existing_data = json.load(f)
+                                if not isinstance(existing_data, list):
+                                    console.print(f"[red]Existing data in {output_file} is not a list. Resetting to an empty list.")
+                                    existing_data = []
+                        except Exception as e:
+                            console.print(f"[red]Failed to load existing data from {output_file}: {e}")
+
+                    updated_data = existing_data + meta[new_images_key]
+                    updated_data = [dict(s) for s in {tuple(d.items()) for d in updated_data}]
+
+                    try:
+                        with open(output_file, 'w') as f:
+                            json.dump(updated_data, f, indent=4)
+                        console.print(f"[green]Successfully updated reuploaded images in {output_file}.")
+                    except Exception as e:
+                        console.print(f"[red]Failed to save reuploaded images: {e}")
+                else:
+                    console.print("[red]new_images_key is not a valid key in meta or is not a list.")
 
                 return meta[new_images_key], False, images_reuploaded
         else:

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -7,6 +7,7 @@ import httpx
 from urllib.parse import urlparse
 import glob
 import requests
+import json
 from src.trackers.COMMON import COMMON
 from src.console import console
 from src.takescreens import disc_screenshots, dvd_screenshots, screenshots
@@ -92,6 +93,34 @@ class OTW():
 
         approved_image_hosts = ['imgbox', 'imgbb', 'pixhost', 'bam']
 
+        reuploaded_images_path = os.path.join(meta['base_dir'], "tmp", meta['uuid'], "reuploaded_images.json")
+        reuploaded_images = []
+
+        if os.path.exists(reuploaded_images_path):
+            try:
+                with open(reuploaded_images_path, 'r') as f:
+                    reuploaded_images = json.load(f)
+            except Exception as e:
+                console.print(f"[red]Failed to load reuploaded images: {e}")
+
+        valid_reuploaded_images = []
+        for image in reuploaded_images:
+            raw_url = image['raw_url']
+            parsed_url = urlparse(raw_url)
+            hostname = parsed_url.netloc
+            mapped_host = self.match_host(hostname, url_host_mapping.keys())
+            mapped_host = url_host_mapping.get(mapped_host, mapped_host)
+
+            if mapped_host in approved_image_hosts:
+                valid_reuploaded_images.append(image)
+            elif meta['debug']:
+                console.print(f"[red]URL '{raw_url}' from reuploaded_images.json is not recognized as an approved host.")
+
+        if valid_reuploaded_images:
+            meta['image_list'] = valid_reuploaded_images
+            console.print("[green]Using valid images from reuploaded_images.json.")
+            return meta['image_list'], False, False
+
         for image in meta['image_list']:
             raw_url = image['raw_url']
             parsed_url = urlparse(raw_url)
@@ -104,15 +133,13 @@ class OTW():
                 else:
                     console.print(f"[red]URL '{raw_url}' is not recognized as part of an approved host.")
 
-        if all(
+        if not all(
             url_host_mapping.get(
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
                 self.match_host(urlparse(image['raw_url']).netloc, url_host_mapping.keys()),
             ) in approved_image_hosts
             for image in meta['image_list']
         ):
-            image_list = meta['image_list']
-        else:
             images_reuploaded = False
             while img_host_index <= len(approved_image_hosts):
                 image_list, retry_mode, images_reuploaded = await self.handle_image_upload(meta, img_host_index, approved_image_hosts)
@@ -341,6 +368,31 @@ class OTW():
                 ) in approved_image_hosts
                 for image in meta[new_images_key]
             ):
+
+                if new_images_key in meta and isinstance(meta[new_images_key], list):
+                    output_file = os.path.join(screenshots_dir, "reuploaded_images.json")
+                    existing_data = []
+                    if os.path.exists(output_file):
+                        try:
+                            with open(output_file, 'r') as f:
+                                existing_data = json.load(f)
+                                if not isinstance(existing_data, list):
+                                    console.print(f"[red]Existing data in {output_file} is not a list. Resetting to an empty list.")
+                                    existing_data = []
+                        except Exception as e:
+                            console.print(f"[red]Failed to load existing data from {output_file}: {e}")
+
+                    updated_data = existing_data + meta[new_images_key]
+                    updated_data = [dict(s) for s in {tuple(d.items()) for d in updated_data}]
+
+                    try:
+                        with open(output_file, 'w') as f:
+                            json.dump(updated_data, f, indent=4)
+                        console.print(f"[green]Successfully updated reuploaded images in {output_file}.")
+                    except Exception as e:
+                        console.print(f"[red]Failed to save reuploaded images: {e}")
+                else:
+                    console.print("[red]new_images_key is not a valid key in meta or is not a list.")
 
                 return meta[new_images_key], False, images_reuploaded
         else:


### PR DESCRIPTION
When site files need images reuploaded, save to json file and reuse where needed, without each site file potentially reuploading images to the same host.