### PR TITLE
add argument delete meta.json

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -99,8 +99,10 @@ class Args():
         parser.add_argument('-uac', '--unattended-confirm', action='store_true', required=False, help=argparse.SUPPRESS)
         parser.add_argument('-vs', '--vapoursynth', action='store_true', required=False, help="Use vapoursynth for screens (requires vs install)")
         parser.add_argument('-cleanup', '--cleanup', action='store_true', required=False, help="Clean up tmp directory")
+        parser.add_argument('-dm', '--delete-meta', action='store_true', required=False, dest='delete_meta', help="Delete only meta.json from tmp directory")
         parser.add_argument('-fl', '--freeleech', nargs='*', required=False, help="Freeleech Percentage", default=0, dest="freeleech")
         parser.add_argument('--infohash', nargs='*', required=False, help="V1 Info Hash")
+        meta = {}
         args, before_args = parser.parse_known_args(input)
         args = vars(args)
         # console.print(args)

--- a/upload.py
+++ b/upload.py
@@ -185,6 +185,10 @@ async def do_the_thing(base_dir):
 
             meta_file = os.path.join(base_dir, "tmp", os.path.basename(path), "meta.json")
 
+            if meta.get('delete_meta') and os.path.exists(meta_file):
+                os.remove(meta_file)
+                console.print("[bold green]Successfully deleted meta.json")
+
             if os.path.exists(meta_file):
                 with open(meta_file, "r") as f:
                     saved_meta = json.load(f)

--- a/upload.py
+++ b/upload.py
@@ -187,7 +187,7 @@ async def do_the_thing(base_dir):
 
             if meta.get('delete_meta') and os.path.exists(meta_file):
                 os.remove(meta_file)
-                console.print("[bold green]Successfully deleted meta.json")
+                console.print("[bold red]Successfully deleted meta.json")
 
             if os.path.exists(meta_file):
                 with open(meta_file, "r") as f:


### PR DESCRIPTION
Deleting the meta.json is useful when you need a metadata refresh, but need to keep existing taken images and such.

Not as intrusive as cleanup which kills the entire tmp directory.

Should be most useful for remote installations where accessing the folder is more painful than a simple argument.