### PR TITLE
Update LT.py

### DIFF
--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -26,7 +26,7 @@ class LT():
         self.upload_url = 'https://lat-team.com/api/torrents/upload'
         self.search_url = 'https://lat-team.com/api/torrents/filter'
         self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
-        self.banned_groups = [""]
+        self.banned_groups = ['.']
         pass
 
     async def get_cat_id(self, category_name, meta):


### PR DESCRIPTION
When --no-tag is used, it treats the tag as an empty string ("") and detects it as a banned group.