### PR TITLE
BD Disc - use playlists

### DIFF
--- a/src/discparse.py
+++ b/src/discparse.py
@@ -179,7 +179,7 @@ class DiscParse():
 
                                     discs[i]['summary'] = bd_summary.strip()
                                     discs[i]['bdinfo'] = bdinfo
-                                    discs[i]['playlists'] = valid_playlists
+                                    discs[i]['playlists'] = selected_playlists
 
                                 except Exception:
                                     console.print(traceback.format_exc())

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -81,34 +81,37 @@ class DiscParse():
                             duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
                             items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
                             console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
-                        console.print("[bold yellow]Enter playlist numbers separated by commas, 'ALL' to select all, or press Enter to select the biggest playlist:")
+                        if len(discs) == 1:
+                            console.print("[bold yellow]Enter playlist numbers separated by commas, 'ALL' to select all, or press Enter to select the biggest playlist:")
 
-                        user_input = input("Select playlists: ").strip()
+                            user_input = input("Select playlists: ").strip()
 
-                        if user_input.lower() == "all":
-                            selected_playlists = valid_playlists
-                            break  # Exit the loop once valid input is handled
-                        elif user_input == "":
-                            # Select the playlist with the largest total size
-                            console.print("[yellow]Selecting the playlist with the largest size:")
-                            selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
-                            break  # Exit the loop once valid input is handled
-                        else:
-                            try:
-                                selected_indices = [int(x) for x in user_input.split(',')]
-                                selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
+                            if user_input.lower() == "all":
+                                selected_playlists = valid_playlists
                                 break  # Exit the loop once valid input is handled
-                            except ValueError:
-                                console.print("[bold red]Invalid input. Please try again.")
+                            elif user_input == "":
+                                # Select the playlist with the largest total size
+                                console.print("[yellow]Selecting the playlist with the largest size:")
+                                selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
+                                break  # Exit the loop once valid input is handled
+                            else:
+                                try:
+                                    selected_indices = [int(x) for x in user_input.split(',')]
+                                    selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
+                                    break  # Exit the loop once valid input is handled
+                                except ValueError:
+                                    console.print("[bold red]Invalid input. Please try again.")
+                        else:
+                            selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
+                            break
                 else:
                     # Select the playlist with the largest total size
-                    console.print("[yellow]Selecting the playlist with the largest size:")
                     selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
 
                 for idx, playlist in enumerate(selected_playlists):
                     console.print(f"[bold green]Scanning playlist {playlist['file']} with duration {int(playlist['duration'] // 3600)} hours {int((playlist['duration'] % 3600) // 60)} minutes {int(playlist['duration'] % 60)} seconds")
                     playlist_number = playlist['file'].replace(".mpls", "")
-                    playlist_report_path = os.path.join(save_dir, f"{playlist_number}_FULL.txt")
+                    playlist_report_path = os.path.join(save_dir, f"Disc{i + 1}_{playlist_number}_FULL.txt")
 
                     if os.path.exists(playlist_report_path):
                         bdinfo_text = playlist_report_path
@@ -177,14 +180,14 @@ class DiscParse():
 
                             bdinfo = self.parse_bdinfo(bd_summary, files[1], path)
 
-                            # Prompt user for custom label if conditions are met
+                            # Prompt user for custom edition if conditions are met
                             if len(selected_playlists) > 1:
                                 current_label = bdinfo.get('label', f"Playlist {idx}")
                                 console.print(f"[bold yellow]Current label for playlist {playlist['file']}: {current_label}")
 
                                 if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
                                     console.print("[bold green]You can create a custom Edition for this playlist.")
-                                    user_input = input(f"Enter a new Edition for playlist {playlist['file']} (or press Enter to keep the current label): ").strip()
+                                    user_input = input(f"Enter a new Edition title for playlist {playlist['file']} (or press Enter to keep the current label): ").strip()
                                     if user_input:
                                         bdinfo['edition'] = user_input
                                         console.print(f"[bold green]Edition updated to: {bdinfo['edition']}")

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -27,100 +27,94 @@ class DiscParse():
             bdinfo_text = None
             path = os.path.abspath(discs[i]['path'])
 
-            # Check if a BD_SUMMARY_EXT.txt already exists
-            for file in os.listdir(save_dir):
-                if file.startswith("BD_SUMMARY_") and file.endswith(f"{str(i).zfill(2)}.txt"):
-                    bdinfo_text = os.path.join(save_dir, file)
-
             if bdinfo_text is None or meta_discs == []:
-                for file in os.listdir(save_dir):
-                    if file.endswith("_FULL.txt") and file.startswith(f"{str(i).zfill(2)}"):
-                        bdinfo_text = os.path.abspath(os.path.join(save_dir, file))
-                else:
-                    bdinfo_text = ""
-                    playlists_path = os.path.join(path, "PLAYLIST")
+                bdinfo_text = ""
+                playlists_path = os.path.join(path, "PLAYLIST")
 
-                    if not os.path.exists(playlists_path):
-                        console.print(f"[bold red]PLAYLIST directory not found for disc {path}")
-                        continue
+                if not os.path.exists(playlists_path):
+                    console.print(f"[bold red]PLAYLIST directory not found for disc {path}")
+                    continue
 
-                    # Parse playlists
-                    valid_playlists = []
-                    for file_name in os.listdir(playlists_path):
-                        if file_name.endswith(".mpls"):
-                            mpls_path = os.path.join(playlists_path, file_name)
-                            try:
-                                with open(mpls_path, "rb") as mpls_file:
-                                    header = mpls.load_movie_playlist(mpls_file)
-                                    mpls_file.seek(header.playlist_start_address, os.SEEK_SET)
-                                    playlist_data = mpls.load_playlist(mpls_file)
-
-                                    duration = 0
-                                    items = []  # Collect .m2ts file paths and sizes
-                                    stream_directory = os.path.join(path, "STREAM")
-                                    for item in playlist_data.play_items:
-                                        duration += (item.outtime - item.intime) / 45000
-                                        try:
-                                            m2ts_file = os.path.join(stream_directory, item.clip_information_filename.strip() + ".m2ts")
-                                            size = os.path.getsize(m2ts_file) if os.path.exists(m2ts_file) else 0
-                                            items.append({"file": m2ts_file, "size": size})
-                                        except AttributeError as e:
-                                            console.print(f"[bold red]Error accessing clip information for item in {file_name}: {e}")
-
-                                    # Save playlists with duration >= 3 minutes
-                                    if duration >= 180:
-                                        valid_playlists.append({
-                                            "file": file_name,
-                                            "duration": duration,
-                                            "path": mpls_path,
-                                            "items": items
-                                        })
-                            except Exception as e:
-                                console.print(f"[bold red]Error parsing playlist {mpls_path}: {e}")
-
-                    if not valid_playlists:
-                        console.print(f"[bold red]No valid playlists found for disc {path}")
-                        continue
-
-                    # Allow user to select playlists
-                    if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
-                        console.print("[bold green]Available playlists:")
-                        for idx, playlist in enumerate(valid_playlists):
-                            duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
-                            items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
-                            console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
-                        console.print("[bold yellow]Enter playlist numbers separated by commas, or 'ALL' to select all:")
-
-                        user_input = input("Select playlists: ").strip()
-
-                        if user_input.lower() == "all":
-                            selected_playlists = valid_playlists
-                        else:
-                            try:
-                                selected_indices = [int(x) for x in user_input.split(',')]
-                                selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
-                            except ValueError:
-                                console.print("[bold red]Invalid input. Skipping playlist selection.")
-                                continue
-                    else:
-                        # Select the playlist with the largest total size
-                        console.print("[yellow]Selecting the playlist with the largest size:")
-                        selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
-
-                    for idx, playlist in enumerate(selected_playlists):
-                        console.print(f"[bold green]Scanning playlist {playlist['file']} with duration {int(playlist['duration'] // 3600)} hours {int((playlist['duration'] % 3600) // 60)} minutes {int(playlist['duration'] % 60)} seconds")
+                # Parse playlists
+                valid_playlists = []
+                for file_name in os.listdir(playlists_path):
+                    if file_name.endswith(".mpls"):
+                        mpls_path = os.path.join(playlists_path, file_name)
                         try:
-                            playlist_number = playlist['file'].replace(".mpls", "")
-                            playlist_extension = playlist['file']
-                            playlist_report_path = os.path.join(save_dir, f"{playlist_number}_FULL.txt")
+                            with open(mpls_path, "rb") as mpls_file:
+                                header = mpls.load_movie_playlist(mpls_file)
+                                mpls_file.seek(header.playlist_start_address, os.SEEK_SET)
+                                playlist_data = mpls.load_playlist(mpls_file)
 
+                                duration = 0
+                                items = []  # Collect .m2ts file paths and sizes
+                                stream_directory = os.path.join(path, "STREAM")
+                                for item in playlist_data.play_items:
+                                    duration += (item.outtime - item.intime) / 45000
+                                    try:
+                                        m2ts_file = os.path.join(stream_directory, item.clip_information_filename.strip() + ".m2ts")
+                                        size = os.path.getsize(m2ts_file) if os.path.exists(m2ts_file) else 0
+                                        items.append({"file": m2ts_file, "size": size})
+                                    except AttributeError as e:
+                                        console.print(f"[bold red]Error accessing clip information for item in {file_name}: {e}")
+
+                                # Save playlists with duration >= 3 minutes
+                                if duration >= 180:
+                                    valid_playlists.append({
+                                        "file": file_name,
+                                        "duration": duration,
+                                        "path": mpls_path,
+                                        "items": items
+                                    })
+                        except Exception as e:
+                            console.print(f"[bold red]Error parsing playlist {mpls_path}: {e}")
+
+                if not valid_playlists:
+                    console.print(f"[bold red]No valid playlists found for disc {path}")
+                    continue
+
+                # Allow user to select playlists
+                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
+                    console.print("[bold green]Available playlists:")
+                    for idx, playlist in enumerate(valid_playlists):
+                        duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
+                        items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
+                        console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
+                    console.print("[bold yellow]Enter playlist numbers separated by commas, or 'ALL' to select all:")
+
+                    user_input = input("Select playlists: ").strip()
+
+                    if user_input.lower() == "all":
+                        selected_playlists = valid_playlists
+                    else:
+                        try:
+                            selected_indices = [int(x) for x in user_input.split(',')]
+                            selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
+                        except ValueError:
+                            console.print("[bold red]Invalid input. Skipping playlist selection.")
+                            continue
+                else:
+                    # Select the playlist with the largest total size
+                    console.print("[yellow]Selecting the playlist with the largest size:")
+                    selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
+
+                for idx, playlist in enumerate(selected_playlists):
+                    console.print(f"[bold green]Scanning playlist {playlist['file']} with duration {int(playlist['duration'] // 3600)} hours {int((playlist['duration'] % 3600) // 60)} minutes {int(playlist['duration'] % 60)} seconds")
+                    playlist_number = playlist['file'].replace(".mpls", "")
+                    playlist_report_path = os.path.join(save_dir, f"{playlist_number}_FULL.txt")
+
+                    if os.path.exists(playlist_report_path):
+                        bdinfo_text = playlist_report_path
+                    else:
+                        try:
+                            # Scanning playlist block (as before)
                             if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
                                 proc = await asyncio.create_subprocess_exec(
-                                    'mono', f"{base_dir}/bin/BDInfo/BDInfo.exe", path, '-m', playlist_extension, save_dir
+                                    'mono', f"{base_dir}/bin/BDInfo/BDInfo.exe", path, '-m', playlist['file'], save_dir
                                 )
                             elif sys.platform.startswith('win32'):
                                 proc = await asyncio.create_subprocess_exec(
-                                    f"{base_dir}/bin/BDInfo/BDInfo.exe", '-m', playlist_extension, path, save_dir
+                                    f"{base_dir}/bin/BDInfo/BDInfo.exe", '-m', playlist['file'], path, save_dir
                                 )
                             else:
                                 console.print("[red]Unsupported platform for BDInfo.")
@@ -135,60 +129,54 @@ class DiscParse():
                                     shutil.move(bdinfo_text, playlist_report_path)
                                     bdinfo_text = playlist_report_path  # Update bdinfo_text to the renamed file
                                     break
-
-                            # Extract summaries
-                            while True:
-                                try:
-                                    if not os.path.exists(bdinfo_text):
-                                        console.print(f"[bold red]No valid BDInfo file found for playlist {playlist_number}.")
-                                        break
-
-                                    with open(bdinfo_text, 'r') as f:
-                                        text = f.read()
-                                        result = text.split("QUICK SUMMARY:", 2)
-                                        files = result[0].split("FILES:", 2)[1].split("CHAPTERS:", 2)[0].split("-------------")
-                                        result2 = result[1].rstrip(" \n")
-                                        result = result2.split("********************", 1)
-                                        bd_summary = result[0].rstrip(" \n")
-                                        f.close()
-                                    with open(bdinfo_text, 'r') as f:  # parse extended BDInfo
-                                        text = f.read()
-                                        result = text.split("[code]", 3)
-                                        result2 = result[2].rstrip(" \n")
-                                        result = result2.split("FILES:", 1)
-                                        ext_bd_summary = result[0].rstrip(" \n")
-                                        f.close()
-
-                                    # Save summaries
-                                    if idx == 0:
-                                        with open(f"{save_dir}/BD_SUMMARY_{str(i).zfill(2)}.txt", 'w') as f:
-                                            f.write(bd_summary.strip())
-                                            f.close()
-                                        with open(f"{save_dir}/BD_SUMMARY_EXT_{str(i).zfill(2)}.txt", 'w') as f:  # write extended BDInfo file
-                                            f.write(ext_bd_summary.strip())
-                                            f.close()
-                                    else:
-                                        with open(f"{save_dir}/BD_SUMMARY_{str(i).zfill(2)}_{idx}.txt", 'w') as f:
-                                            f.write(bd_summary.strip())
-                                            f.close()
-                                        with open(f"{save_dir}/BD_SUMMARY_EXT_{str(i).zfill(2)}_{idx}.txt", 'w') as f:  # write extended BDInfo file
-                                            f.write(ext_bd_summary.strip())
-                                            f.close()
-
-                                    bdinfo = self.parse_bdinfo(bd_summary, files[1], path)
-
-                                    discs[i]['summary'] = bd_summary.strip()
-                                    discs[i]['bdinfo'] = bdinfo
-                                    discs[i]['playlists'] = selected_playlists
-
-                                except Exception:
-                                    console.print(traceback.format_exc())
-                                    await asyncio.sleep(5)
-                                    continue
-                                break
-
                         except Exception as e:
                             console.print(f"[bold red]Error scanning playlist {playlist['file']}: {e}")
+                            continue
+
+                    # Process the BDInfo report in the while True loop
+                    while True:
+                        try:
+                            if not os.path.exists(bdinfo_text):
+                                console.print(f"[bold red]No valid BDInfo file found for playlist {playlist_number}.")
+                                break
+
+                            with open(bdinfo_text, 'r') as f:
+                                text = f.read()
+                                result = text.split("QUICK SUMMARY:", 2)
+                                files = result[0].split("FILES:", 2)[1].split("CHAPTERS:", 2)[0].split("-------------")
+                                result2 = result[1].rstrip(" \n")
+                                result = result2.split("********************", 1)
+                                bd_summary = result[0].rstrip(" \n")
+
+                            with open(bdinfo_text, 'r') as f:  # Parse extended BDInfo
+                                text = f.read()
+                                result = text.split("[code]", 3)
+                                result2 = result[2].rstrip(" \n")
+                                result = result2.split("FILES:", 1)
+                                ext_bd_summary = result[0].rstrip(" \n")
+
+                            # Save summaries
+                            if idx == 0:
+                                with open(f"{save_dir}/BD_SUMMARY_{str(i).zfill(2)}.txt", 'w') as f:
+                                    f.write(bd_summary.strip())
+                                with open(f"{save_dir}/BD_SUMMARY_EXT_{str(i).zfill(2)}.txt", 'w') as f:
+                                    f.write(ext_bd_summary.strip())
+                                bdinfo = self.parse_bdinfo(bd_summary, files[1], path)
+
+                                discs[i]['summary'] = bd_summary.strip()
+                                discs[i]['bdinfo'] = bdinfo
+                                discs[i]['playlists'] = selected_playlists
+                            else:
+                                with open(f"{save_dir}/BD_SUMMARY_{str(i).zfill(2)}_{idx}.txt", 'w') as f:
+                                    f.write(bd_summary.strip())
+                                with open(f"{save_dir}/BD_SUMMARY_EXT_{str(i).zfill(2)}_{idx}.txt", 'w') as f:
+                                    f.write(ext_bd_summary.strip())
+
+                        except Exception:
+                            console.print(traceback.format_exc())
+                            await asyncio.sleep(5)
+                            continue
+                        break
 
             else:
                 discs = meta_discs

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -80,19 +80,21 @@ class DiscParse():
                         duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
                         items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
                         console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
-                    console.print("[bold yellow]Enter playlist numbers separated by commas, or 'ALL' to select all:")
+                    console.print("[bold yellow]Enter playlist numbers separated by commas, 'ALL' to select all, press enter to default to largest:")
 
                     user_input = input("Select playlists: ").strip()
 
                     if user_input.lower() == "all":
                         selected_playlists = valid_playlists
+                    elif user_input == "":
+                        selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
                     else:
                         try:
                             selected_indices = [int(x) for x in user_input.split(',')]
                             selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
                         except ValueError:
                             console.print("[bold red]Invalid input. Skipping playlist selection.")
-                            continue
+                            selected_playlists = []
                 else:
                     # Select the playlist with the largest total size
                     console.print("[yellow]Selecting the playlist with the largest size:")

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -75,26 +75,31 @@ class DiscParse():
 
                 # Allow user to select playlists
                 if not meta['unattended'] or (meta['unattended'] and meta.get('unattended-confirm', False)):
-                    console.print("[bold green]Available playlists:")
-                    for idx, playlist in enumerate(valid_playlists):
-                        duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
-                        items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
-                        console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
-                    console.print("[bold yellow]Enter playlist numbers separated by commas, 'ALL' to select all, press enter to default to largest:")
+                    while True:  # Loop until valid input is provided
+                        console.print("[bold green]Available playlists:")
+                        for idx, playlist in enumerate(valid_playlists):
+                            duration_str = f"{int(playlist['duration'] // 3600)}h {int((playlist['duration'] % 3600) // 60)}m {int(playlist['duration'] % 60)}s"
+                            items_str = ', '.join(f"{os.path.basename(item['file'])} ({item['size'] // (1024 * 1024)} MB)" for item in playlist['items'])
+                            console.print(f"[{idx}] {playlist['file']} - {duration_str} - {items_str}")
+                        console.print("[bold yellow]Enter playlist numbers separated by commas, 'ALL' to select all, or press Enter to select the biggest playlist:")
 
-                    user_input = input("Select playlists: ").strip()
+                        user_input = input("Select playlists: ").strip()
 
-                    if user_input.lower() == "all":
-                        selected_playlists = valid_playlists
-                    elif user_input == "":
-                        selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
-                    else:
-                        try:
-                            selected_indices = [int(x) for x in user_input.split(',')]
-                            selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
-                        except ValueError:
-                            console.print("[bold red]Invalid input. Skipping playlist selection.")
-                            selected_playlists = []
+                        if user_input.lower() == "all":
+                            selected_playlists = valid_playlists
+                            break  # Exit the loop once valid input is handled
+                        elif user_input == "":
+                            # Select the playlist with the largest total size
+                            console.print("[yellow]Selecting the playlist with the largest size:")
+                            selected_playlists = [max(valid_playlists, key=lambda p: sum(item['size'] for item in p['items']))]
+                            break  # Exit the loop once valid input is handled
+                        else:
+                            try:
+                                selected_indices = [int(x) for x in user_input.split(',')]
+                                selected_playlists = [valid_playlists[idx] for idx in selected_indices if 0 <= idx < len(valid_playlists)]
+                                break  # Exit the loop once valid input is handled
+                            except ValueError:
+                                console.print("[bold red]Invalid input. Please try again.")
                 else:
                     # Select the playlist with the largest total size
                     console.print("[yellow]Selecting the playlist with the largest size:")

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -25,7 +25,7 @@ class DiscParse():
 
         for i in range(len(discs)):
             bdinfo_text = None
-            path = os.path.abspath(discs[i]['path']).rstrip('\\BDMV')
+            path = os.path.abspath(discs[i]['path'])
 
             # Check if a BD_SUMMARY_EXT.txt already exists
             for file in os.listdir(save_dir):
@@ -38,7 +38,7 @@ class DiscParse():
                         bdinfo_text = os.path.abspath(os.path.join(save_dir, file))
                 else:
                     bdinfo_text = ""
-                    playlists_path = os.path.join(path, "BDMV", "PLAYLIST")
+                    playlists_path = os.path.join(path, "PLAYLIST")
 
                     if not os.path.exists(playlists_path):
                         console.print(f"[bold red]PLAYLIST directory not found for disc {path}")

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -57,7 +57,7 @@ class DiscParse():
 
                                     duration = 0
                                     items = []  # Collect .m2ts file paths and sizes
-                                    stream_directory = os.path.join(path, "BDMV", "STREAM")
+                                    stream_directory = os.path.join(path, "STREAM")
                                     for item in playlist_data.play_items:
                                         duration += (item.outtime - item.intime) / 45000
                                         try:

--- a/src/discparse.py
+++ b/src/discparse.py
@@ -29,12 +29,12 @@ class DiscParse():
 
             # Check if a BD_SUMMARY_EXT.txt already exists
             for file in os.listdir(save_dir):
-                if file.startswith("BD_SUMMARY_") and file.endswith(f"{str(i).zfill(5)}.txt"):
+                if file.startswith("BD_SUMMARY_") and file.endswith(f"{str(i).zfill(2)}.txt"):
                     bdinfo_text = os.path.join(save_dir, file)
 
             if bdinfo_text is None or meta_discs == []:
                 for file in os.listdir(save_dir):
-                    if file.endswith("_FULL.txt") and file.startswith(f"{str(i).zfill(5)}"):
+                    if file.endswith("_FULL.txt") and file.startswith(f"{str(i).zfill(2)}"):
                         bdinfo_text = os.path.abspath(os.path.join(save_dir, file))
                 else:
                     bdinfo_text = ""

--- a/src/prep.py
+++ b/src/prep.py
@@ -484,9 +484,9 @@ class Prep():
                     discs.append(disc)
         if is_disc == "BDMV":
             if meta.get('edit', False) is False:
-                discs, bdinfo = await parse.get_bdinfo(discs, meta['uuid'], meta['base_dir'], meta.get('discs', []))
+                discs, bdinfo = await parse.get_bdinfo(meta, discs, meta['uuid'], meta['base_dir'], meta.get('discs', []))
             else:
-                discs, bdinfo = await parse.get_bdinfo(meta['discs'], meta['uuid'], meta['base_dir'], meta['discs'])
+                discs, bdinfo = await parse.get_bdinfo(meta, meta['discs'], meta['uuid'], meta['base_dir'], meta['discs'])
         elif is_disc == "DVD":
             discs = await parse.get_dvdinfo(discs)
             export = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'w', newline="", encoding='utf-8')

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -87,6 +87,70 @@ class COMMON():
                     raw_url = images[img_index]['raw_url']
                     descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url]")
                 descfile.write("[/center]")
+                if each['type'] == "BDMV":
+                    bdinfo_keys = [key for key in each if key.startswith("bdinfo")]
+                    screens = int(self.config['DEFAULT'].get('screens', 6))
+                    if len(bdinfo_keys) > 1:
+                        if 'retry_count' not in meta:
+                            meta['retry_count'] = 0
+
+                        for i, key in enumerate(bdinfo_keys[1:], start=1):  # Skip the first bdinfo
+                            new_images_key = f'new_images_playlist_{i}'
+                            bdinfo = each[key]
+                            edition = bdinfo.get("edition", "Unknown Edition")
+
+                            # Find the corresponding summary for this bdinfo
+                            summary_key = f"summary_{i}" if i > 0 else "summary"
+                            summary = each.get(summary_key, "No summary available")
+
+                            if new_images_key in meta and meta[new_images_key]:
+                                descfile.write("[center]\n\n")
+                                # Use the summary corresponding to the current bdinfo
+                                descfile.write(f"[spoiler={edition}][code]{summary}[/code][/spoiler]\n\n")
+                                if meta['debug']:
+                                    console.print("[yellow]Using original uploaded images for first disc")
+                                descfile.write("[center]")
+                                for img in meta[new_images_key]:
+                                    web_url = img['web_url']
+                                    raw_url = img['raw_url']
+                                    image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                    descfile.write(image_str)
+                                descfile.write("[/center]\n\n")
+                            else:
+                                descfile.write("[center]\n\n")
+                                # Use the summary corresponding to the current bdinfo
+                                descfile.write(f"[spoiler={edition}][code]{summary}[/code][/spoiler]\n\n")
+                                descfile.write("[/center]\n\n")
+                                meta['retry_count'] += 1
+                                meta[new_images_key] = []
+                                new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
+                                if not new_screens:
+                                    use_vs = meta.get('vapoursynth', False)
+                                    try:
+                                        disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), screens, True)
+                                    except Exception as e:
+                                        print(f"Error during BDMV screenshot capture: {e}")
+                                    new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
+                                if new_screens and not meta.get('skip_imghost_upload', False):
+                                    uploaded_images, _ = upload_screens(meta, screens, 1, 0, screens, new_screens, {new_images_key: meta[new_images_key]})
+                                    for img in uploaded_images:
+                                        meta[new_images_key].append({
+                                            'img_url': img['img_url'],
+                                            'raw_url': img['raw_url'],
+                                            'web_url': img['web_url']
+                                        })
+
+                                    descfile.write("[center]")
+                                    for img in uploaded_images:
+                                        web_url = img['web_url']
+                                        raw_url = img['raw_url']
+                                        image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                        descfile.write(image_str)
+                                    descfile.write("[/center]\n\n")
+
+                                meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
+                                with open(meta_filename, 'w') as f:
+                                    json.dump(meta, f, indent=4)
 
             # Handle multiple discs case
             elif len(discs) > 1:
@@ -441,10 +505,11 @@ class COMMON():
 
         # Determine the URL based on whether we're searching by file name or ID
         if file_name:
-            url = f"{search_url}?file_name={file_name}"
+            params['file_name'] = file_name  # Add file_name to params
+            url = search_url
             console.print(f"[green]Searching {tracker} by file name: [bold yellow]{file_name}[/bold yellow]")
         elif id:
-            url = f"{torrent_url}{id}?"
+            url = f"{torrent_url}{id}"
             console.print(f"[green]Searching {tracker} by ID: [bold yellow]{id}[/bold yellow] via {url}")
         else:
             console.print("[red]No ID or file name provided for search.[/red]")

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -654,6 +654,11 @@ class PTP():
                 each = discs[0]
                 new_screens = []
                 if each['type'] == "BDMV":
+                    bdinfo_keys = [key for key in each if key.startswith("bdinfo")]
+                    bdinfo = meta.get('bdinfo')
+                    if len(bdinfo_keys) > 1:
+                        edition = bdinfo.get("edition", "Unknown Edition")
+                        desc.write(f"[b]{edition}[/b]\n\n")
                     desc.write(f"[mediainfo]{each['summary']}[/mediainfo]\n\n")
                     base2ptp = self.convert_bbcode(base)
                     if base2ptp.strip() != "":
@@ -675,6 +680,59 @@ class PTP():
                         raw_url = meta['image_list'][img_index]['raw_url']
                         desc.write(f"[img]{raw_url}[/img]\n")
                     desc.write("\n")
+                screens = int(self.config['DEFAULT'].get('screens', 6))
+                if len(bdinfo_keys) > 1:
+                    if 'retry_count' not in meta:
+                        meta['retry_count'] = 0
+
+                    for i, key in enumerate(bdinfo_keys[1:], start=1):  # Skip the first bdinfo
+                        new_images_key = f'new_images_playlist_{i}'
+                        bdinfo = each[key]
+                        edition = bdinfo.get("edition", "Unknown Edition")
+
+                        # Find the corresponding summary for this bdinfo
+                        summary_key = f"summary_{i}" if i > 0 else "summary"
+                        summary = each.get(summary_key, "No summary available")
+
+                        if new_images_key in meta and meta[new_images_key]:
+                            desc.write(f"\n[b]{edition}[/b]\n\n")
+                            # Use the summary corresponding to the current bdinfo
+                            desc.write(f"[mediainfo]{summary}[/mediainfo]\n\n")
+                            if meta['debug']:
+                                console.print("[yellow]Using original uploaded images for first disc")
+                            for img in meta[new_images_key]:
+                                raw_url = img['raw_url']
+                                desc.write(f"[img]{raw_url}[/img]\n")
+                        else:
+                            desc.write(f"\n[b]{edition}[/b]\n")
+                            # Use the summary corresponding to the current bdinfo
+                            desc.write(f"[mediainfo]{summary}[/mediainfo]\n\n")
+                            meta['retry_count'] += 1
+                            meta[new_images_key] = []
+                            new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
+                            if not new_screens:
+                                use_vs = meta.get('vapoursynth', False)
+                                try:
+                                    disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), screens, True)
+                                except Exception as e:
+                                    print(f"Error during BDMV screenshot capture: {e}")
+                                new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
+                            if new_screens and not meta.get('skip_imghost_upload', False):
+                                uploaded_images, _ = upload_screens(meta, screens, 1, 0, screens, new_screens, {new_images_key: meta[new_images_key]})
+                                for img in uploaded_images:
+                                    meta[new_images_key].append({
+                                        'img_url': img['img_url'],
+                                        'raw_url': img['raw_url'],
+                                        'web_url': img['web_url']
+                                    })
+
+                                for img in uploaded_images:
+                                    raw_url = img['raw_url']
+                                    desc.write(f"[img]{raw_url}[/img]\n")
+
+                            meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
+                            with open(meta_filename, 'w') as f:
+                                json.dump(meta, f, indent=4)
 
             # Handle multiple discs case
             elif len(discs) > 1:

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -313,8 +313,12 @@ def upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_lis
         existing_count = 0
     else:
         image_glob = glob.glob("*.png")
-        if 'POSTER.png' in image_glob:
-            image_glob.remove('POSTER.png')
+        unwanted_patterns = ["FILE*", "PLAYLIST*", "POSTER*"]
+        unwanted_files = set()
+        for pattern in unwanted_patterns:
+            unwanted_files.update(glob.glob(pattern))
+
+        image_glob = [file for file in image_glob if file not in unwanted_files]
         image_glob = list(set(image_glob))
         if meta['debug']:
             console.print("image globs:", image_glob)


### PR DESCRIPTION
Use playlists instead of scanning the entire disc.

```python
Available playlists:
[0] 00000.mpls - 1h 25m 10s - 00000.m2ts (24475 MB)
[1] 00002.mpls - 0h 24m 26s - 00003.m2ts (5956 MB)
[2] 00006.mpls - 1h 33m 24s - 00007.m2ts (5093 MB)
[3] 00010.mpls - 0h 9m 22s - 00011.m2ts (1827 MB)
Enter playlist numbers separated by commas, or 'ALL' to select all:
```
The longest and/or first playlist in the full scan is not always correct. This PR allows the user to select the correct playlist, else will select the largest playlist in unattended. The full scan was only ever parsed to get the playlist anyway.

Will have the side benefit of being quicker to process BD.

Multi-discs select the largest playlist, fancy playlist support for multi-disc may come later.

- [x] Handle when existing files exist
- [x] Implement edition support (work like multi-disc)
- [x] Check multi-disc handling