### PR TITLE
[MTV.py] Adding second mediainfo for DVD .vob files where applicable.

### DIFF
--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -177,6 +177,14 @@ class MTV():
                 desc.write("[mediainfo]" + bd_dump + "[/mediainfo]\n\n")
             elif mi_dump:
                 desc.write("[mediainfo]" + mi_dump + "[/mediainfo]\n\n")
+                
+            if (
+                meta.get('is_disc') == "DVD" and
+                isinstance(meta.get('discs'), list) and
+                len(meta['discs']) > 0 and 
+                'vob_mi' in meta['discs'][0]
+            ):
+                desc.write("[mediainfo]" + meta['discs'][0]['vob_mi'] + "[/mediainfo]\n\n")
 
             if f'{self.tracker}_images_key' in meta:
                 images = meta[f'{self.tracker}_images_key']

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -177,11 +177,11 @@ class MTV():
                 desc.write("[mediainfo]" + bd_dump + "[/mediainfo]\n\n")
             elif mi_dump:
                 desc.write("[mediainfo]" + mi_dump + "[/mediainfo]\n\n")
-                
+
             if (
                 meta.get('is_disc') == "DVD" and
                 isinstance(meta.get('discs'), list) and
-                len(meta['discs']) > 0 and 
+                len(meta['discs']) > 0 and
                 'vob_mi' in meta['discs'][0]
             ):
                 desc.write("[mediainfo]" + meta['discs'][0]['vob_mi'] + "[/mediainfo]\n\n")


### PR DESCRIPTION
It's not required by MTV rules, but it's very much needed. And it will bring consistence with UNIT3D uploads.