### PR TITLE
Fix edit-args

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-from src.args import Args
 from src.console import console
 from src.exceptions import *  # noqa: F403
 from src.clients import Clients
 from data.config import config
-from src.uphelper import UploadHelper
-from src.trackersetup import TRACKER_SETUP, tracker_class_map
-from src.takescreens import disc_screenshots, dvd_screenshots, screenshots
+from src.trackersetup import tracker_class_map
 from src.tvmaze import search_tvmaze
 from src.imdb import get_imdb_info_api, search_imdb, imdb_other_meta
 from src.trackermeta import update_metadata_from_tracker
@@ -14,7 +11,6 @@ from src.tmdb import tmdb_other_meta, get_tmdb_imdb_from_mediainfo, get_tmdb_fro
 from src.region import get_region, get_distributor, get_service
 from src.exportmi import exportInfo, mi_resolution
 from src.getseasonep import get_season_episode
-from src.trackerstatus import process_all_trackers
 
 try:
     import traceback
@@ -33,7 +29,6 @@ try:
     import tmdbsimple as tmdb
     import time
     import itertools
-    import cli_ui
     import aiohttp
 except ModuleNotFoundError:
     console.print(traceback.print_exc())
@@ -186,7 +181,6 @@ class Prep():
         if " AKA " in filename.replace('.', ' '):
             filename = filename.split('AKA')[0]
         meta['filename'] = filename
-
         meta['bdinfo'] = bdinfo
 
         # Debugging information after population
@@ -205,7 +199,6 @@ class Prep():
         client = Clients(config=config)
         if meta.get('infohash') is not None:
             meta = await client.get_ptp_from_hash(meta)
-        tracker_setup = TRACKER_SETUP(config=config)
         if not meta.get('image_list'):
             # Reuse information from trackers with fallback
             found_match = False
@@ -350,93 +343,15 @@ class Prep():
                 meta['edition'] = re.sub(r"REPACK[\d]?", "", meta['edition']).strip().replace('  ', ' ')
         else:
             meta['edition'] = ""
-        meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await self.get_name(meta)
-        if meta['debug']:
-            meta_finish_time = time.time()
-            console.print(f"Metadata processed in {meta_finish_time - meta_start_time:.2f} seconds")
-        parser = Args(config)
-        helper = UploadHelper()
-        enabled_trackers = tracker_setup.trackers_enabled(meta)
-        if "saved_trackers" not in meta:
-            meta['trackers'] = enabled_trackers
-        else:
-            meta['trackers'] = meta['saved_trackers']
-        if meta.get('edit', False):
-            meta['edit'] = False
-        confirm = await helper.get_confirmation(meta)
-        while confirm is False:
-            with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
-                json.dump(meta, f, indent=4)
-            meta['saved_trackers'] = meta['trackers']
-            editargs = cli_ui.ask_string("Input args that need correction e.g. (--tag NTb --category tv --tmdb 12345)")
-            editargs = (meta['path'],) + tuple(editargs.split())
-            if meta.get('debug', False):
-                editargs += ("--debug",)
-            meta, help, before_args = parser.parse(editargs, meta)
-            meta['edit'] = True
-            meta = await self.gather_prep(meta=meta, mode='cli')
-            meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await self.get_name(meta)
-            confirm = await helper.get_confirmation(meta)
 
-        if meta['debug']:
-            dupe_start_time = time.time()
-        successful_trackers = await process_all_trackers(meta)
-        if meta['debug']:
-            dupe_finish_time = time.time()
-            console.print(f"Dupe checking processed in {dupe_finish_time - dupe_start_time:.2f} seconds")
-
-        meta['skip_uploading'] = int(self.config['DEFAULT'].get('tracker_pass_checks', 1))
-        if not meta['debug']:
-            if successful_trackers < meta['skip_uploading']:
-                console.print(f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]")
-                return
-
-        meta['we_are_uploading'] = True
-
-        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
-            json.dump(meta, f, indent=4)
-
-        if 'manual_frames' not in meta:
-            meta['manual_frames'] = {}
-        manual_frames = meta['manual_frames']
-        # Take Screenshots
-        if meta['is_disc'] == "BDMV":
-            if not meta.get('edit', False):
-                use_vs = meta.get('vapoursynth', False)
-                try:
-                    disc_screenshots(
-                        meta, filename, bdinfo, meta['uuid'], base_dir, use_vs,
-                        meta.get('image_list', []), meta.get('ffdebug', False), None
-                    )
-                except Exception as e:
-                    print(f"Error during BDMV screenshot capture: {e}")
-
-        elif meta['is_disc'] == "DVD":
-            if not meta.get('edit', False):
-                try:
-                    dvd_screenshots(
-                        meta, 0, None, None
-                    )
-                except Exception as e:
-                    print(f"Error during DVD screenshot capture: {e}")
-
-        else:
-            if not meta.get('edit', False):
-                try:
-                    screenshots(
-                        videopath, filename, meta['uuid'], base_dir, meta,
-                        manual_frames=manual_frames  # Pass additional kwargs directly
-                    )
-                except Exception as e:
-                    print(f"Error during generic screenshot capture: {e}")
-
-        # WORK ON THIS
         meta.get('stream', False)
         meta['stream'] = await self.stream_optimized(meta['stream'])
         meta.get('anon', False)
         meta['anon'] = self.is_anon(meta['anon'])
-        if meta['saved_description'] is False:
-            meta = await self.gen_desc(meta)
+        if meta['debug']:
+            meta_finish_time = time.time()
+            console.print(f"Metadata processed in {meta_finish_time - meta_start_time:.2f} seconds")
+
         return meta
 
     """

--- a/upload.py
+++ b/upload.py
@@ -93,6 +93,7 @@ async def process_meta(meta, base_dir):
         trackers = config['TRACKERS']['default_trackers']
     if "," in trackers:
         trackers = trackers.split(',')
+    meta['trackers'] = trackers
     with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
         json.dump(meta, f, indent=4)
         f.close()

--- a/upload.py
+++ b/upload.py
@@ -18,6 +18,10 @@ from src.trackerhandle import process_trackers
 from src.queuemanage import handle_queue
 from src.console import console
 from src.torrentcreate import create_torrent, create_random_torrents, create_base_from_existing_torrent
+from src.uphelper import UploadHelper
+from src.trackerstatus import process_all_trackers
+from src.takescreens import disc_screenshots, dvd_screenshots, screenshots
+
 
 cli_ui.setup(color='always', title="Audionut's Upload Assistant")
 
@@ -80,10 +84,80 @@ async def process_meta(meta, base_dir):
     meta['base_dir'] = base_dir
     prep = Prep(screens=meta['screens'], img_host=meta['imghost'], config=config)
     meta = await prep.gather_prep(meta=meta, mode='cli')
-    if not meta:
-        return
+    meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await prep.get_name(meta)
+    parser = Args(config)
+    helper = UploadHelper()
+    if meta.get('trackers', None) is not None:
+        trackers = meta['trackers']
     else:
-        meta['cutoff'] = int(config['DEFAULT'].get('cutoff_screens', 3))
+        trackers = config['TRACKERS']['default_trackers']
+    if "," in trackers:
+        trackers = trackers.split(',')
+    with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
+        json.dump(meta, f, indent=4)
+        f.close()
+    confirm = await helper.get_confirmation(meta)
+    while confirm is False:
+        editargs = cli_ui.ask_string("Input args that need correction e.g. (--tag NTb --category tv --tmdb 12345)")
+        editargs = (meta['path'],) + tuple(editargs.split())
+        if meta.get('debug', False):
+            editargs += ("--debug",)
+        console.print("meta['trackers']:", meta['trackers'])
+        if meta.get('trackers', None) is not None:
+            editargs += ("--trackers", ', '.join(meta['trackers']))
+        console.print("editargs:", editargs)
+        meta, help, before_args = parser.parse(editargs, meta)
+        console.print("before_args:", before_args)
+        console.print("meta after parse:", meta)
+        meta['edit'] = True
+        meta = await prep.gather_prep(meta=meta, mode='cli')
+        meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await prep.get_name(meta)
+        confirm = await helper.get_confirmation(meta)
+
+    successful_trackers = await process_all_trackers(meta)
+
+    meta['skip_uploading'] = int(config['DEFAULT'].get('tracker_pass_checks', 1))
+    if successful_trackers < meta['skip_uploading'] and not meta['debug']:
+        console.print(f"[red]Not enough successful trackers ({successful_trackers}/{meta['skip_uploading']}). EXITING........[/red]")
+
+    else:
+        meta['we_are_uploading'] = True
+        filename = meta.get('title', None)
+        bdinfo = meta.get('bdinfo', None)
+        videopath = meta.get('path', None)
+        console.print(f"Processing {filename} for upload")
+        if 'manual_frames' not in meta:
+            meta['manual_frames'] = {}
+        manual_frames = meta['manual_frames']
+        # Take Screenshots
+        if meta['is_disc'] == "BDMV":
+            use_vs = meta.get('vapoursynth', False)
+            try:
+                disc_screenshots(
+                    meta, filename, bdinfo, meta['uuid'], base_dir, use_vs,
+                    meta.get('image_list', []), meta.get('ffdebug', False), None
+                )
+            except Exception as e:
+                print(f"Error during BDMV screenshot capture: {e}")
+
+        elif meta['is_disc'] == "DVD":
+            try:
+                dvd_screenshots(
+                    meta, 0, None, None
+                )
+            except Exception as e:
+                print(f"Error during DVD screenshot capture: {e}")
+
+        else:
+            try:
+                screenshots(
+                    videopath, filename, meta['uuid'], base_dir, meta,
+                    manual_frames=manual_frames  # Pass additional kwargs directly
+                )
+            except Exception as e:
+                print(f"Error during generic screenshot capture: {e}")
+
+        meta['cutoff'] = int(config['DEFAULT'].get('cutoff_screens', 0))
         if len(meta.get('image_list', [])) < meta.get('cutoff') and meta.get('skip_imghost_upload', False) is False:
             if 'image_list' not in meta:
                 meta['image_list'] = []
@@ -114,6 +188,9 @@ async def process_meta(meta, base_dir):
 
         if int(meta.get('randomized', 0)) >= 1:
             create_random_torrents(meta['base_dir'], meta['uuid'], meta['randomized'], meta['path'])
+
+        if meta['saved_description'] is False:
+            meta = await prep.gen_desc(meta)
 
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
             json.dump(meta, f, indent=4)
@@ -148,7 +225,7 @@ async def save_processed_file(log_file, file_path):
 
 
 async def do_the_thing(base_dir):
-    meta = {'base_dir': base_dir}
+    meta = dict()
     paths = []
     for each in sys.argv[1:]:
         if os.path.exists(each):


### PR DESCRIPTION
During the refactor of the process in V2, one unintended consequence was background looping of the tracker_status process, resulting in tracker confirmation prompts equaling the amount of times meta was edited via `is this correct`.

This refactor seeks to unfuck things.

Will also attempt to refactor the edit arg process to properly track original and edited meta. ie: If someone specifies an argument to be modified, that argument should stick, even if the arguments are modified 37 times until the user finally figures it out. *low priority*

Also seek to catch any edge cases where an argument, ie: trackers, does not modify correctly.

- [x] Check BDMV/DVD image handling
- [x] Make sure the branch is correctly synced with local
- [ ] Look at editargs more
- [ ] Triple check everything