### PR TITLE
Limit used screenshots to config option [failed]

### DIFF
--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -8,7 +8,6 @@ from PIL import Image
 import io
 from io import BytesIO
 
-expected_images = int(config['DEFAULT']['screens'])
 
 async def prompt_user_for_confirmation(message: str) -> bool:
     try:
@@ -21,6 +20,7 @@ async def prompt_user_for_confirmation(message: str) -> bool:
 
 
 async def check_images_concurrently(imagelist, meta):
+    expected_images = meta['screens']
     approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb']
     invalid_host_found = False  # Track if any image is on a non-approved host
 
@@ -340,7 +340,7 @@ async def update_metadata_from_tracker(tracker_name, tracker_instance, meta, sea
 
 async def handle_image_list(meta, tracker_name):
     if meta.get('image_list'):
-        console.print(f"[cyan]Selected the following {expected_images} valid images from {tracker_name}:")
+        console.print(f"[cyan]Selected the following {len(meta['screens'])} valid images from {tracker_name}:")
         for img in meta['image_list']:
             console.print(f"Image:[green]'{img.get('img_url')}'[/green]")
 

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -8,6 +8,7 @@ from PIL import Image
 import io
 from io import BytesIO
 
+expected_images = int(config['DEFAULT']['screens'])
 
 async def prompt_user_for_confirmation(message: str) -> bool:
     try:
@@ -20,7 +21,6 @@ async def prompt_user_for_confirmation(message: str) -> bool:
 
 
 async def check_images_concurrently(imagelist, meta):
-    expected_images = meta['screens']
     approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb']
     invalid_host_found = False  # Track if any image is on a non-approved host
 
@@ -340,7 +340,7 @@ async def update_metadata_from_tracker(tracker_name, tracker_instance, meta, sea
 
 async def handle_image_list(meta, tracker_name):
     if meta.get('image_list'):
-        console.print(f"[cyan]Selected the following {len(meta['screens'])} valid images from {tracker_name}:")
+        console.print(f"[cyan]Selected the following {expected_images} valid images from {tracker_name}:")
         for img in meta['image_list']:
             console.print(f"Image:[green]'{img.get('img_url')}'[/green]")
 

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -26,7 +26,7 @@ class BLU():
         self.search_url = 'https://blutopia.cc/api/torrents/filter'
         self.torrent_url = 'https://blutopia.cc/api/torrents/'
         self.upload_url = 'https://blutopia.cc/api/torrents/upload'
-        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
+        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionuts Upload Assistant[/url][/center]"
         self.banned_groups = [
             '[Oj]', '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AROMA', 'aXXo', 'Brrip', 'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc', 'FaNGDiNG0', 'FGT', 'Flights',
             'FRDS', 'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LEGi0N', 'LOAD', 'MeGusta', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'OFT',

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -55,7 +55,7 @@ class COMMON():
         process_limit = int(self.config['DEFAULT'].get('processLimit', 10))
         try:
             screenheader = self.config['DEFAULT']['screenshot_header']
-        except Exception:
+        except ValueError:
             screenheader = None
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}]DESCRIPTION.txt", 'w', encoding='utf8') as descfile:
             if desc_header:
@@ -169,9 +169,12 @@ class COMMON():
                             descfile.write(f"{each['name']}:\n")
                             descfile.write(f"[spoiler={os.path.basename(each['vob'])}][code]{each['vob_mi']}[/code][/spoiler]")
                             descfile.write(f"[spoiler={os.path.basename(each['ifo'])}][code]{each['ifo_mi']}[/code][/spoiler]\n\n")
-                        # For the first disc, use images from `meta['image_list']`
+                        # For the first disc, use images from `meta['image_list']` and add screenheader
                         if meta['debug']:
                             console.print("[yellow]Using original uploaded images for first disc")
+                        if screenheader is not None:
+                            descfile.write(screenheader + '\n')
+                        descfile.write("[center]")
                         for img_index in range(len(images[:int(meta['screens'])])):
                             web_url = images[img_index]['web_url']
                             raw_url = images[img_index]['raw_url']
@@ -355,8 +358,11 @@ class COMMON():
 
                     # Write images if they exist
                     new_images_key = f'new_images_file_{i}'
-                    if i == 0:  # For the first file, use 'image_list' key
+                    if i == 0:  # For the first file, use 'image_list' key and add screenheader
                         if images:
+                            if screenheader is not None:
+                                descfile.write(screenheader + '\n')
+                                char_count += len(screenheader + '\n')
                             descfile.write("[center]")
                             char_count += len("[center]")
                             for img_index in range(len(images)):

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -174,7 +174,6 @@ class COMMON():
                             console.print("[yellow]Using original uploaded images for first disc")
                         if screenheader is not None:
                             descfile.write(screenheader + '\n')
-                        descfile.write("[center]")
                         for img_index in range(len(images[:int(meta['screens'])])):
                             web_url = images[img_index]['web_url']
                             raw_url = images[img_index]['raw_url']

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -162,6 +162,7 @@ class COMMON():
                     new_images_key = f'new_images_disc_{i}'
 
                     if i == 0:
+                        descfile.write("[center]")
                         if each['type'] == "BDMV":
                             descfile.write(f"{each.get('name', 'BDINFO')}\n\n")
                         elif each['type'] == "DVD":


### PR DESCRIPTION
Limits the amount of screenshots used from a sourced tracker to the amount set in the config file.

Also cleaned up the output of the image validation