### PR TITLE
Limit used screenshots to config option

### DIFF
--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -8,6 +8,8 @@ from PIL import Image
 import io
 from io import BytesIO
 
+# Define expected amount of screenshots from the config
+expected_images = int(config['DEFAULT']['screens'])
 
 async def prompt_user_for_confirmation(message: str) -> bool:
     try:
@@ -17,9 +19,6 @@ async def prompt_user_for_confirmation(message: str) -> bool:
         return False
     except EOFError:
         sys.exit(1)
-
-# Define expected amount of screenshots from the config
-expected_images = int(config['DEFAULT']['screens'])
 
 async def check_images_concurrently(imagelist, meta):
     approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb']
@@ -92,6 +91,12 @@ async def check_images_concurrently(imagelist, meta):
                                 )
                                 return None
 
+                                meta['image_sizes'][img_url] = len(image_content)
+                                if meta['debug']:
+                                    console.print(
+                                        f"Valid image {img_url} with resolution {image.width}x{image.height} "
+                                        f"and size {len(image_content) / 1024:.2f} KiB"
+                                    )
                         except Exception as e:
                             console.print(f"[red]Failed to process image {img_url}: {e}")
                             return None

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -18,6 +18,8 @@ async def prompt_user_for_confirmation(message: str) -> bool:
     except EOFError:
         sys.exit(1)
 
+# Define expected amount of screenshots from the config
+expected_images = int(config['DEFAULT']['screens'])
 
 async def check_images_concurrently(imagelist, meta):
     approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb']
@@ -90,11 +92,6 @@ async def check_images_concurrently(imagelist, meta):
                                 )
                                 return None
 
-                            meta['image_sizes'][img_url] = len(image_content)
-                            console.print(
-                                f"Valid image {img_url} with resolution {image.width}x{image.height} "
-                                f"and size {len(image_content) / 1024:.2f} KiB"
-                            )
                         except Exception as e:
                             console.print(f"[red]Failed to process image {img_url}: {e}")
                             return None
@@ -109,8 +106,10 @@ async def check_images_concurrently(imagelist, meta):
     tasks = [check_and_collect(image_dict) for image_dict in imagelist]
     results = await asyncio.gather(*tasks)
 
-    # Collect valid images
+    # Collect valid images and limit to amount set in config
     valid_images = [image for image in results if image is not None]
+    if expected_images < len(valid_images):
+        valid_images = valid_images[:expected_images]
 
     # Convert default_trackers string into a list
     default_trackers = config['TRACKERS'].get('default_trackers', '')
@@ -145,7 +144,6 @@ async def check_image_link(url):
                         try:
                             image = Image.open(io.BytesIO(image_data))
                             image.verify()  # This will check if the image is broken
-                            console.print(f"[green]Image verified successfully: {url}[/green]")
                             return True
                         except (IOError, SyntaxError) as e:  # noqa #F841
                             console.print(f"[red]Image verification failed (corrupt image): {url}[/red]")
@@ -349,9 +347,9 @@ async def update_metadata_from_tracker(tracker_name, tracker_instance, meta, sea
 
 async def handle_image_list(meta, tracker_name):
     if meta.get('image_list'):
-        console.print(f"[cyan]Found the following images from {tracker_name}:")
+        console.print(f"[cyan]Selected the following {expected_images} valid images from {tracker_name}:")
         for img in meta['image_list']:
-            console.print(f"[blue]{img}[/blue]")
+            console.print(f"Image:[green]'{img.get('img_url')}'[/green]")
 
         if meta['unattended']:
             keep_images = True

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -11,6 +11,7 @@ from io import BytesIO
 # Define expected amount of screenshots from the config
 expected_images = int(config['DEFAULT']['screens'])
 
+
 async def prompt_user_for_confirmation(message: str) -> bool:
     try:
         response = input(f"{message} (Y/n): ").strip().lower()
@@ -19,6 +20,7 @@ async def prompt_user_for_confirmation(message: str) -> bool:
         return False
     except EOFError:
         sys.exit(1)
+
 
 async def check_images_concurrently(imagelist, meta):
     approved_image_hosts = ['ptpimg', 'imgbox', 'imgbb']

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -93,12 +93,12 @@ async def check_images_concurrently(imagelist, meta):
                                 )
                                 return None
 
-                                meta['image_sizes'][img_url] = len(image_content)
-                                if meta['debug']:
-                                    console.print(
-                                        f"Valid image {img_url} with resolution {image.width}x{image.height} "
-                                        f"and size {len(image_content) / 1024:.2f} KiB"
-                                    )
+                            meta['image_sizes'][img_url] = len(image_content)
+                            if meta['debug']:
+                                console.print(
+                                    f"Valid image {img_url} with resolution {image.width}x{image.height} "
+                                    f"and size {len(image_content) / 1024:.2f} KiB"
+                                )
                         except Exception as e:
                             console.print(f"[red]Failed to process image {img_url}: {e}")
                             return None


### PR DESCRIPTION
Limits the amount of screenshots used from a sourced tracker to the amount set in the config file.

Also cleaned up the output of the image validation.