### PR TITLE
Image handling update

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -46,9 +46,9 @@ config = {
         "cutoff_screens": "3",
 
         # multi processing task limit
-        # When capturing/optimizing/uploading images, limit to this many concurrent tasks
-        # defaults to os.cpu_count() if this value not set
-        # "task_limit": "1",
+        # When optimizing images, limit to this many concurrent tasks
+        # defaults to os.cpu_count() // 2 if this value not set
+        # "process_limit": "1",
 
         # Providing the option to change the size of the screenshot thumbnails where supported.
         # Default is 350, ie [img=350]
@@ -87,10 +87,6 @@ config = {
 
         # Enable lossless PNG Compression (True/False)
         "optimize_images": True,
-
-        # Use only half available CPU cores to avoid memory allocation errors on some seedboxes.
-        # Only when using lossless compression
-        "shared_seedbox": False,
 
         # The name of your default torrent client, set in the torrent client sections below
         "default_torrent_client": "Client1",

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -88,7 +88,7 @@ async def handle_image_upload(meta, tracker, url_host_mapping, approved_image_ho
     new_images_key = f'{tracker}_images_key'
     discs = meta.get('discs', [])  # noqa F841
     filelist = meta.get('video', [])
-    filename = meta['filename']
+    filename = meta['title']
     path = meta['path']
     if isinstance(filelist, str):
         filelist = [filelist]

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -115,19 +115,19 @@ async def handle_image_upload(meta, tracker, url_host_mapping, approved_image_ho
                 console.print(f"[yellow]Insufficient screenshots found: generating {multi_screens} screenshots.")
             if meta['is_disc'] == "BDMV":
                 try:
-                    disc_screenshots(meta, filename, meta['bdinfo'], folder_id, base_dir, meta.get('vapoursynth', False), [], meta.get('ffdebug', False), multi_screens, True)
+                    await disc_screenshots(meta, filename, meta['bdinfo'], folder_id, base_dir, meta.get('vapoursynth', False), [], meta.get('ffdebug', False), multi_screens, True)
                 except Exception as e:
                     print(f"Error during BDMV screenshot capture: {e}")
             elif meta['is_disc'] == "DVD":
                 try:
-                    dvd_screenshots(
+                    await dvd_screenshots(
                         meta, 0, None, True
                     )
                 except Exception as e:
                     print(f"Error during DVD screenshot capture: {e}")
             else:
                 try:
-                    screenshots(
+                    await screenshots(
                         path, filename, meta['uuid'], base_dir, meta, multi_screens, True, None)
                 except Exception as e:
                     print(f"Error during generic screenshot capture: {e}")

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -164,7 +164,7 @@ async def handle_image_upload(meta, tracker, url_host_mapping, approved_image_ho
                 console.print(f"[green]Uploading to approved host '{current_img_host}'.")
                 break
 
-        uploaded_images, _ = upload_screens(
+        uploaded_images, _ = await upload_screens(
             meta, multi_screens, img_host_index, 0, multi_screens,
             all_screenshots, {new_images_key: meta[new_images_key]}, retry_mode
         )

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -75,7 +75,8 @@ async def disc_screenshots(meta, filename, bdinfo, folder_id, base_dir, use_vs, 
                 console.print("[red]Error: Unable to parse frame rate from bdinfo['video'][0]['fps']")
 
     keyframe = 'nokey' if "VC-1" in bdinfo['video'][0]['codec'] or bdinfo['video'][0]['hdr_dv'] != "" else 'none'
-    print(f"File: {file}, Length: {length}, Frame Rate: {frame_rate}")
+    if meta['debug']:
+        print(f"File: {file}, Length: {length}, Frame Rate: {frame_rate}")
     os.chdir(f"{base_dir}/tmp/{folder_id}")
     existing_screens = glob.glob(f"{sanitized_filename}-*.png")
     total_existing = len(existing_screens) + len(existing_images)
@@ -155,6 +156,7 @@ async def disc_screenshots(meta, filename, bdinfo, folder_id, base_dir, use_vs, 
         num_tasks = len(valid_images)
         max_cores = task_limit if task_limit > 0 else os.cpu_count() // 2
         num_workers = min(num_tasks, max_cores)  # Limit to number of tasks or available cores
+        console.print("[yellow]Opimizing images")
         if meta['debug']:
             console.print(f"Using {num_workers} worker(s) for {len(valid_images)} image(s)")
 
@@ -366,9 +368,6 @@ async def dvd_screenshots(meta, disc_num, num_screens=None, retry_cap=None):
             existing_images += 1
             existing_image_paths.append(image)
 
-    if meta['debug']:
-        console.print(f"Found {existing_images} existing screenshots")
-
     if existing_images == num_screens and not meta.get('retake', False):
         console.print("[yellow]The correct number of screenshots already exists. Skipping capture process.")
         capture_results = existing_image_paths
@@ -414,8 +413,6 @@ async def dvd_screenshots(meta, disc_num, num_screens=None, retry_cap=None):
                 os.remove(smallest)
 
         optimized_results = []
-        if meta['debug']:
-            start_opto_time = time.time()
 
         # Filter out non-existent files first
         valid_images = [image for image in capture_results if os.path.exists(image)]
@@ -426,13 +423,13 @@ async def dvd_screenshots(meta, disc_num, num_screens=None, retry_cap=None):
         num_workers = min(num_tasks, max_cores)  # Limit to number of tasks or available cores
 
         if num_workers == 0:
-            print("[red]No valid images found for optimization.[/red]")
+            console.print("[red]No valid images found for optimization.[/red]")
             return
         else:
-            print("Now optimizing images")
+            console.print("[yellow]Now optimizing images")
 
         if meta['debug']:
-            print(f"Using {num_workers} worker(s) for {num_tasks} image(s)")
+            console.print(f"Using {num_workers} worker(s) for {num_tasks} image(s)")
 
         # Set up multiprocessing pool with the determined number of workers
         with Pool(processes=num_workers) as pool:
@@ -440,11 +437,7 @@ async def dvd_screenshots(meta, disc_num, num_screens=None, retry_cap=None):
 
         optimized_results = [res for res in optimized_results if not isinstance(res, str) or not res.startswith("Error")]
 
-        print(f"[green]Successfully optimized {len(optimized_results)} images.")
-
-        if meta['debug']:
-            finish_opto_time = time.time()
-            print(f"Screenshots processed in {finish_opto_time - start_opto_time:.4f} seconds")
+        console.print(f"[green]Successfully optimized {len(optimized_results)} images.")
 
         valid_results = []
         remaining_retakes = []
@@ -623,9 +616,6 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
             existing_images += 1
             existing_image_paths.append(image_path)
 
-    if meta['debug']:
-        console.print(f"Found {existing_images} existing screenshots")
-
     tone_map = meta.get('tone_map', False)
     if tone_map and "HDR" in meta['hdr']:
         hdr_tonemap = True
@@ -670,8 +660,6 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
         console.print(f"[green]Successfully captured {len(capture_results)} screenshots.")
 
         optimized_results = []
-        if meta['debug']:
-            start_opto_time = time.time()
 
         # Filter out non-existent files first
         valid_images = [image for image in capture_results if os.path.exists(image)]
@@ -682,13 +670,13 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
         num_workers = min(num_tasks, max_cores)  # Limit to number of tasks or available cores
 
         if num_workers == 0:
-            print("[red]No valid images found for optimization.[/red]")
+            console.print("[red]No valid images found for optimization.[/red]")
             return
         else:
-            print("Now optimizing images")
+            console.print("[yellow]Now optimizing images")
 
         if meta['debug']:
-            print(f"Using {num_workers} worker(s) for {num_tasks} image(s)")
+            console.print(f"Using {num_workers} worker(s) for {num_tasks} image(s)")
 
         # Set up multiprocessing pool with the determined number of workers
         with Pool(processes=num_workers) as pool:
@@ -696,11 +684,7 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
 
         optimized_results = [res for res in optimized_results if not isinstance(res, str) or not res.startswith("Error")]
 
-        print(f"[green]Successfully optimized {len(optimized_results)} images.")
-
-        if meta['debug']:
-            finish_opto_time = time.time()
-            print(f"Screenshots processed in {finish_opto_time - start_opto_time:.4f} seconds")
+        console.print(f"[green]Successfully optimized {len(optimized_results)} images.")
 
         valid_results = []
         remaining_retakes = []

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -192,28 +192,36 @@ async def disc_screenshots(meta, filename, bdinfo, folder_id, base_dir, use_vs, 
                 for attempt in range(1, retry_attempts + 1):
                     console.print(f"[yellow]Retaking screenshot for: {image_path} (Attempt {attempt}/{retry_attempts})[/yellow]")
                     try:
-                        os.remove(image_path)
+                        index = int(image_path.rsplit('-', 1)[-1].split('.')[0])
+                        console.print(f"[blue]DEBUG: Extracted index = {index} for {image_path}[/blue]")
+
+                        if os.path.exists(image_path):
+                            os.remove(image_path)
+
                         random_time = random.uniform(0, length)
-                        await capture_disc_task((i, file, random_time, image_path, keyframe, loglevel, hdr_tonemap))
-                        await optimize_image_task(image_path)
-                        new_size = os.path.getsize(image_path)
+                        screenshot_response = await capture_disc_task(
+                            (index, file, random_time, image_path, keyframe, loglevel, hdr_tonemap)
+                        )
+
+                        optimize_image_task(screenshot_response)
+                        new_size = os.path.getsize(screenshot_response)
                         valid_image = False
 
                         if "imgbb" in img_host and new_size > 75000 and new_size <= 31000000:
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
                         elif new_size > 75000 and new_size <= 10000000 and any(host in ["imgbox", "pixhost"] for host in img_host):
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
                         elif new_size > 75000 and any(host in ["ptpimg", "lensdump", "ptscreens", "oeimg", "zipline"] for host in img_host):
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
 
                         if valid_image:
-                            valid_results.append(image_path)
+                            valid_results.append(screenshot_response)
                             break
                         else:
-                            console.print(f"[red]Retaken image {image_path} does not meet the size requirements for {img_host}. Retrying...[/red]")
+                            console.print(f"[red]Retaken image {screenshot_response} does not meet the size requirements for {img_host}. Retrying...[/red]")
                     except Exception as e:
                         console.print(f"[red]Error retaking screenshot for {image_path}: {e}[/red]")
                 else:
@@ -468,17 +476,17 @@ async def dvd_screenshots(meta, disc_num, num_screens=None, retry_cap=None):
                             break
 
                     try:
-                        # ✅ Ensure `capture_dvd_screenshot()` always returns a tuple
+                        # Ensure `capture_dvd_screenshot()` always returns a tuple
                         screenshot_response = await capture_dvd_screenshot(
                             (index, input_file, image, adjusted_time, meta, width, height, w_sar, h_sar)
                         )
 
-                        # ✅ Ensure it is a tuple before unpacking
+                        # Ensure it is a tuple before unpacking
                         if not isinstance(screenshot_response, tuple) or len(screenshot_response) != 2:
                             console.print(f"[red]Failed to capture screenshot for {image}. Retrying...[/red]")
                             continue
 
-                        index, screenshot_result = screenshot_response  # ✅ Safe unpacking
+                        index, screenshot_result = screenshot_response  # Safe unpacking
 
                         if screenshot_result is None:
                             console.print(f"[red]Failed to capture screenshot for {image}. Retrying...[/red]")
@@ -724,28 +732,33 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
                 for attempt in range(1, retry_attempts + 1):
                     console.print(f"[yellow]Retaking screenshot for: {image_path} (Attempt {attempt}/{retry_attempts})[/yellow]")
                     try:
-                        os.remove(image_path)
+                        index = int(image_path.rsplit('-', 1)[-1].split('.')[0])
+                        if os.path.exists(image_path):
+                            os.remove(image_path)
                         random_time = random.uniform(0, length)
-                        await capture_screenshot((i, path, random_time, image_path, width, height, w_sar, h_sar, loglevel, hdr_tonemap))
-                        await optimize_image_task(image_path)
-                        new_size = os.path.getsize(image_path)
+                        screenshot_response = await capture_disc_task(
+                            (index, path, random_time, image_path, width, height, w_sar, h_sar, loglevel, hdr_tonemap)
+                        )
+
+                        optimize_image_task(screenshot_response)
+                        new_size = os.path.getsize(screenshot_response)
                         valid_image = False
 
                         if "imgbb" in img_host and new_size > 75000 and new_size <= 31000000:
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
                         elif new_size > 75000 and new_size <= 10000000 and any(host in ["imgbox", "pixhost"] for host in img_host):
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
                         elif new_size > 75000 and any(host in ["ptpimg", "lensdump", "ptscreens", "oeimg"] for host in img_host):
-                            console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
+                            console.print(f"[green]Successfully retaken screenshot for: {screenshot_response} ({new_size} bytes)[/green]")
                             valid_image = True
 
                         if valid_image:
-                            valid_results.append(image_path)
+                            valid_results.append(screenshot_response)
                             break
                         else:
-                            console.print(f"[red]Retaken image {image_path} does not meet the size requirements for {img_host}. Retrying...[/red]")
+                            console.print(f"[red]Retaken image {screenshot_response} does not meet the size requirements for {img_host}. Retrying...[/red]")
                     except Exception as e:
                         console.print(f"[red]Error retaking screenshot for {image_path}: {e}[/red]")
                 else:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -131,7 +131,7 @@ class COMMON():
                                         print(f"Error during BDMV screenshot capture: {e}")
                                     new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
                                 if new_screens and not meta.get('skip_imghost_upload', False):
-                                    uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                    uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                     for img in uploaded_images:
                                         meta[new_images_key].append({
                                             'img_url': img['img_url'],
@@ -240,7 +240,7 @@ class COMMON():
                                         new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png")
 
                                 if new_screens and not meta.get('skip_imghost_upload', False):
-                                    uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                    uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
 
                                     # Append each uploaded image's data to `meta[new_images_key]`
                                     for img in uploaded_images:
@@ -316,7 +316,7 @@ class COMMON():
 
                             # Upload generated screenshots
                             if new_screens and not meta.get('skip_imghost_upload', False):
-                                uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                 for img in uploaded_images:
                                     meta[new_images_key].append({
                                         'img_url': img['img_url'],

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -228,13 +228,13 @@ class COMMON():
                                     if each['type'] == "BDMV":
                                         use_vs = meta.get('vapoursynth', False)
                                         try:
-                                            disc_screenshots(meta, f"FILE_{i}", each['bdinfo'], meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
+                                            await disc_screenshots(meta, f"FILE_{i}", each['bdinfo'], meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
                                         except Exception as e:
                                             print(f"Error during BDMV screenshot capture: {e}")
                                         new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
                                     if each['type'] == "DVD":
                                         try:
-                                            dvd_screenshots(meta, i, multi_screens, True)
+                                            await dvd_screenshots(meta, i, multi_screens, True)
                                         except Exception as e:
                                             print(f"Error during DVD screenshot capture: {e}")
                                         new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png")
@@ -308,7 +308,7 @@ class COMMON():
                                 if meta['debug']:
                                     console.print(f"[yellow]No existing screenshots for {new_images_key}; generating new ones.")
                             try:
-                                screenshots(file, f"FILE_{i}", meta['uuid'], meta['base_dir'], meta, multi_screens, True, None)
+                                await screenshots(file, f"FILE_{i}", meta['uuid'], meta['base_dir'], meta, multi_screens, True, None)
                             except Exception as e:
                                 print(f"Error during generic screenshot capture: {e}")
 

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -126,7 +126,7 @@ class COMMON():
                                 if not new_screens:
                                     use_vs = meta.get('vapoursynth', False)
                                     try:
-                                        disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
+                                        await disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
                                     except Exception as e:
                                         print(f"Error during BDMV screenshot capture: {e}")
                                     new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -720,7 +720,7 @@ class PTP():
                                     print(f"Error during BDMV screenshot capture: {e}")
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
                             if new_screens and not meta.get('skip_imghost_upload', False):
-                                uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                 for img in uploaded_images:
                                     meta[new_images_key].append({
                                         'img_url': img['img_url'],
@@ -778,7 +778,7 @@ class PTP():
                                         print(f"Error during BDMV screenshot capture: {e}")
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
                                 if new_screens and not meta.get('skip_imghost_upload', False):
-                                    uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                    uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                     for img in uploaded_images:
                                         meta[new_images_key].append({
                                             'img_url': img['img_url'],
@@ -832,7 +832,7 @@ class PTP():
                                         print(f"Error during DVD screenshot capture: {e}")
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png")
                                 if new_screens and not meta.get('skip_imghost_upload', False):
-                                    uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                    uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                     for img in uploaded_images:
                                         meta[new_images_key].append({
                                             'img_url': img['img_url'],
@@ -899,7 +899,7 @@ class PTP():
                                     print(f"Error during generic screenshot capture: {e}")
                             new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
                             if new_screens and not meta.get('skip_imghost_upload', False):
-                                uploaded_images, _ = upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
+                                uploaded_images, _ = await upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]})
                                 for img in uploaded_images:
                                     meta[new_images_key].append({
                                         'img_url': img['img_url'],

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -715,7 +715,7 @@ class PTP():
                             if not new_screens:
                                 use_vs = meta.get('vapoursynth', False)
                                 try:
-                                    disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
+                                    await disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
                                 except Exception as e:
                                     print(f"Error during BDMV screenshot capture: {e}")
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png")
@@ -773,7 +773,7 @@ class PTP():
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
                                 if not new_screens:
                                     try:
-                                        disc_screenshots(meta, f"FILE_{i}", each['bdinfo'], meta['uuid'], meta['base_dir'], meta.get('vapoursynth', False), [], meta.get('ffdebug', False), multi_screens, True)
+                                        await disc_screenshots(meta, f"FILE_{i}", each['bdinfo'], meta['uuid'], meta['base_dir'], meta.get('vapoursynth', False), [], meta.get('ffdebug', False), multi_screens, True)
                                     except Exception as e:
                                         print(f"Error during BDMV screenshot capture: {e}")
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
@@ -825,7 +825,7 @@ class PTP():
                                 new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png")
                                 if not new_screens:
                                     try:
-                                        dvd_screenshots(
+                                        await dvd_screenshots(
                                             meta, i, multi_screens, True
                                         )
                                     except Exception as e:
@@ -893,7 +893,7 @@ class PTP():
                             new_screens = glob.glob1(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png")
                             if not new_screens:
                                 try:
-                                    screenshots(
+                                    await screenshots(
                                         file, f"FILE_{i}", meta['uuid'], meta['base_dir'], meta, multi_screens, True, None)
                                 except Exception as e:
                                     print(f"Error during generic screenshot capture: {e}")

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -7,9 +7,7 @@ import requests
 import glob
 import base64
 import time
-from rich.progress import Progress
 import re
-import concurrent.futures
 import gc
 import json
 
@@ -302,7 +300,7 @@ def upload_image_task(args):
         }
 
 
-def upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_list, return_dict, retry_mode=False, max_retries=3):
+async def upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_list, return_dict, retry_mode=False, max_retries=3):
     if meta['debug']:
         upload_start_time = time.time()
 
@@ -359,39 +357,28 @@ def upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_lis
     host_limits = {"oeimg": 6, "ptscreens": 1, "lensdump": 1}
     pool_size = host_limits.get(img_host, default_pool_size)
     max_workers = min(len(upload_tasks), pool_size)
+
     results = []
-    executor = concurrent.futures.ProcessPoolExecutor(max_workers=max_workers)
+    semaphore = asyncio.Semaphore(max_workers)
 
-    try:
-        future_to_task = {
-            executor.submit(upload_image_task, task[1:]): task[0]
-            for task in upload_tasks
-        }
+    async def async_upload(task):
+        """Wrapper function to run upload_image_task with concurrency control."""
+        index, *task_args = task
+        async with semaphore:
+            try:
+                result = await asyncio.to_thread(upload_image_task, task_args)
 
-        with Progress(disable=len(upload_tasks) == 0) as progress:
-            task = progress.add_task("Uploading Screenshots", total=len(upload_tasks))
+                if result.get('status') == 'success':
+                    return (index, result)
+                else:
+                    console.print(f"[red]{result}")
+                    return None
+            except Exception as e:
+                console.print(f"[red]Error during upload: {str(e)}")
+                return None
 
-            for future in concurrent.futures.as_completed(future_to_task):
-                index = future_to_task[future]
-                try:
-                    result = future.result()
-                    if result.get('status') == 'success':
-                        results.append((index, result))
-                    else:
-                        console.print(f"[red]{result}")
-                except Exception as e:
-                    console.print(f"[red]Error during upload: {str(e)}")
-
-                progress.update(task, advance=1)
-
-        # Wait for all tasks to complete
-        concurrent.futures.wait(future_to_task.keys(), timeout=None)
-
-    finally:
-        executor.shutdown(wait=True)
-        del executor
-        gc.collect()
-
+    upload_results = await asyncio.gather(*[async_upload(task) for task in upload_tasks])
+    results = [res for res in upload_results if res is not None]
     results.sort(key=lambda x: x[0])
 
     successfully_uploaded = [(index, result) for index, result in results if result['status'] == 'success']
@@ -402,10 +389,9 @@ def upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_lis
             meta['imghost'] = config['DEFAULT'][f'img_host_{img_host_num}']
             console.print(f"[cyan]Switching to the next image host: {config['DEFAULT'][f'img_host_{img_host_num}']}[/cyan]")
 
-            del executor
             gc.collect()
 
-            return upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_list, return_dict, retry_mode=True)
+            return await upload_screens(meta, screens, img_host_num, i, total_screens, custom_img_list, return_dict, retry_mode=True)
 
         else:
             console.print("[red]No more image hosts available. Aborting upload process.")

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -353,7 +353,7 @@ async def upload_screens(meta, screens, img_host_num, i, total_screens, custom_i
         for index, image in enumerate(image_glob[:images_needed])
     ]
 
-    default_pool_size = int(meta.get('task_limit', os.cpu_count()))
+    default_pool_size = len(upload_tasks)
     host_limits = {"oeimg": 6, "ptscreens": 1, "lensdump": 1}
     pool_size = host_limits.get(img_host, default_pool_size)
     max_workers = min(len(upload_tasks), pool_size)

--- a/upload.py
+++ b/upload.py
@@ -164,7 +164,7 @@ async def process_meta(meta, base_dir):
             if 'image_list' not in meta:
                 meta['image_list'] = []
             return_dict = {}
-            new_images, dummy_var = upload_screens(meta, meta['screens'], 1, 0, meta['screens'], [], return_dict=return_dict)
+            new_images, dummy_var = await upload_screens(meta, meta['screens'], 1, 0, meta['screens'], [], return_dict=return_dict)
 
         elif meta.get('skip_imghost_upload', False) is True and meta.get('image_list', False) is False:
             meta['image_list'] = []

--- a/upload.py
+++ b/upload.py
@@ -135,7 +135,7 @@ async def process_meta(meta, base_dir):
         if meta['is_disc'] == "BDMV":
             use_vs = meta.get('vapoursynth', False)
             try:
-                disc_screenshots(
+                await disc_screenshots(
                     meta, filename, bdinfo, meta['uuid'], base_dir, use_vs,
                     meta.get('image_list', []), meta.get('ffdebug', False), None
                 )

--- a/upload.py
+++ b/upload.py
@@ -140,11 +140,11 @@ async def process_meta(meta, base_dir):
                     meta.get('image_list', []), meta.get('ffdebug', False), None
                 )
             except Exception as e:
-                print(f"Error during BDMV screenshot capture: {e}")
+                console.print(f"[red]Error during BDMV screenshot capture: {e}")
 
         elif meta['is_disc'] == "DVD":
             try:
-                dvd_screenshots(
+                await dvd_screenshots(
                     meta, 0, None, None
                 )
             except Exception as e:
@@ -152,7 +152,7 @@ async def process_meta(meta, base_dir):
 
         else:
             try:
-                screenshots(
+                await screenshots(
                     videopath, filename, meta['uuid'], base_dir, meta,
                     manual_frames=manual_frames  # Pass additional kwargs directly
                 )


### PR DESCRIPTION
I went down the task spawning route originally as I was having trouble with async calls and imgbox.

takescreens does not have that problem. The issue with consoles becoming non-responsive _may_ be due to the ffmpeg sub-processes that were being spawned, maybe not.

will figure out how to handle imgbox

- [x] define num_cpu in config
- [x] image taking all 3 types
- [x] image uploading
- [x] rehosting all 3 types
- [x] multi disc/files taking and uploading
- [x] console cleanup