### PR TITLE
Update MTV.py: no AKA removing

### DIFF
--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -247,7 +247,6 @@ class MTV():
                     audio_str = audio_str.replace(token, "")
             if meta.get('type') in ('WEBDL', 'WEBRIP', 'ENCODE') and "DD" in audio_str:
                 mtv_name = mtv_name.replace(audio_str, audio_str.replace(' ', '', 1))
-            mtv_name = mtv_name.replace(meta.get('aka', ''), '')
             if meta['category'] == "TV" and meta.get('tv_pack', 0) == 0 and meta.get('episode_title_storage', '').strip() != '' and meta['episode'].strip() != '':
                 mtv_name = mtv_name.replace(meta['episode'], f"{meta['episode']} {meta['episode_title_storage']}")
             if 'DD+' in meta.get('audio', '') and 'DDP' in meta['uuid']:


### PR DESCRIPTION
I suggest to keep AKA in MTV uploads titles:

- The rules are not against it. And indirectly even encouraging it, cause AKA makes torrents easier to find there (see 5.3).
- There ara plenty of verified by staff uploads with AKA in titles.