### PR TITLE
Resolves the `ValueError: invalid literal for int() with base 0` issue  and ensure consistent metadata handling for Movies and TV shows.

### DIFF
--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -161,7 +161,7 @@ async def tmdb_other_meta(meta):
             console.print('[yellow]TMDB does not have a release date, using year from filename instead (if it exists)')
             meta['year'] = meta['search_year']
         external = movie.external_ids()
-        
+
         # IMDb ID Handling for Movies
         if meta.get('imdb_id', 0) == 0:
             imdb_id = external.get('imdb_id', None)
@@ -227,7 +227,7 @@ async def tmdb_other_meta(meta):
             console.print('[yellow]TMDB does not have a release date, using year from filename instead (if it exists)')
             meta['year'] = meta['search_year']
         external = tv.external_ids()
-        
+
         # IMDb ID Handling for TV Shows
         if meta.get('imdb_id', 0) == 0:
             imdb_id = external.get('imdb_id', None)
@@ -241,7 +241,7 @@ async def tmdb_other_meta(meta):
                     meta['imdb_id'] = int(imdb_id_clean)
                 else:
                     console.print(f"[bold red]Invalid IMDb ID returned: {imdb_id}[/bold red]")
-                    meta['imdb_id'] = 0  #  Default to 0 if invalid
+                    meta['imdb_id'] = 0  #Default to 0 if invalid
         else:
             meta['imdb_id'] = int(meta.get('imdb_id', 0))
 

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -161,6 +161,8 @@ async def tmdb_other_meta(meta):
             console.print('[yellow]TMDB does not have a release date, using year from filename instead (if it exists)')
             meta['year'] = meta['search_year']
         external = movie.external_ids()
+        
+        # IMDb ID Handling for Movies
         if meta.get('imdb_id', 0) == 0:
             imdb_id = external.get('imdb_id', None)
 
@@ -170,11 +172,10 @@ async def tmdb_other_meta(meta):
             else:
                 imdb_id_clean = imdb_id.lstrip('t')  # Remove 'tt' prefix safely
                 if imdb_id_clean.isdigit():  # Ensure it's a valid numeric string
-                    meta['imdb_id'] = int(f'{imdb_id_clean}', 0)
+                    meta['imdb_id'] = int(imdb_id_clean)
                 else:
                     console.print(f"[bold red]Invalid IMDb ID returned: {imdb_id}[/bold red]")
-                    meta['imdb_id'] = 0  # Default to 0 if invalid
-
+                    meta['imdb_id'] = 0
         else:
             meta['imdb_id'] = int(meta.get('imdb_id', 0))
 
@@ -226,6 +227,8 @@ async def tmdb_other_meta(meta):
             console.print('[yellow]TMDB does not have a release date, using year from filename instead (if it exists)')
             meta['year'] = meta['search_year']
         external = tv.external_ids()
+        
+        # IMDb ID Handling for TV Shows
         if meta.get('imdb_id', 0) == 0:
             imdb_id = external.get('imdb_id', None)
 
@@ -235,11 +238,10 @@ async def tmdb_other_meta(meta):
             else:
                 imdb_id_clean = imdb_id.lstrip('t')  # Remove 'tt' prefix safely
                 if imdb_id_clean.isdigit():  # Ensure it's a valid numeric string
-                    meta['imdb_id'] = int(f'{imdb_id_clean}', 0)
+                    meta['imdb_id'] = int(imdb_id_clean)
                 else:
                     console.print(f"[bold red]Invalid IMDb ID returned: {imdb_id}[/bold red]")
-                    meta['imdb_id'] = 0  # Default to 0 if invalid
-
+                    meta['imdb_id'] = 0  #  Default to 0 if invalid
         else:
             meta['imdb_id'] = int(meta.get('imdb_id', 0))
 


### PR DESCRIPTION
Replaced with `int(imdb_id_clean)` to ensure proper base-10 conversion

Applied IMDb ID validation to both Movies and TV sections

Ensured only valid numeric IMDb IDs are converted to integers

Added error handling to prevent crashes when an invalid IMDb ID is encountered