### PR TITLE
Allow some hardcoded user overrides

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -128,6 +128,9 @@ config = {
         # set true to use mkbrr for torrent creation
         "mkbrr": False,
 
+        # set true to use argument overrides from data/templates/user-args.json
+        "user_overrides": False,
+
     },
 
     # these are used for DB links on AR

--- a/data/templates/user-args-template.json
+++ b/data/templates/user-args-template.json
@@ -17,6 +17,7 @@
           "--no-year",
           "--personalrelease",
           "--descfile", "path_do_desc_file"
+          "--manual_frames=100,200,300,400,500,600,700"
         ]
       }
     ]

--- a/data/templates/user-args-template.json
+++ b/data/templates/user-args-template.json
@@ -1,0 +1,23 @@
+## This is just a template file. Replace with your own values and rename to user-args.json
+## Currently only tmdb_id is supported, and this file is parsed after metadata processing
+## Changing category or season or episode for instance, is ill advised as these are used in metadata processing
+
+{
+    "entries": [
+      {
+        "tmdb_id": "tv/12345",
+        "args": [
+          "--no-aka",
+          "--screens", "4"
+        ]
+      },
+      {
+        "tmdb_id": "movie/54321",
+        "args": [
+          "--no-year",
+          "--personalrelease",
+          "--descfile", "path_do_desc_file"
+        ]
+      }
+    ]
+  }

--- a/data/templates/user-args-template.json
+++ b/data/templates/user-args-template.json
@@ -1,6 +1,7 @@
 ## This is just a template file. Replace with your own values and rename to user-args.json
 ## Currently only tmdb_id is supported, and this file is parsed after metadata processing
 ## Changing category or season or episode for instance, is ill advised as these are used in metadata processing
+## Not throughly tested, for args try using a list instead of a string or vice versa if you encounter issues
 
 {
     "entries": [

--- a/src/prep.py
+++ b/src/prep.py
@@ -589,7 +589,8 @@ class Prep():
                     else:
                         meta['episode_title'] = episode_details['name']
         meta = await self.tag_override(meta)
-        if meta.get('user_overrides', False):
+        user_overrides = config['DEFAULT'].get('user_overrides', False)
+        if user_overrides:
             meta = await self.get_source_override(meta)
         if meta.get('tag') == "-SubsPlease":  # SubsPlease-specific
             tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])  # Get all tracks

--- a/src/prep.py
+++ b/src/prep.py
@@ -589,6 +589,8 @@ class Prep():
                     else:
                         meta['episode_title'] = episode_details['name']
         meta = await self.tag_override(meta)
+        if meta.get('user_overrides', False):
+            meta = await self.get_source_override(meta)
         if meta.get('tag') == "-SubsPlease":  # SubsPlease-specific
             tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])  # Get all tracks
             bitrate = tracks[1].get('BitRate', '') if len(tracks) > 1 and not isinstance(tracks[1].get('BitRate', ''), dict) else ''  # Check that bitrate is not a dict
@@ -1802,3 +1804,124 @@ class Prep():
                         languages.append(extracted.lower())
 
         return languages
+
+    async def get_source_override(self, meta):
+        try:
+            with open(f"{meta['base_dir']}/data/templates/user-args.json", 'r', encoding="utf-8") as f:
+                user_args = json.load(f)
+
+            current_tmdb_id = meta.get('tmdb_id', 0)
+
+            # Convert to int for comparison if it's a string
+            if isinstance(current_tmdb_id, str) and current_tmdb_id.isdigit():
+                current_tmdb_id = int(current_tmdb_id)
+
+            for entry in user_args.get('entries', []):
+                entry_tmdb_id = entry.get('tmdb_id')
+                args = entry.get('args', [])
+
+                if not entry_tmdb_id:
+                    continue
+
+                # Parse the entry's TMDB ID from the user-args.json file
+                entry_category, entry_normalized_id = await self.parse_tmdb_id(entry_tmdb_id)
+                if entry_category != meta['category']:
+                    if meta['debug']:
+                        console.print(f"Skipping user entry because override category {entry_category} does not match UA category {meta['category']}:")
+                    continue
+
+                # Check if IDs match
+                if entry_normalized_id == current_tmdb_id:
+                    console.print(f"[green]Found matching override for TMDb ID: {entry_normalized_id}")
+                    console.print(f"[yellow]Applying arguments: {' '.join(args)}")
+
+                    meta = await self.apply_args_to_meta(meta, args)
+                    break
+
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            console.print(f"[red]Error loading user-args.json: {e}")
+
+        return meta
+
+    async def parse_tmdb_id(self, tmdb_id, category=None):
+        if tmdb_id is None:
+            return category, 0
+
+        tmdb_id = str(tmdb_id).strip().lower()
+        if not tmdb_id or tmdb_id == 0:
+            return category, 0
+
+        if '/' in tmdb_id:
+            parts = tmdb_id.split('/')
+            if len(parts) >= 2:
+                prefix = parts[0]
+                id_part = parts[1]
+
+                if prefix == 'tv':
+                    category = 'TV'
+                elif prefix == 'movie':
+                    category = 'MOVIE'
+
+                try:
+                    normalized_id = int(id_part)
+                    return category, normalized_id
+                except ValueError:
+                    return category, 0
+
+        try:
+            normalized_id = int(tmdb_id)
+            return category, normalized_id
+        except ValueError:
+            return category, 0
+
+    async def apply_args_to_meta(self, meta, args):
+        from src.args import Args
+
+        try:
+            arg_keys_to_track = set()
+
+            i = 0
+            while i < len(args):
+                arg = args[i]
+                if arg.startswith('--'):
+                    # Remove '--' prefix and convert dashes to underscores
+                    key = arg[2:].replace('-', '_')
+                    arg_keys_to_track.add(key)
+                    if i + 1 < len(args) and not args[i + 1].startswith('--'):
+                        i += 1
+                i += 1
+
+            if meta['debug']:
+                console.print(f"[Debug] Tracking changes for keys: {', '.join(arg_keys_to_track)}")
+
+            # Create a new Args instance and process the arguments
+            arg_processor = Args(self.config)
+            full_args = ['upload.py'] + args
+            updated_meta, _, _ = arg_processor.parse(full_args, meta.copy())
+            updated_meta['path'] = meta.get('path')
+            modified_keys = []
+
+            for key in arg_keys_to_track:
+                if key in updated_meta and key in meta:
+                    # Skip path to preserve original
+                    if key == 'path':
+                        continue
+
+                    new_value = updated_meta[key]
+                    old_value = meta[key]
+                    # Only update if the value actually changed
+                    if new_value != old_value:
+                        meta[key] = new_value
+                        modified_keys.append(key)
+                        if meta['debug']:
+                            console.print(f"[Debug] Override: {key} changed from {old_value} to {new_value}")
+            if meta['debug'] and modified_keys:
+                console.print(f"[Debug] Applied overrides for: {', '.join(modified_keys)}")
+
+        except Exception as e:
+            console.print(f"[red]Error processing arguments: {e}")
+            if meta['debug']:
+                import traceback
+                console.print(traceback.format_exc())
+
+        return meta

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -661,10 +661,19 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
     os.chdir(f"{base_dir}/tmp/{folder_id}")
 
     if manual_frames:
-        if meta['debug']:
+        if meta.get('debug', False):
             console.print(f"[yellow]Using manual frames: {manual_frames}")
-        manual_frames = [int(frame) for frame in manual_frames.split(',')]
-        ss_times = [frame / frame_rate for frame in manual_frames]
+
+        try:
+            if isinstance(manual_frames, str):
+                manual_frames = [int(frame.strip()) for frame in manual_frames.split(',')]
+            elif isinstance(manual_frames, list):
+                manual_frames = [int(frame) if isinstance(frame, str) else frame for frame in manual_frames]
+
+            ss_times = [frame / frame_rate for frame in manual_frames]
+        except (TypeError, ValueError) as e:
+            console.print(f"[red]Error processing manual frames: {e}. Using auto-generated frames.[/red]")
+            ss_times = await valid_ss_time([], num_screens + 1, length, frame_rate, exclusion_zone=500)
     else:
         ss_times = await valid_ss_time([], num_screens + 1, length, frame_rate, exclusion_zone=500)
 


### PR DESCRIPTION
Currently only TMDB supported.

You should probably only override args that are not strictly tied to metadata, like `--no-aka`  or other `--no` type args.
Other examples would be `--manual_frames`, any of the description handling.

The user-args.json should follow this formatting style
```python
{
    "entries": [
      {
        "tmdb_id": "tv/12345",
        "args": [
          "--no-aka",
          "--screens", "4"
        ]
      },
      {
        "tmdb_id": "tv/54321",
        "args": [
          "--no-year",
          "--personalrelease",
          "--descfile", "path_do_desc_file"
        ]
      }
    ]
  }
```