### PR TITLE
Catch HUNO BluRay naming requirement

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -246,7 +246,7 @@ class HUNO():
         edition = meta.get('edition', "")
         hybrid = "Hybrid" if "HYBRID" in basename.upper() else ""
         scale = "DS4K" if "DS4K" in basename.upper() else "RM4K" if "RM4K" in basename.upper() else ""
-        
+
         # YAY NAMING FUN
         if meta['category'] == "MOVIE":  # MOVIE SPECIFIC
             if type == "DISC":  # Disk

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -247,6 +247,10 @@ class HUNO():
         hybrid = "Hybrid" if "HYBRID" in basename.upper() else ""
         scale = "DS4K" if "DS4K" in basename.upper() else "RM4K" if "RM4K" in basename.upper() else ""
 
+        async def get_source(self, source):
+        sources = {
+            "Blu-ray": "BluRay",
+        
         # YAY NAMING FUN
         if meta['category'] == "MOVIE":  # MOVIE SPECIFIC
             if type == "DISC":  # Disk

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -231,7 +231,7 @@ class HUNO():
         tag = meta.get('tag', "").replace("-", "- ")
         if tag == "":
             tag = "- NOGRP"
-        source = meta.get('source', "")
+        source = meta.get('source', "").replace("Blu-ray", "BluRay")
         uhd = meta.get('uhd', "")
         hdr = meta.get('hdr', "")
         if not hdr.strip():
@@ -246,10 +246,6 @@ class HUNO():
         edition = meta.get('edition', "")
         hybrid = "Hybrid" if "HYBRID" in basename.upper() else ""
         scale = "DS4K" if "DS4K" in basename.upper() else "RM4K" if "RM4K" in basename.upper() else ""
-
-        async def get_source(self, source):
-        sources = {
-            "Blu-ray": "BluRay",
         
         # YAY NAMING FUN
         if meta['category'] == "MOVIE":  # MOVIE SPECIFIC


### PR DESCRIPTION
The tracker does not accept "Blu-ray" as a source, only "BluRay", even if it is a Full Disk release.