### PR TITLE
feat: pull logo from tmdb

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -39,6 +39,12 @@ config = {
         "img_host_8": "dalexni",
         "img_host_9": "zipline",
 
+        # Whether to add a logo for the show/movie from TMDB to the top of the description
+        "add_logo": False,
+
+        # Logo image size
+        "logo_size": "420",
+
         # Number of screenshots to capture
         "screens": "6",
 

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -45,6 +45,10 @@ config = {
         # Logo image size
         "logo_size": "420",
 
+        # Accepted logo language (ISO 639-1)
+        # If a logo with this language cannot be found, English will be used instead
+        "logo_language": "en",
+
         # Number of screenshots to capture
         "screens": "6",
 

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -273,6 +273,7 @@ async def tmdb_other_meta(
     runtime = 60
     certification = ""
     backdrop = ""
+    logo_path = ""
     poster_path = ""
     tmdb_type = ""
     mal_id = 0
@@ -440,6 +441,20 @@ async def tmdb_other_meta(
             if backdrop:
                 backdrop = f"https://image.tmdb.org/t/p/original{backdrop}"
 
+            if config['DEFAULT'].get('add_logo', False):
+                # Get movie images
+                image_response = await client.get(
+                    f"{TMDB_BASE_URL}/movie/{tmdb_id}/images",
+                    params={"api_key": TMDB_API_KEY}
+                )
+                image_response.raise_for_status()
+                image_data = image_response.json()
+
+                logos = image_data.get('logos', [])
+                first_logo = next((logo for logo in logos if logo.get('iso_639_1') == 'en'), None) or (logos[0] if logos else None)
+                if first_logo:
+                    logo_path = f"https://image.tmdb.org/t/p/original{first_logo['file_path']}"
+                
             overview = movie_data['overview']
             tmdb_type = 'Movie'
             runtime = movie_data.get('runtime', 60)
@@ -561,6 +576,20 @@ async def tmdb_other_meta(
             if backdrop:
                 backdrop = f"https://image.tmdb.org/t/p/original{backdrop}"
 
+            if config['DEFAULT'].get('add_logo', False):
+                # Get tv images
+                image_response = await client.get(
+                    f"{TMDB_BASE_URL}/tv/{tmdb_id}/images",
+                    params={"api_key": TMDB_API_KEY}
+                )
+                image_response.raise_for_status()
+                image_data = image_response.json()
+
+                logos = image_data.get('logos', [])
+                first_logo = next((logo for logo in logos if logo.get('iso_639_1') == 'en'), None) or (logos[0] if logos else None)
+                if first_logo:
+                    logo_path = f"https://image.tmdb.org/t/p/original{first_logo['file_path']}"                
+
             overview = tv_data['overview']
             tmdb_type = tv_data.get('type', 'Scripted')
 
@@ -594,6 +623,7 @@ async def tmdb_other_meta(
         'aka': retrieved_aka,
         'poster': poster,
         'tmdb_poster': poster_path,
+        'logo': logo_path,
         'backdrop': backdrop,
         'overview': overview,
         'tmdb_type': tmdb_type,

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -947,9 +947,10 @@ async def get_logo(client, tmdb_id, category, debug = False):
     image_response.raise_for_status()
     image_data = image_response.json()
 
+    logo_path = None
     for language in logo_languages:
         logos = image_data.get('logos', [])
-        first_logo = next((logo for logo in logos if logo.get('iso_639_1') == language), None) or (logos[0] if logos else None)
+        first_logo = next((logo for logo in logos if logo.get('iso_639_1') == language), None)
         if first_logo:
             logo_path = f"https://image.tmdb.org/t/p/original{first_logo['file_path']}"
             break

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -85,6 +85,14 @@ class COMMON():
                 desc = bbcode.convert_comparison_to_collapse(desc, 1000)
             desc = desc.replace('[img]', '[img=300]')
             descfile.write(desc)
+
+            add_logo_enabled = self.config["DEFAULT"].get("add_logo", False)
+            if add_logo_enabled and 'logo' in meta:
+                logo = meta['logo']
+                logo_size = self.config["DEFAULT"].get("logo_size", 420)
+                if logo != "":
+                    descfile.write(f"[center][img={logo_size}]{logo}[/img][/center]")  
+
             # Handle single disc case
             if len(discs) == 1:
                 each = discs[0]

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -91,7 +91,7 @@ class COMMON():
                 logo = meta['logo']
                 logo_size = self.config["DEFAULT"].get("logo_size", 420)
                 if logo != "":
-                    descfile.write(f"[center][img={logo_size}]{logo}[/img][/center]")  
+                    descfile.write(f"[center][img={logo_size}]{logo}[/img][/center]\n\n")
 
             # Handle single disc case
             if len(discs) == 1:


### PR DESCRIPTION
Credits to Uploadrr which already has this feature and made me want to implement it here.

What this PR does:
- Adds 2 config options to control whether to pull logos from TMDB, and the logo size.
- If enabled, it will pull the first logo for the TV/Movie from TMDB using the `/{tmdbId}/images` endpoint and place it at the top of the BBCode description.

By default the option is disabled and no extra requests are sent to TMDB.

What it looks like:

![image](https://github.com/user-attachments/assets/7809d42c-5aad-4599-a009-86252ffa9775)

Let me know if this is unwanted or what can be made to improve it if necessary. 

Cheers!
