### PR TITLE
add argument --not-anime

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -94,6 +94,7 @@ class Args():
         parser.add_argument('-edition', '--edition', '--repack', nargs='*', required=False, help="Edition/Repack String e.g.(Director's Cut, Uncut, Hybrid, REPACK, REPACK3)", type=str, dest='manual_edition')
         parser.add_argument('-season', '--season', nargs=1, required=False, help="Season (number)", type=str)
         parser.add_argument('-episode', '--episode', nargs=1, required=False, help="Episode (number)", type=str)
+        parser.add_argument('--not-anime', dest='not_anime', action='store_true', required=False, help="This is not an Anime release")
         parser.add_argument('-met', '--manual-episode-title', nargs='*', required=False, help="Set episode title, empty = empty", type=str, dest="manual_episode_title", default=None)
         parser.add_argument('-daily', '--daily', nargs=1, required=False, help="Air date of this episode (YYYY-MM-DD)", type=datetime.date.fromisoformat, dest="manual_date")
         parser.add_argument('--no-season', dest='no_season', action='store_true', required=False, help="Remove Season from title")


### PR DESCRIPTION
When the argument is set, we can safely run `get_season_episode`, which is required to run the newly added episode functions.

These episode snatching functions have been added to async calls when:
`if int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0:` or
`elif int(meta['imdb_id']) != 0 and int(meta['tmdb_id']) != 0:`

Significantly speeding episode data retrieval.

The argument is a good use case with `https://github.com/Audionut/Upload-Assistant/blob/master/data/templates/user-args-template.json`