### PR TITLE
Adjust font size of screenshot overlays to match the resolution.

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -702,7 +702,8 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
     meta['frame_overlay'] = config['DEFAULT'].get('frame_overlay', False)
     if meta['frame_overlay']:
         console.print("[yellow]Getting frame information for overlays...")
-        resolution_pb = meta.get('resolution')
+        # resolution_pb = meta.get('resolution','1080p')
+        resolution_pb = int(''.join(filter(str.isdigit, meta.get('resolution','1080p'))))
         console.print(f"[yellow]RESOLUTION: {resolution_pb}")
         frame_info_tasks = [
             get_frame_info(path, ss_times[i], meta)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1057,9 +1057,9 @@ async def capture_screenshot(args):
             base_text = base_text.filter('drawtext',
                                          text=f"Frame Number: {frame_number}",
                                          fontcolor='white',
-                                         fontsize={font_size},
-                                         x={x_all},
-                                         y={y_number},
+                                         fontsize=font_size,
+                                         x=x_all,
+                                         y=y_number,
                                          box=1,
                                          boxcolor='black@0.5'
                                          )
@@ -1068,9 +1068,9 @@ async def capture_screenshot(args):
             base_text = base_text.filter('drawtext',
                                          text=f"Frame Type: {frame_type}",
                                          fontcolor='white',
-                                         fontsize={font_size},
-                                         x={x_all},
-                                         y={y_type},
+                                         fontsize=font_size,
+                                         x=x_all,
+                                         y=y_type,
                                          box=1,
                                          boxcolor='black@0.5'
                                          )
@@ -1080,9 +1080,9 @@ async def capture_screenshot(args):
                 base_text = base_text.filter('drawtext',
                                              text="Tonemapped HDR",
                                              fontcolor='white',
-                                             fontsize={font_size},
-                                             x={x_all},
-                                             y={y_hdr},
+                                             fontsize=font_size,
+                                             x=x_all,
+                                             y=y_hdr,
                                              box=1,
                                              boxcolor='black@0.5'
                                              )

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -702,6 +702,8 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
     meta['frame_overlay'] = config['DEFAULT'].get('frame_overlay', False)
     if meta['frame_overlay']:
         console.print("[yellow]Getting frame information for overlays...")
+        resolution_pb = meta.get('resolution')
+        console.print("[yellow]RESOLUTION: {resolution_pb}")
         frame_info_tasks = [
             get_frame_info(path, ss_times[i], meta)
             for i in range(num_screens + 1)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -703,7 +703,7 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
     if meta['frame_overlay']:
         console.print("[yellow]Getting frame information for overlays...")
         resolution_pb = meta.get('resolution')
-        console.print("[yellow]RESOLUTION: {resolution_pb}")
+        console.print(f"[yellow]RESOLUTION: {resolution_pb}")
         frame_info_tasks = [
             get_frame_info(path, ss_times[i], meta)
             for i in range(num_screens + 1)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1058,8 +1058,8 @@ async def capture_screenshot(args):
                                          text=f"Frame Number: {frame_number}",
                                          fontcolor='white',
                                          fontsize={font_size},
-                                         x=10,
-                                         y=10,
+                                         x={x_all},
+                                         y={y_number},
                                          box=1,
                                          boxcolor='black@0.5'
                                          )
@@ -1069,8 +1069,8 @@ async def capture_screenshot(args):
                                          text=f"Frame Type: {frame_type}",
                                          fontcolor='white',
                                          fontsize={font_size},
-                                         x=10,
-                                         y=40,
+                                         x={x_all},
+                                         y={y_type},
                                          box=1,
                                          boxcolor='black@0.5'
                                          )
@@ -1081,8 +1081,8 @@ async def capture_screenshot(args):
                                              text="Tonemapped HDR",
                                              fontcolor='white',
                                              fontsize={font_size},
-                                             x=10,
-                                             y=70,
+                                             x={x_all},
+                                             y={y_hdr},
                                              box=1,
                                              boxcolor='black@0.5'
                                              )

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -702,9 +702,6 @@ async def screenshots(path, filename, folder_id, base_dir, meta, num_screens=Non
     meta['frame_overlay'] = config['DEFAULT'].get('frame_overlay', False)
     if meta['frame_overlay']:
         console.print("[yellow]Getting frame information for overlays...")
-        # resolution_pb = meta.get('resolution','1080p')
-        resolution_pb = int(''.join(filter(str.isdigit, meta.get('resolution','1080p'))))
-        console.print(f"[yellow]RESOLUTION: {resolution_pb}")
         frame_info_tasks = [
             get_frame_info(path, ss_times[i], meta)
             for i in range(num_screens + 1)
@@ -1043,6 +1040,11 @@ async def capture_screenshot(args):
                     frame_number = int(pts_time * frame_rate)
 
             frame_type = frame_info.get('frame_type', 'Unknown')
+
+            # Get the resolution and convert it to integer
+            resol = int(''.join(filter(str.isdigit, meta.get('resolution','1080p'))))
+            # Assess the font size from the resolution
+            font_size = round(24*resol/1080)
 
             # Use the filtered output with frame info
             base_text = ff

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1042,7 +1042,7 @@ async def capture_screenshot(args):
             frame_type = frame_info.get('frame_type', 'Unknown')
 
             # Get the resolution and convert it to integer
-            resol = int(''.join(filter(str.isdigit, meta.get('resolution','1080p'))))
+            resol = int(''.join(filter(str.isdigit, meta.get('resolution', '1080p'))))
             # Assess the font size from the resolution
             font_size = round(24*resol/1080)
             x_all = round(10*resol/1080)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1045,6 +1045,10 @@ async def capture_screenshot(args):
             resol = int(''.join(filter(str.isdigit, meta.get('resolution','1080p'))))
             # Assess the font size from the resolution
             font_size = round(24*resol/1080)
+            x_all = round(10*resol/1080)
+            y_number = round(10*resol/1080)
+            y_type = round(40*resol/1080)
+            y_hdr = round(70*resol/1080)
 
             # Use the filtered output with frame info
             base_text = ff
@@ -1053,7 +1057,7 @@ async def capture_screenshot(args):
             base_text = base_text.filter('drawtext',
                                          text=f"Frame Number: {frame_number}",
                                          fontcolor='white',
-                                         fontsize=24,
+                                         fontsize={font_size},
                                          x=10,
                                          y=10,
                                          box=1,
@@ -1064,7 +1068,7 @@ async def capture_screenshot(args):
             base_text = base_text.filter('drawtext',
                                          text=f"Frame Type: {frame_type}",
                                          fontcolor='white',
-                                         fontsize=24,
+                                         fontsize={font_size},
                                          x=10,
                                          y=40,
                                          box=1,
@@ -1076,7 +1080,7 @@ async def capture_screenshot(args):
                 base_text = base_text.filter('drawtext',
                                              text="Tonemapped HDR",
                                              fontcolor='white',
-                                             fontsize=24,
+                                             fontsize={font_size},
                                              x=10,
                                              y=70,
                                              box=1,


### PR DESCRIPTION
Title says all.
Example of 2160p screenshot without the proposed modification:
![Companion-4](https://github.com/user-attachments/assets/37834b4a-0073-4ac6-8b51-144158f8d31f)
Example of 2160p screenshot with the proposed modification:
![4K-hdr-test](https://github.com/user-attachments/assets/03b07b74-cf6d-4b65-b061-6a631d3a70b6)
