### PR TITLE
Correct absolute episode number lookup

### DIFF
--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -246,6 +246,7 @@ async def get_tvdb_series_episodes(base_dir, token, tvdb_id, season, episode, ap
             for ep in all_episodes:
                 season_number = ep.get("seasonNumber")
                 episode_number = ep.get("number")
+                absolute_episode_count = ep.get("absoluteNumber")
 
                 # Ensure season_number is valid and convert to int if needed
                 if season_number is not None:
@@ -270,7 +271,6 @@ async def get_tvdb_series_episodes(base_dir, token, tvdb_id, season, episode, ap
                 is_special = season_number == 0
 
                 if not is_special:
-                    absolute_episode_count += 1
                     # Store mapping of absolute number to season/episode
                     absolute_mapping[absolute_episode_count] = {
                         "season": season_number,

--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -230,7 +230,6 @@ async def get_tvdb_series_episodes(base_dir, token, tvdb_id, season, episode, ap
 
             # Process and organize episode data
             episodes_by_season = {}
-            absolute_episode_count = 0
             absolute_mapping = {}  # Map absolute numbers to season/episode
 
             # Sort by aired date first (if available)


### PR DESCRIPTION
Removed line 273 (any reason to increment `absolute_episode_count` by 1?), grab absolute ep from payload instead.

Tested with One Piece S22 and Solo Lvling S2 from SubsPls