### PR TITLE
Clean existing meta

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -168,6 +168,10 @@ config = {
         # set true to skip automated client torrent searching
         'skip_auto_torrent': False,
 
+        # NOT RECOMMENDED UNLESS YOU KNOW WHAT YOU ARE DOING
+        # set true to not delete existing meta.json file before running
+        "keep_meta": False,
+
     },
 
     # these are used for DB links on AR

--- a/src/args.py
+++ b/src/args.py
@@ -157,6 +157,7 @@ class Args():
         parser.add_argument('-ua', '--unattended', action='store_true', required=False, help=argparse.SUPPRESS)
         parser.add_argument('-uac', '--unattended-confirm', action='store_true', required=False, help=argparse.SUPPRESS)
         parser.add_argument('-vs', '--vapoursynth', action='store_true', required=False, help="Use vapoursynth for screens (requires vs install)")
+        parser.add_argument('-dm', '--delete-meta', action='store_true', required=False, dest='delete_meta', help="Delete only meta.json from tmp directory")
         parser.add_argument('-dtmp', '--delete-tmp', action='store_true', required=False, dest='delete_tmp', help="Delete tmp directory for the working file/folder")
         parser.add_argument('-cleanup', '--cleanup', action='store_true', required=False, help="Clean up tmp directory")
         parser.add_argument('-fl', '--freeleech', nargs=1, required=False, help="Freeleech Percentage", default=0, dest="freeleech")

--- a/src/args.py
+++ b/src/args.py
@@ -157,7 +157,6 @@ class Args():
         parser.add_argument('-ua', '--unattended', action='store_true', required=False, help=argparse.SUPPRESS)
         parser.add_argument('-uac', '--unattended-confirm', action='store_true', required=False, help=argparse.SUPPRESS)
         parser.add_argument('-vs', '--vapoursynth', action='store_true', required=False, help="Use vapoursynth for screens (requires vs install)")
-        parser.add_argument('-dm', '--delete-meta', action='store_true', required=False, dest='delete_meta', help="Delete only meta.json from tmp directory")
         parser.add_argument('-dtmp', '--delete-tmp', action='store_true', required=False, dest='delete_tmp', help="Delete tmp directory for the working file/folder")
         parser.add_argument('-cleanup', '--cleanup', action='store_true', required=False, help="Clean up tmp directory")
         parser.add_argument('-fl', '--freeleech', nargs=1, required=False, help="Freeleech Percentage", default=0, dest="freeleech")

--- a/upload.py
+++ b/upload.py
@@ -541,7 +541,7 @@ async def do_the_thing(base_dir):
                     try:
                         os.remove(meta_file)
                         if meta['debug']:
-                            console.print(f"[bold green]Found and deleted existing metadata file: {meta_file}")
+                            console.print(f"[bold yellow]Found and deleted existing metadata file: {meta_file}")
                     except Exception as e:
                         console.print(f"[bold red]Failed to delete metadata file {meta_file}: {str(e)}")
                 else:

--- a/upload.py
+++ b/upload.py
@@ -537,21 +537,19 @@ async def do_the_thing(base_dir):
 
                 meta_file = os.path.join(base_dir, "tmp", os.path.basename(path), "meta.json")
 
-                if meta.get('delete_meta') and os.path.exists(meta_file):
-                    os.remove(meta_file)
-                    console.print("[bold red]Successfully deleted meta.json")
-
                 if os.path.exists(meta_file):
-                    with open(meta_file, "r") as f:
-                        saved_meta = json.load(f)
-                        console.print("[yellow]Existing metadata file found, it holds cached values")
-                        meta.update(await merge_meta(meta, saved_meta, path))
+                    try:
+                        os.remove(meta_file)
+                        if meta['debug']:
+                            console.print(f"[bold green]Found and deleted existing metadata file: {meta_file}")
+                    except Exception as e:
+                        console.print(f"[bold red]Failed to delete metadata file {meta_file}: {str(e)}")
                 else:
                     if meta['debug']:
                         console.print(f"[yellow]No metadata file found at {meta_file}")
 
             except Exception as e:
-                console.print(f"[red]Failed to load metadata for path '{path}': {e}")
+                console.print(f"[red]Exception: '{path}': {e}")
                 reset_terminal()
 
             if meta['debug']:

--- a/upload.py
+++ b/upload.py
@@ -537,16 +537,29 @@ async def do_the_thing(base_dir):
 
                 meta_file = os.path.join(base_dir, "tmp", os.path.basename(path), "meta.json")
 
-                if os.path.exists(meta_file):
-                    try:
-                        os.remove(meta_file)
+                keep_meta = config['DEFAULT'].get('keep_meta', False)
+
+                if not keep_meta:
+                    if os.path.exists(meta_file):
+                        try:
+                            os.remove(meta_file)
+                            if meta['debug']:
+                                console.print(f"[bold yellow]Found and deleted existing metadata file: {meta_file}")
+                        except Exception as e:
+                            console.print(f"[bold red]Failed to delete metadata file {meta_file}: {str(e)}")
+                    else:
                         if meta['debug']:
-                            console.print(f"[bold yellow]Found and deleted existing metadata file: {meta_file}")
-                    except Exception as e:
-                        console.print(f"[bold red]Failed to delete metadata file {meta_file}: {str(e)}")
-                else:
-                    if meta['debug']:
-                        console.print(f"[yellow]No metadata file found at {meta_file}")
+                            console.print(f"[yellow]No metadata file found at {meta_file}")
+
+                if meta.get('delete_meta') and os.path.exists(meta_file):
+                    os.remove(meta_file)
+                    console.print("[bold red]Successfully deleted meta.json")
+
+                if keep_meta and os.path.exists(meta_file):
+                    with open(meta_file, "r") as f:
+                        saved_meta = json.load(f)
+                        console.print("[yellow]Existing metadata file found, it holds cached values")
+                        meta.update(await merge_meta(meta, saved_meta, path))
 
             except Exception as e:
                 console.print(f"[red]Exception: '{path}': {e}")


### PR DESCRIPTION
Existing meta.json is more problematic then useful.

Now that uploaded image links are safely stored in `image_data.json` (rehosted images for sites have their own file), it's time to put an end to all problems associated with existing data.