### PR TITLE
Correct typo to enable UA to set the 'Internal' tag on HDB.

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -293,7 +293,7 @@ class HDB():
             # If internal, set 1
             if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
                 if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
-                    data['internal'] = 1
+                    data['origin'] = 1
             # If not BDMV fill mediainfo
             if meta.get('is_disc', '') != "BDMV":
                 data['techinfo'] = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt", 'r', encoding='utf-8').read()


### PR DESCRIPTION
A typo prevented UA to set automatically the 'Internal' tag on HDB.
I made an upload of an internal encode on HDB to check that it now works with this candidate pull request. :)