### PR TITLE
Properly force kill child processes on linux/darwin

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1307,7 +1307,10 @@ async def kill_all_child_processes():
     gone, still_alive = psutil.wait_procs(children, timeout=3)  # Wait for termination
     for process in still_alive:
         console.print(f"[red]Force killing stubborn process: {process.pid}[/red]")
-        process.kill()
+        if sys.platform.startswith('win32'):
+            process.kill()
+        else:
+            os.killpg(process.pid, signal.SIGTERM)
 
 
 def optimize_image_task(image):


### PR DESCRIPTION
I am on macOS.
When executing the UA command in terminal, I used to get the following error at the end:
```
Uploads processed in 43.8642 seconds
Exception ignored in: <function ResourceTracker.__del__ at 0x1213a0ea0>
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.10/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 77, in __del__
  File "/opt/homebrew/Cellar/python@3.12/3.12.10/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 86, in _stop
  File "/opt/homebrew/Cellar/python@3.12/3.12.10/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 111, in _stop_locked
ChildProcessError: [Errno 10] No child processes
```
This appeared only after upgrading from python 3.12.9 to 3.12.10
The error was showing up either with the `-debug`option or when actually uploading (with uploading stilll correctly achieved).
Some debugging proved that the exception was thrown just when the script was exiting.
After some googling, it seemed that the reason for this was that the `oxipng` job was force killed in takescreen.py without the parent process being properly informed. So at the end of the script, the system was attempting to kill a child process that did no longer exist. After some further googling, I came up with that `os.killpg(process.pid, signal.SIGTERM)`solution which completely solved the issue for me (on macOS). But, as google also explained to me that `os.killpg` was not working on Windows, I kept the former code with Windows.

