### PR TITLE
In PTP descriptions, do not replace [code] by [quote].

### DIFF
--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -640,7 +640,7 @@ class PTP():
         desc = desc.replace("[center]", "[align=center]").replace("[/center]", "[/align]")
         desc = desc.replace("[left]", "[align=left]").replace("[/left]", "[/align]")
         desc = desc.replace("[right]", "[align=right]").replace("[/right]", "[/align]")
-        desc = desc.replace("[code]", "[quote]").replace("[/code]", "[/quote]")
+        # desc = desc.replace("[code]", "[quote]").replace("[/code]", "[/quote]")
         desc = desc.replace("[h3]", "").replace("[/h3]", "")
         desc = re.sub(r"\[img=[^\]]+\]", "[img]", desc)
         return desc


### PR DESCRIPTION
I propose to comment out that line. While I understand that it may prove useful in some cases, it has a very bad side effect. 
If you are an encoder, you will likely want to add some script (AviSynth, VapourSynth) in your description. In that case, you will want to enclose your script in `[code]...[/code]` so that unwanted emojis do not show up in your script and to have your script rendered in a nice monospaced font.
That line systematically convert the `[code]...[/code]` around your script into `[quote]...[/quote]`, so I propose to comment it out.