### PR TITLE
Description Customization

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -62,9 +62,10 @@ config = {
 
         # Number of screenshots to capture
         "screens": "6",
-		
+
         # Number of screenshots per row in the description. Default is single row.
-		# "screens_per_row": "3",
+        # Only for sites that use common description for now
+        # "screens_per_row": "3",
 
         # Add some overlay details to the screenshots
         # Frame number/type and Tonemapped if applicable
@@ -135,10 +136,10 @@ config = {
         # Absolute limit on processed files in packs.
         # You might not want to process screens/mediainfo for 40 episodes in a season pack.
         "processLimit": "5",
-		
+
         # Providing the option to add a description header, in bbcode, at the top of the description section
-		# where supported
-		# "custom_description_header": "[center] My Release [/center]",
+        # where supported
+        # "custom_description_header": "[center] My Release [/center]",
 
         # Providing the option to add a header, in bbcode, above the screenshot section where supported
         # "screenshot_header": "[center] SCREENSHOTS [/center]",
@@ -480,11 +481,10 @@ config = {
         # "UNIT3D_TEMPLATE": {
         #    "api_key": "UNIT3D_TEMPLATE api key",
         #    "announce_url": "https://domain.tld/announce/customannounceurl",
-        #    # "anon" : False,
-		#	"custom_signature" : "",
-		#	"custom_description_header": "",
-		#	"custom_screenshot_header": "",
-        #    # "modq" : False  ## Not working yet
+        #    "anon" : False,
+        #    "custom_description_header": "",
+        #    "custom_screenshot_header": "",
+        #    "modq" : False,  ## Not working yet
         # },
         "UTP": {
             "api_key": "UTP api key",

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -62,6 +62,9 @@ config = {
 
         # Number of screenshots to capture
         "screens": "6",
+		
+        # Number of screenshots per row in the description. Default is single row.
+		# "screens_per_row": "3",
 
         # Add some overlay details to the screenshots
         # Frame number/type and Tonemapped if applicable
@@ -132,6 +135,10 @@ config = {
         # Absolute limit on processed files in packs.
         # You might not want to process screens/mediainfo for 40 episodes in a season pack.
         "processLimit": "5",
+		
+        # Providing the option to add a description header, in bbcode, at the top of the description section
+		# where supported
+		# "custom_description_header": "[center] My Release [/center]",
 
         # Providing the option to add a header, in bbcode, above the screenshot section where supported
         # "screenshot_header": "[center] SCREENSHOTS [/center]",
@@ -247,12 +254,12 @@ config = {
         "CBR": {
             "api_key": "CBR api key",
             "announce_url": "https://capybarabr.com/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "DP": {
             "api_key": "DP api key",
             "announce_url": "https://darkpeers.org/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "FL": {
             "username": "FL username",
@@ -284,28 +291,28 @@ config = {
             "username": "username",
             "password": "password",
             "my_announce_url": "https://hdts-announce.ru/announce.php?pid=<PASS_KEY/PID>",
-            # "anon" : "False"
+            # "anon" : "False",
             "announce_url": "https://hdts-announce.ru/announce.php",  # DO NOT EDIT THIS LINE
         },
         "HHD": {
             "api_key": "HHD api key",
             "announce_url": "https://homiehelpdesk.net/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "HUNO": {
             "api_key": "HUNO api key",
             "announce_url": "https://hawke.uno/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "ITT": {
             "api_key": "ITT api key",
             "announce_url": "https://itatorrents.xyz/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "LCD": {
             "api_key": "LCD api key",
             "announce_url": "https://locadora.cc/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "LST": {
             "useAPI": False,  # Set to True if using LST for automatic ID searching or description parsing
@@ -318,7 +325,7 @@ config = {
         "LT": {
             "api_key": "LT api key",
             "announce_url": "https://lat-team.com/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "MTV": {
             'api_key': 'get from security page',
@@ -338,17 +345,17 @@ config = {
             "useAPI": False,  # Set to True if using OE for automatic ID searching or description parsing
             "api_key": "OE api key",
             "announce_url": "https://onlyencodes.cc/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "OTW": {
             "api_key": "OTW api key",
             "announce_url": "https://oldtoons.world/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "PSS": {
             "api_key": "PSS api key",
             "announce_url": "https://privatesilverscreen.cc/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "PTER": {  # Does not appear to be working at all
             "passkey": 'passkey',
@@ -365,7 +372,7 @@ config = {
             "ApiKey": 'ptp api key',
             "username": "",
             "password": "",
-            "announce_url": ""
+            "announce_url": "",
         },
         "PTT": {
             "api_key": "PTT api key",
@@ -375,24 +382,24 @@ config = {
         "R4E": {
             "api_key": "R4E api key",
             "announce_url": "https://racing4everyone.eu/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "RAS": {
             "api_key": "RAS api key",
             "announce_url": "https://rastastugan.org/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "RF": {
             "api_key": "RF api key",
             "announce_url": "https://reelflix.xyz/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "RTF": {
             "username": "username",
             "password": "password",
             "api_key": 'get_it_by_running_/api/ login command from https://retroflix.club/api/doc',
             "announce_url": "get from upload page",
-            # "anon": True
+            # "anon": True,
         },
         "SAM": {
             "api_key": "Samaritano API KEY",
@@ -402,7 +409,7 @@ config = {
         "SHRI": {
             "api_key": "SHRI api key",
             "announce_url": "https://shareisland.org/announce/customannounceurl",
-            # "anon" : "False"
+            # "anon" : "False",
         },
         "SN": {
             "api_key": "SN",
@@ -419,7 +426,7 @@ config = {
         "STC": {
             "api_key": "STC",
             "announce_url": "https://skipthecommericals.xyz/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "THR": {
             "username": "username",
@@ -429,7 +436,7 @@ config = {
             "pronfo_api_key": "pronfo api key",
             "pronfo_theme": "pronfo theme code",
             "pronfo_rapi_id": "pronfo remote api id",
-            # "anon" : False
+            # "anon" : False,
         },
         "TIK": {
             "useAPI": False,  # Set to True if using TIK for automatic ID searching, won't work great until folder searching is added to UNIT3D API
@@ -444,7 +451,7 @@ config = {
         "TOCA": {
             "api_key": "TOCA api key",
             "announce_url": "https://tocashare.biz/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "TTG": {
             "username": "username",
@@ -453,12 +460,12 @@ config = {
             "login_answer": "login_answer",
             "user_id": "user_id",
             "announce_url": "https://totheglory.im/announce/",
-            # "anon" : False
+            # "anon" : False,
         },
         "TVC": {
             "api_key": "TVC API Key",
             "announce_url": "https://tvchaosuk.com/announce/<PASSKEY>",
-            # "anon": "False"
+            # "anon": "False",
         },
         "UHD": {
             "api_key": "UHDshare API KEY",
@@ -474,22 +481,25 @@ config = {
         #    "api_key": "UNIT3D_TEMPLATE api key",
         #    "announce_url": "https://domain.tld/announce/customannounceurl",
         #    # "anon" : False,
+		#	"custom_signature" : "",
+		#	"custom_description_header": "",
+		#	"custom_screenshot_header": "",
         #    # "modq" : False  ## Not working yet
         # },
         "UTP": {
             "api_key": "UTP api key",
             "announce_url": "https://UTP/announce/customannounceurl",
-            # "anon" : False
+            # "anon" : False,
         },
         "YOINK": {
             "api_key": "YOINK api key",
             "announce_url": "https://yoinked.org/announce/customannounceurl",
-            # "anon" : "False"
+            # "anon" : "False",
         },
         "YUS": {
             "api_key": "YUS api key",
             "announce_url": "https://yu-scene.net/announce/customannounceurl",
-            # "anon" : "False"
+            # "anon" : "False",
         },
     },
 

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -98,7 +98,10 @@ class COMMON():
             console.print(f"[yellow]Warning: Error setting custom signature: {str(e)}[/yellow]")
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}]DESCRIPTION.txt", 'w', encoding='utf8') as descfile:
             if desc_header:
-                descfile.write(desc_header)
+                if not desc_header.endswith('\n'):
+                    descfile.write(desc_header + '\n')
+                else:
+                    descfile.write(desc_header)
             add_logo_enabled = self.config["DEFAULT"].get("add_logo", False)
             if add_logo_enabled and 'logo' in meta:
                 logo = meta['logo']

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -80,7 +80,7 @@ class COMMON():
         except Exception:
             screenheader = None
         try:
-            # If tracker has description header specified in config, use that. Otherwise, check if custom description header default is used. 
+            # If tracker has description header specified in config, use that. Otherwise, check if custom description header default is used.
             desc_header = self.config['TRACKERS'][tracker].get('custom_description_header', self.config['DEFAULT'].get('custom_description_header', desc_header))
         except Exception as e:
             console.print(f"[yellow]Warning: Error setting custom description header: {str(e)}[/yellow]")
@@ -282,7 +282,7 @@ class COMMON():
                             raw_url = images[img_index]['raw_url']
                             image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
                             descfile.write(image_str)
-                    
+
                             # If screensPerRow is set and we have reached that number of screenshots, add a new line
                             if screensPerRow and (img_index + 1) % screensPerRow == 0:
                                 descfile.write("\n")
@@ -402,7 +402,7 @@ class COMMON():
                     web_url = images[img_index]['web_url']
                     raw_url = images[img_index]['raw_url']
                     descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url]")
-                    
+
                     # If screensPerRow is set and we have reached that number of screenshots, add a new line
                     if screensPerRow and (img_index + 1) % screensPerRow == 0:
                         descfile.write("\n")
@@ -513,7 +513,7 @@ class COMMON():
                                 image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
                                 descfile.write(image_str)
                                 char_count += len(image_str)
-                    
+
                                 # If screensPerRow is set and we have reached that number of screenshots, add a new line
                                 if screensPerRow and (img_index + 1) % screensPerRow == 0:
                                     descfile.write("\n")


### PR DESCRIPTION
Changed a few aspects of how the Description is formatted.

1. Fixed a bug in COMMON.py where the screenshot header, if provided, would appear after the first file name when uploading multiple files.
2. Added an option in the default section of the config for a custom description header. I also added this as an option under each tracker in the configuration. Edited COMMON.py to check if the tracker has a custom header in the config; if not, it is the custom header in the default set; if not, fall back to original logic and desc header from tracker.py. Logic is Config.Tracker.custom_description_header > Config.default.custom_description_header > COMMON.py.unit3d_edit_desc(desc_header)
3. Added an option for custom signature per tracker in the config file. Edited common.py to use tracker signature if set, if not, fall back to tracker.py signature. Logic is Config.Tracker.custom_signature > COMMON.py.unit3d_edit_desc(signature)
4. Added an option in the config for tracker-specific screenshot header. Edited common.py to prefer this over the one found in the default section if it's set. logic is Config.Tracker.custom_screenshot_header > Config.default.screenshot_header 
5. Added a new option in the config default section to specify how many screenshots you want in a row before a new line is added in the description. Edited COMMON.py to check if this is set. If it is, when adding screenshots, it will add a new line after that number of screenshots has been reached. parameter is: screens_per_row

Tracker-specific options in the config were added under the Unit3D template and are commented out. Additional default options were also commented out and have some helper text.

Added comments to explain the added logic in COMMON.py.

Format for description using these changes:
1. Description Header (Updated setting of variable, this structure was already in place)
2. Description file/link (unchanged, but including to show order of formatting)
3. Screenshot Header (Updated setting of variable, this structure was already in place)
4. Screenshots (Updated how they are formatted into rows)
5. Signature (Updated setting of variable, this structure was already in place)

Changes were checked in Aither.