### PR TITLE
OTW - use year in TV title

### DIFF
--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -90,13 +90,13 @@ class OTW():
 
             series_year = meta.get('tvdb_episode_data', {}).get('series_year')
             if series_year and str(series_year).isdigit():
-		years.append(int(series_year))
+                years.append(int(series_year))
             # Use the oldest year if any found, else empty string
             year = str(min(years)) if years else ""
             if meta.get('no_year', False) is False:
                 otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
-	    return otw_name
+        return otw_name
 
     async def upload(self, meta, disctype):
         common = COMMON(config=self.config)

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -77,6 +77,21 @@ class OTW():
         otw_name = otw_name.replace(meta["aka"], '')
         if meta['is_disc'] == "DVD":
             otw_name = otw_name.replace(source, f"{source} {resolution}")
+        if meta['category'] == "TV":
+            try:
+                year = meta['year']
+                if not year:
+                    raise ValueError("No TMDB Year Found..trying IMDB")
+            except (KeyError, ValueError):
+                try:
+                    year = meta['imdb_info']['year']
+                    if not year:
+                        raise ValueError("No IMDB Year Found..")
+                except (KeyError, ValueError):
+                    year = ""
+
+            if meta.get('no_year', False) is False:
+                otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
         return otw_name
 

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -78,23 +78,23 @@ class OTW():
         if meta['is_disc'] == "DVD":
             otw_name = otw_name.replace(source, f"{source} {resolution}")
         if meta['category'] == "TV":
-        years = []
+            years = []
 
-	    tmdb_year = meta.get('year')
-            if tmdb_year and str(tmdb_year).isdigit():
-            years.append(int(tmdb_year))
+            tmdb_year = meta.get('year')
+                if tmdb_year and str(tmdb_year).isdigit():
+                years.append(int(tmdb_year))
 
-	    imdb_year = meta.get('imdb_info', {}).get('year')
-            if imdb_year and str(imdb_year).isdigit():
-            years.append(int(imdb_year))
+            imdb_year = meta.get('imdb_info', {}).get('year')
+                if imdb_year and str(imdb_year).isdigit():
+                years.append(int(imdb_year))
 
-	    series_year = meta.get('tvdb_episode_data', {}).get('series_year')
-            if series_year and str(series_year).isdigit():
-            years.append(int(series_year))
+            series_year = meta.get('tvdb_episode_data', {}).get('series_year')
+                if series_year and str(series_year).isdigit():
+                years.append(int(series_year))
             # Use the oldest year if any found, else empty string
-	    year = str(min(years)) if years else ""
-	    if meta.get('no_year', False) is False:
-            otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
+            year = str(min(years)) if years else ""
+            if meta.get('no_year', False) is False:
+                otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
 	    return otw_name
 

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -77,21 +77,24 @@ class OTW():
         otw_name = otw_name.replace(meta["aka"], '')
         if meta['is_disc'] == "DVD":
             otw_name = otw_name.replace(source, f"{source} {resolution}")
-        if meta['category'] == "TV":
-            try:
-                year = meta['year']
-                if not year:
-                    raise ValueError("No TMDB Year Found..trying IMDB")
-            except (KeyError, ValueError):
-                try:
-                    year = meta['imdb_info']['year']
-                    if not year:
-                        raise ValueError("No IMDB Year Found..")
-                except (KeyError, ValueError):
-                    year = ""
+		if meta['category'] == "TV":
+			years = []
 
-            if meta.get('no_year', False) is False:
-                otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
+			tmdb_year = meta.get('year')
+			if tmdb_year and str(tmdb_year).isdigit():
+				years.append(int(tmdb_year))
+
+			imdb_year = meta.get('imdb_info', {}).get('year')
+			if imdb_year and str(imdb_year).isdigit():
+				years.append(int(imdb_year))
+
+			series_year = meta.get('tvdb_episode_data', {}).get('series_year')
+			if series_year and str(series_year).isdigit():
+				years.append(int(series_year))
+			# Use the oldest year if any found, else empty string
+			year = str(min(years)) if years else ""
+			if meta.get('no_year', False) is False:
+				otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
         return otw_name
 

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -77,26 +77,26 @@ class OTW():
         otw_name = otw_name.replace(meta["aka"], '')
         if meta['is_disc'] == "DVD":
             otw_name = otw_name.replace(source, f"{source} {resolution}")
-	if meta['category'] == "TV":
-	    years = []
+        if meta['category'] == "TV":
+        years = []
 
 	    tmdb_year = meta.get('year')
-	    if tmdb_year and str(tmdb_year).isdigit():
-	        years.append(int(tmdb_year))
+            if tmdb_year and str(tmdb_year).isdigit():
+            years.append(int(tmdb_year))
 
 	    imdb_year = meta.get('imdb_info', {}).get('year')
-	    if imdb_year and str(imdb_year).isdigit():
-	        years.append(int(imdb_year))
+            if imdb_year and str(imdb_year).isdigit():
+            years.append(int(imdb_year))
 
 	    series_year = meta.get('tvdb_episode_data', {}).get('series_year')
-	    if series_year and str(series_year).isdigit():
-	        years.append(int(series_year))
-	    # Use the oldest year if any found, else empty string
+            if series_year and str(series_year).isdigit():
+            years.append(int(series_year))
+            # Use the oldest year if any found, else empty string
 	    year = str(min(years)) if years else ""
 	    if meta.get('no_year', False) is False:
-	        otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
+            otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
-        return otw_name
+	    return otw_name
 
     async def upload(self, meta, disctype):
         common = COMMON(config=self.config)

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -77,24 +77,24 @@ class OTW():
         otw_name = otw_name.replace(meta["aka"], '')
         if meta['is_disc'] == "DVD":
             otw_name = otw_name.replace(source, f"{source} {resolution}")
-		if meta['category'] == "TV":
-			years = []
+	if meta['category'] == "TV":
+	    years = []
 
-			tmdb_year = meta.get('year')
-			if tmdb_year and str(tmdb_year).isdigit():
-				years.append(int(tmdb_year))
+	    tmdb_year = meta.get('year')
+	    if tmdb_year and str(tmdb_year).isdigit():
+	        years.append(int(tmdb_year))
 
-			imdb_year = meta.get('imdb_info', {}).get('year')
-			if imdb_year and str(imdb_year).isdigit():
-				years.append(int(imdb_year))
+	    imdb_year = meta.get('imdb_info', {}).get('year')
+	    if imdb_year and str(imdb_year).isdigit():
+	        years.append(int(imdb_year))
 
-			series_year = meta.get('tvdb_episode_data', {}).get('series_year')
-			if series_year and str(series_year).isdigit():
-				years.append(int(series_year))
-			# Use the oldest year if any found, else empty string
-			year = str(min(years)) if years else ""
-			if meta.get('no_year', False) is False:
-				otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
+	    series_year = meta.get('tvdb_episode_data', {}).get('series_year')
+	    if series_year and str(series_year).isdigit():
+	        years.append(int(series_year))
+	    # Use the oldest year if any found, else empty string
+	    year = str(min(years)) if years else ""
+	    if meta.get('no_year', False) is False:
+	        otw_name = otw_name.replace(meta['title'], f"{meta['title']} {year}", 1)
 
         return otw_name
 

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -81,16 +81,16 @@ class OTW():
             years = []
 
             tmdb_year = meta.get('year')
-                if tmdb_year and str(tmdb_year).isdigit():
+            if tmdb_year and str(tmdb_year).isdigit():
                 years.append(int(tmdb_year))
 
             imdb_year = meta.get('imdb_info', {}).get('year')
-                if imdb_year and str(imdb_year).isdigit():
+            if imdb_year and str(imdb_year).isdigit():
                 years.append(int(imdb_year))
 
             series_year = meta.get('tvdb_episode_data', {}).get('series_year')
-                if series_year and str(series_year).isdigit():
-                years.append(int(series_year))
+            if series_year and str(series_year).isdigit():
+		years.append(int(series_year))
             # Use the oldest year if any found, else empty string
             year = str(min(years)) if years else ""
             if meta.get('no_year', False) is False:

--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -73,6 +73,7 @@ async def get_tvdb_episode_data(base_dir, token, tvdb_id, season, episode, api_k
                     "season_name": episode_data.get("seasonName", ""),
                     "series_name": series_data.get("name", ""),
                     "series_overview": series_data.get("overview", ""),
+                    'series_year': series_data.get("year", ""),
                 }
 
                 if debug:


### PR DESCRIPTION
> NOTE: For TV series, the Year in the title should be the year that the series premiered, not necessarily the year in which a particular season or episode aired. 

https://oldtoons.world/pages/1