### PR TITLE
Allow '-s 0' option when uploading to HDB

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -507,7 +507,8 @@ class HDB():
             if self.rehost_images is True:
                 console.print("[green]Rehosting Images...")
                 hdbimg_bbcode = await self.hdbimg_upload(meta)
-                descfile.write(f"{hdbimg_bbcode}")
+                if hdbimg_bbcode is not None:
+                    descfile.write(f"{hdbimg_bbcode}")
             else:
                 images = meta['image_list']
                 if len(images) > 0:
@@ -552,31 +553,32 @@ class HDB():
             print(f"[DEBUG] Using {hdbimg_screen_count} images for upload")
 
         files = {}
-        for i in range(hdbimg_screen_count):
-            file_path = images[i]
-            try:
-                files[f'images_files[{i}]'] = (f'image_{i}.png', open(file_path, 'rb'), 'image/png')
-                if meta['debug']:
-                    print(f"[DEBUG] Added file {file_path} as images_files[{i}]")
-            except Exception as e:
-                print(f"[ERROR] Failed to open {file_path}: {e}")
-                return None
+        if hdbimg_screen_count > 0:
+            for i in range(hdbimg_screen_count):
+                file_path = images[i]
+                try:
+                    files[f'images_files[{i}]'] = (f'image_{i}.png', open(file_path, 'rb'), 'image/png')
+                    if meta['debug']:
+                        print(f"[DEBUG] Added file {file_path} as images_files[{i}]")
+                except Exception as e:
+                    print(f"[ERROR] Failed to open {file_path}: {e}")
+                    return None
 
-        try:
-            response = requests.post(url, data=data, files=files)
-            if meta['debug']:
-                print(f"[DEBUG] HTTP Response Code: {response.status_code}")
-                print(f"[DEBUG] Response Text: {response.text[:500]}")  # Limit output for readability
-            return response.text
-        except requests.RequestException as e:
-            print(f"[ERROR] HTTP Request failed: {e}")
-            return None
-        finally:
-            # Close files to prevent resource leaks
-            for f in files.values():
-                f[1].close()
+            try:
+                response = requests.post(url, data=data, files=files)
                 if meta['debug']:
-                    print(f"[DEBUG] Closed file {f[0]}")
+                    print(f"[DEBUG] HTTP Response Code: {response.status_code}")
+                    print(f"[DEBUG] Response Text: {response.text[:500]}")  # Limit output for readability
+                return response.text
+            except requests.RequestException as e:
+                print(f"[ERROR] HTTP Request failed: {e}")
+                return None
+            finally:
+                # Close files to prevent resource leaks
+                for f in files.values():
+                    f[1].close()
+                    if meta['debug']:
+                        print(f"[DEBUG] Closed file {f[0]}")
 
     async def get_info_from_torrent_id(self, hdb_id):
         hdb_imdb = hdb_tvdb = hdb_name = hdb_torrenthash = None


### PR DESCRIPTION
When you upload your own encode to HDB, you will likely add comparisons between source/filtered/encode in your description. In that case, you don't need to include additional screenshots, so you will want to use the "-s 0" option in UA.
But, up to now, this was adding the line:
"error: Upload failed - no images received"
at the end of the uploaded description.

This PR aims at handling this (somewhat specific) case more smoothly.
Tested in debug mode.