### PR TITLE
Add comparison images

### DIFF
--- a/src/add_comparison.py
+++ b/src/add_comparison.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import cli_ui
 from collections import defaultdict
 from src.uploadscreens import upload_screens
 from data.config import config
@@ -90,6 +91,15 @@ async def add_comparison(meta):
         }
 
     comparison_index = meta.get('comparison_index')
+    if not comparison_index:
+        console.print("[red]No comparison index provided. Please specify a comparison index matching the input file.")
+        while True:
+            cli_input = cli_ui.input("Enter comparison index number: ")
+            try:
+                comparison_index = str(int(cli_input.strip()))
+                break
+            except Exception:
+                console.print(f"[red]Invalid comparison index: {cli_input.strip()}")
     if comparison_index and comparison_index in meta_comparisons:
         if 'image_list' not in meta:
             meta['image_list'] = []

--- a/src/add_comparison.py
+++ b/src/add_comparison.py
@@ -1,0 +1,115 @@
+import os
+import re
+import json
+from collections import defaultdict
+from src.uploadscreens import upload_screens
+from data.config import config
+from src.console import console
+
+
+async def add_comparison(meta):
+    comparison_path = meta.get('comparison')
+    if not comparison_path or not os.path.isdir(comparison_path):
+        return []
+
+    comparison_data_file = f"{meta['base_dir']}/tmp/{meta['uuid']}/comparison_data.json"
+    if os.path.exists(comparison_data_file):
+        try:
+            with open(comparison_data_file, 'r') as f:
+                saved_comparison_data = json.load(f)
+                if meta.get('debug'):
+                    console.print(f"[cyan]Loading previously saved comparison data from {comparison_data_file}")
+                meta["comparison_groups"] = saved_comparison_data
+
+                comparison_index = meta.get('comparison_index')
+                if comparison_index and comparison_index in saved_comparison_data:
+                    if 'image_list' not in meta:
+                        meta['image_list'] = []
+
+                    urls_to_add = saved_comparison_data[comparison_index].get('urls', [])
+                    if meta.get('debug'):
+                        console.print(f"[cyan]Adding {len(urls_to_add)} images from comparison group {comparison_index} to image_list")
+
+                    for url_info in urls_to_add:
+                        if url_info not in meta['image_list']:
+                            meta['image_list'].append(url_info)
+
+                return saved_comparison_data
+        except Exception as e:
+            console.print(f"[yellow]Error loading saved comparison data: {e}")
+
+    files = [f for f in os.listdir(comparison_path) if f.lower().endswith('.png')]
+    pattern = re.compile(r"(\d+)-(\d+)-(.+)\.png", re.IGNORECASE)
+
+    groups = defaultdict(list)
+    suffixes = {}
+
+    for f in files:
+        match = pattern.match(f)
+        if match:
+            first, second, suffix = match.groups()
+            groups[second].append((int(first), f))
+            if second not in suffixes:
+                suffixes[second] = suffix
+
+    meta_comparisons = {}
+    img_host_keys = [k for k in config.get('DEFAULT', {}) if k.startswith('img_host_')]
+    img_host_indices = [int(k.split('_')[-1]) for k in img_host_keys]
+    img_host_indices.sort()
+
+    if not img_host_indices:
+        raise ValueError("No image hosts found in config. Please ensure at least one 'img_host_X' key is present in config.")
+
+    for idx, second in enumerate(sorted(groups, key=lambda x: int(x)), 1):
+        img_host_num = img_host_indices[0]
+        current_img_host_key = f'img_host_{img_host_num}'
+        current_img_host = config.get('DEFAULT', {}).get(current_img_host_key)
+
+        group = sorted(groups[second], key=lambda x: x[0])
+        group_files = [f for _, f in group]
+        custom_img_list = [os.path.join(comparison_path, filename) for filename in group_files]
+        upload_meta = meta.copy()
+        console.print(f"[cyan]Uploading comparison group {second} with files: {group_files}")
+
+        upload_result, _ = await upload_screens(
+            upload_meta, custom_img_list, img_host_num, 0, len(custom_img_list), custom_img_list, {}
+        )
+
+        uploaded_infos = [
+            {k: item.get(k) for k in ("img_url", "raw_url", "web_url")}
+            for item in upload_result
+        ]
+
+        group_name = suffixes.get(second, "")
+
+        meta_comparisons[second] = {
+            "files": group_files,
+            "urls": uploaded_infos,
+            "img_host": current_img_host,
+            "name": group_name
+        }
+
+    comparison_index = meta.get('comparison_index')
+    if comparison_index and comparison_index in meta_comparisons:
+        if 'image_list' not in meta:
+            meta['image_list'] = []
+
+        urls_to_add = meta_comparisons[comparison_index].get('urls', [])
+        if meta.get('debug'):
+            console.print(f"[cyan]Adding {len(urls_to_add)} images from comparison group {comparison_index} to image_list")
+
+        for url_info in urls_to_add:
+            if url_info not in meta['image_list']:
+                meta['image_list'].append(url_info)
+
+    meta["comparison_groups"] = meta_comparisons
+
+    try:
+        with open(comparison_data_file, 'w') as f:
+            json.dump(meta_comparisons, f, indent=4)
+        if meta.get('debug'):
+            console.print(f"[cyan]Saved comparison data to {comparison_data_file}")
+    except Exception as e:
+        console.print(f"[yellow]Failed to save comparison data: {e}")
+
+    return meta_comparisons

--- a/src/args.py
+++ b/src/args.py
@@ -34,7 +34,8 @@ Common options:
   -daily, --daily            Air date of a daily type episode (YYYY-MM-DD)
   -c, --category             Category (movie, tv, fanres)
   -t, --type                 Type (disc, remux, encode, webdl, etc.)
-  --source                    Source (Blu-ray, BluRay, DVD, WEBDL, etc.)
+  --source                   Source (Blu-ray, BluRay, DVD, WEBDL, etc.)
+  -comps, --comparison       Use comparison images from a folder (input folder path): see -comps_index
   -debug, --debug            Prints more information, runs everything without actually uploading
 
 Use --help for a full list of options.
@@ -78,8 +79,8 @@ class Args():
         parser.add_argument('-lq', '--limit-queue', dest='limit_queue', nargs=1, required=False, help="Limit the amount of queue files processed", type=int, default=0)
         parser.add_argument('--unit3d', action='store_true', required=False, help="[parse a txt output file from UNIT3D-Upload-Checker]")
         parser.add_argument('-s', '--screens', nargs=1, required=False, help="Number of screenshots", default=int(self.config['DEFAULT']['screens']))
-        parser.add_argument('-comps', '--comparison', nargs='+', required=False, help="Use comparison images from this folder (input folder path)", default=None)
-        parser.add_argument('-comps_index', '--comparison_index', nargs=1, required=False, help="Which of your comparison indexes is the main images", type=int, default=None)
+        parser.add_argument('-comps', '--comparison', nargs='+', required=False, help="Use comparison images from a folder (input folder path)", default=None)
+        parser.add_argument('-comps_index', '--comparison_index', nargs=1, required=False, help="Which of your comparison indexes is the main images (required when comps)", type=int, default=None)
         parser.add_argument('-mf', '--manual_frames', nargs=1, required=False, help="Comma-separated frame numbers to use as screenshots", type=str, default=None)
         parser.add_argument('-c', '--category', nargs=1, required=False, help="Category [MOVIE, TV, FANRES]", choices=['movie', 'tv', 'fanres'])
         parser.add_argument('-t', '--type', nargs=1, required=False, help="Type [DISC, REMUX, ENCODE, WEBDL, WEBRIP, HDTV, DVDRIP]", choices=['disc', 'remux', 'encode', 'webdl', 'web-dl', 'webrip', 'hdtv', 'dvdrip'], dest="manual_type")

--- a/src/args.py
+++ b/src/args.py
@@ -79,7 +79,7 @@ class Args():
         parser.add_argument('-lq', '--limit-queue', dest='limit_queue', nargs=1, required=False, help="Limit the amount of queue files processed", type=int, default=0)
         parser.add_argument('--unit3d', action='store_true', required=False, help="[parse a txt output file from UNIT3D-Upload-Checker]")
         parser.add_argument('-s', '--screens', nargs=1, required=False, help="Number of screenshots", default=int(self.config['DEFAULT']['screens']))
-        parser.add_argument('-comps', '--comparison', nargs='+', required=False, help="Use comparison images from a folder (input folder path)", default=None)
+        parser.add_argument('-comps', '--comparison', nargs='+', required=False, help="Use comparison images from a folder (input folder path). See: https://github.com/Audionut/Upload-Assistant/pull/487", default=None)
         parser.add_argument('-comps_index', '--comparison_index', nargs=1, required=False, help="Which of your comparison indexes is the main images (required when comps)", type=int, default=None)
         parser.add_argument('-mf', '--manual_frames', nargs=1, required=False, help="Comma-separated frame numbers to use as screenshots", type=str, default=None)
         parser.add_argument('-c', '--category', nargs=1, required=False, help="Category [MOVIE, TV, FANRES]", choices=['movie', 'tv', 'fanres'])

--- a/src/args.py
+++ b/src/args.py
@@ -204,6 +204,8 @@ class Args():
                         meta[key] = f"-{value2}"
                     elif key == 'descfile':
                         meta[key] = os.path.abspath(value2)
+                    elif key == 'comparison':
+                        meta[key] = os.path.abspath(value2)
                     elif key == 'screens':
                         meta[key] = int(value2)
                     elif key == 'season':

--- a/src/args.py
+++ b/src/args.py
@@ -78,6 +78,8 @@ class Args():
         parser.add_argument('-lq', '--limit-queue', dest='limit_queue', nargs=1, required=False, help="Limit the amount of queue files processed", type=int, default=0)
         parser.add_argument('--unit3d', action='store_true', required=False, help="[parse a txt output file from UNIT3D-Upload-Checker]")
         parser.add_argument('-s', '--screens', nargs=1, required=False, help="Number of screenshots", default=int(self.config['DEFAULT']['screens']))
+        parser.add_argument('-comps', '--comparison', nargs='+', required=False, help="Use comparison images from this folder (input folder path)", default=None)
+        parser.add_argument('-comps_index', '--comparison_index', nargs=1, required=False, help="Which of your comparison indexes is the main images", type=int, default=None)
         parser.add_argument('-mf', '--manual_frames', nargs=1, required=False, help="Comma-separated frame numbers to use as screenshots", type=str, default=None)
         parser.add_argument('-c', '--category', nargs=1, required=False, help="Category [MOVIE, TV, FANRES]", choices=['movie', 'tv', 'fanres'])
         parser.add_argument('-t', '--type', nargs=1, required=False, help="Type [DISC, REMUX, ENCODE, WEBDL, WEBRIP, HDTV, DVDRIP]", choices=['disc', 'remux', 'encode', 'webdl', 'web-dl', 'webrip', 'hdtv', 'dvdrip'], dest="manual_type")

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -243,6 +243,35 @@ class BHD():
                             desc.write(f"[spoiler={os.path.basename(each['largest_evo'])}][code][{each['evo_mi']}[/code][/spoiler]\n")
                             desc.write("\n")
             desc.write(base.replace("[img]", "[img width=300]"))
+            if meta.get('comparison') and meta.get('comparison_groups'):
+                desc.write("[center]")
+                comparison_groups = meta.get('comparison_groups', {})
+                sorted_group_indices = sorted(comparison_groups.keys(), key=lambda x: int(x))
+
+                comp_sources = []
+                for group_idx in sorted_group_indices:
+                    group_data = comparison_groups[group_idx]
+                    group_name = group_data.get('name', f'Group {group_idx}')
+                    comp_sources.append(group_name)
+
+                sources_string = ", ".join(comp_sources)
+                desc.write(f"[comparison={sources_string}]\n")
+
+                images_per_group = min([
+                    len(comparison_groups[idx].get('urls', []))
+                    for idx in sorted_group_indices
+                ])
+
+                for img_idx in range(images_per_group):
+                    for group_idx in sorted_group_indices:
+                        group_data = comparison_groups[group_idx]
+                        urls = group_data.get('urls', [])
+                        if img_idx < len(urls):
+                            img_url = urls[img_idx].get('raw_url', '')
+                            if img_url:
+                                desc.write(f"{img_url}\n")
+
+                desc.write("[/comparison][/center]\n\n")
             if f'{self.tracker}_images_key' in meta:
                 images = meta[f'{self.tracker}_images_key']
             else:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -418,7 +418,7 @@ class COMMON():
                     for group_idx in sorted_group_indices:
                         group_data = comparison_groups[group_idx]
                         group_name = group_data.get('name', f'Group {group_idx}')
-                        comp_sources.append(group_name.capitalize())
+                        comp_sources.append(group_name)
 
                     sources_string = ", ".join(comp_sources)
                     descfile.write(f"[comparison={sources_string}]\n")

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -409,15 +409,36 @@ class COMMON():
 
             # Handle single file case
             if len(filelist) == 1:
-                if meta['debug']:
-                    mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt", 'r', encoding='utf-8').read()
-                    if mi_dump:
-                        parsed_mediainfo = self.parser.parse_mediainfo(mi_dump)
-                        formatted_bbcode = self.parser.format_bbcode(parsed_mediainfo)
-                        for i, file in enumerate(filelist):
-                            if i == 0:
-                                filename = os.path.splitext(os.path.basename(file.strip()))[0]
-                                descfile.write(f"[center][spoiler={filename}]{formatted_bbcode}[/spoiler]\n")
+                if meta.get('comparison') and meta.get('comparison_groups'):
+                    descfile.write("[center]")
+                    comparison_groups = meta.get('comparison_groups', {})
+                    sorted_group_indices = sorted(comparison_groups.keys(), key=lambda x: int(x))
+
+                    comp_sources = []
+                    for group_idx in sorted_group_indices:
+                        group_data = comparison_groups[group_idx]
+                        group_name = group_data.get('name', f'Group {group_idx}')
+                        comp_sources.append(group_name.capitalize())
+
+                    sources_string = ", ".join(comp_sources)
+                    descfile.write(f"[comparison={sources_string}]\n")
+
+                    images_per_group = min([
+                        len(comparison_groups[idx].get('urls', []))
+                        for idx in sorted_group_indices
+                    ])
+
+                    for img_idx in range(images_per_group):
+                        for group_idx in sorted_group_indices:
+                            group_data = comparison_groups[group_idx]
+                            urls = group_data.get('urls', [])
+                            if img_idx < len(urls):
+                                img_url = urls[img_idx].get('raw_url', '')
+                                if img_url:
+                                    descfile.write(f"{img_url}\n")
+
+                    descfile.write("[/comparison][/center]\n\n")
+
                 if screenheader is not None:
                     descfile.write(screenheader + '\n')
                 descfile.write("[center]")
@@ -425,8 +446,6 @@ class COMMON():
                     web_url = images[img_index]['web_url']
                     raw_url = images[img_index]['raw_url']
                     descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url]")
-
-                    # If screensPerRow is set and we have reached that number of screenshots, add a new line
                     if screensPerRow and (img_index + 1) % screensPerRow == 0:
                         descfile.write("\n")
                 descfile.write("[/center]")

--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -516,11 +516,12 @@ class HDB():
                                 group_names.append(group_name)
 
                             comparison_header = " vs ".join(group_names)
+                            descfile.write("[/b]\n")
                             descfile.write(f"Screenshot comparison\n{comparison_header}")
                         else:
                             descfile.write("Screenshot comparison")
 
-                        descfile.write("[/b]\n")
+                        descfile.write("\n\n")
                         descfile.write(f"{hdbimg_bbcode}")
                         descfile.write("[/center]")
                     else:

--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -541,7 +541,6 @@ class HDB():
     async def hdbimg_upload(self, meta):
         if meta.get('comparison', False):
             comparison_path = meta.get('comparison')
-            thumb_size = 'w250'
             if not os.path.isdir(comparison_path):
                 console.print(f"[red]Comparison path not found: {comparison_path}")
                 return None
@@ -584,6 +583,10 @@ class HDB():
             # Interleave images for correct ordering
             all_image_files = []
             sorted_group_indices = sorted(group_images.keys(), key=lambda x: int(x))
+            if len(sorted_group_indices) < 4:
+                thumb_size = 'w250'
+            else:
+                thumb_size = 'w100'
 
             for image_idx in range(max_images_per_group):
                 for group_idx in sorted_group_indices:

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -933,6 +933,30 @@ class PTP():
                 if base2ptp.strip() != "":
                     desc.write(base2ptp)
                     desc.write("\n\n")
+                if meta.get('comparison', None):
+                    if 'comparison_groups' in meta and meta['comparison_groups']:
+                        desc.write("\n")
+
+                        comparison_groups = meta['comparison_groups']
+                        group_keys = sorted(comparison_groups.keys(), key=lambda x: int(x))
+                        comparison_names = [comparison_groups[key].get('name', f'Group {key}') for key in group_keys]
+                        comparison_header = ', '.join(comparison_names)
+                        desc.write(f"[comparison={comparison_header}]\n")
+
+                        num_images = min([len(comparison_groups[key]['urls']) for key in group_keys])
+
+                        for img_index in range(num_images):
+                            for key in group_keys:
+                                group = comparison_groups[key]
+                                if img_index < len(group['urls']):
+                                    img_data = group['urls'][img_index]
+                                    raw_url = img_data.get('raw_url', '')
+                                    if raw_url:
+                                        desc.write(f"[img]{raw_url}[/img] ")
+                            desc.write("\n")
+
+                        desc.write("[/comparison]\n\n")
+
                 for img_index in range(len(images[:int(meta['screens'])])):
                     raw_url = meta['image_list'][img_index]['raw_url']
                     desc.write(f"[img]{raw_url}[/img]\n")

--- a/upload.py
+++ b/upload.py
@@ -26,6 +26,7 @@ from src.uphelper import UploadHelper
 from src.trackerstatus import process_all_trackers
 from src.takescreens import disc_screenshots, dvd_screenshots, screenshots
 from src.cleanup import cleanup
+from src.add_comparison import add_comparison
 if os.name == "posix":
     import termios
 
@@ -156,123 +157,127 @@ async def process_meta(meta, base_dir):
             meta['manual_frames'] = {}
         manual_frames = meta['manual_frames']
 
-        image_data_file = f"{meta['base_dir']}/tmp/{meta['uuid']}/image_data.json"
-        if os.path.exists(image_data_file) and not meta.get('image_list'):
+        if meta.get('comparison', False):
+            await add_comparison(meta)
+
+        else:
+            image_data_file = f"{meta['base_dir']}/tmp/{meta['uuid']}/image_data.json"
+            if os.path.exists(image_data_file) and not meta.get('image_list'):
+                try:
+                    with open(image_data_file, 'r') as img_file:
+                        image_data = json.load(img_file)
+
+                        if 'image_list' in image_data and not meta.get('image_list'):
+                            meta['image_list'] = image_data['image_list']
+                            if meta.get('debug'):
+                                console.print(f"[cyan]Loaded {len(image_data['image_list'])} previously saved image links")
+
+                        if 'image_sizes' in image_data and not meta.get('image_sizes'):
+                            meta['image_sizes'] = image_data['image_sizes']
+                            if meta.get('debug'):
+                                console.print("[cyan]Loaded previously saved image sizes")
+                except Exception as e:
+                    console.print(f"[yellow]Could not load saved image data: {str(e)}")
+
+            # Take Screenshots
             try:
-                with open(image_data_file, 'r') as img_file:
-                    image_data = json.load(img_file)
+                if meta['is_disc'] == "BDMV":
+                    use_vs = meta.get('vapoursynth', False)
+                    try:
+                        await disc_screenshots(
+                            meta, bdmv_filename, bdinfo, meta['uuid'], base_dir, use_vs,
+                            meta.get('image_list', []), meta.get('ffdebug', False), None
+                        )
+                    except asyncio.CancelledError:
+                        console.print("[red]Screenshot capture was cancelled. Cleaning up...[/red]")
+                        await cleanup_screenshot_temp_files(meta)  # Cleanup only on cancellation
+                        raise  # Ensure cancellation propagates properly
+                    except Exception as e:
+                        console.print(f"[red]Error during BDMV screenshot capture: {e}[/red]", highlight=False)
+                        await cleanup_screenshot_temp_files(meta)  # Cleanup only on error
 
-                    if 'image_list' in image_data and not meta.get('image_list'):
-                        meta['image_list'] = image_data['image_list']
-                        if meta.get('debug'):
-                            console.print(f"[cyan]Loaded {len(image_data['image_list'])} previously saved image links")
+                elif meta['is_disc'] == "DVD":
+                    try:
+                        await dvd_screenshots(
+                            meta, 0, None, None
+                        )
+                    except asyncio.CancelledError:
+                        console.print("[red]DVD screenshot capture was cancelled. Cleaning up...[/red]")
+                        await cleanup_screenshot_temp_files(meta)
+                        raise
+                    except Exception as e:
+                        console.print(f"[red]Error during DVD screenshot capture: {e}[/red]", highlight=False)
+                        await cleanup_screenshot_temp_files(meta)
 
-                    if 'image_sizes' in image_data and not meta.get('image_sizes'):
-                        meta['image_sizes'] = image_data['image_sizes']
-                        if meta.get('debug'):
-                            console.print("[cyan]Loaded previously saved image sizes")
-            except Exception as e:
-                console.print(f"[yellow]Could not load saved image data: {str(e)}")
+                else:
+                    try:
+                        if meta['debug']:
+                            console.print(f"videopath: {videopath}, filename: {filename}, meta: {meta['uuid']}, base_dir: {base_dir}, manual_frames: {manual_frames}")
 
-        # Take Screenshots
-        try:
-            if meta['is_disc'] == "BDMV":
-                use_vs = meta.get('vapoursynth', False)
-                try:
-                    await disc_screenshots(
-                        meta, bdmv_filename, bdinfo, meta['uuid'], base_dir, use_vs,
-                        meta.get('image_list', []), meta.get('ffdebug', False), None
-                    )
-                except asyncio.CancelledError:
-                    console.print("[red]Screenshot capture was cancelled. Cleaning up...[/red]")
-                    await cleanup_screenshot_temp_files(meta)  # Cleanup only on cancellation
-                    raise  # Ensure cancellation propagates properly
-                except Exception as e:
-                    console.print(f"[red]Error during BDMV screenshot capture: {e}[/red]", highlight=False)
-                    await cleanup_screenshot_temp_files(meta)  # Cleanup only on error
+                        await screenshots(
+                            videopath, filename, meta['uuid'], base_dir, meta,
+                            manual_frames=manual_frames  # Pass additional kwargs directly
+                        )
+                    except asyncio.CancelledError:
+                        console.print("[red]Generic screenshot capture was cancelled. Cleaning up...[/red]")
+                        await cleanup_screenshot_temp_files(meta)
+                        raise
+                    except Exception as e:
+                        console.print(f"[red]Error during generic screenshot capture: {e}[/red]", highlight=False)
+                        console.print(traceback.format_exc())
+                        await cleanup_screenshot_temp_files(meta)
 
-            elif meta['is_disc'] == "DVD":
-                try:
-                    await dvd_screenshots(
-                        meta, 0, None, None
-                    )
-                except asyncio.CancelledError:
-                    console.print("[red]DVD screenshot capture was cancelled. Cleaning up...[/red]")
-                    await cleanup_screenshot_temp_files(meta)
-                    raise
-                except Exception as e:
-                    console.print(f"[red]Error during DVD screenshot capture: {e}[/red]", highlight=False)
-                    await cleanup_screenshot_temp_files(meta)
-
-            else:
-                try:
-                    if meta['debug']:
-                        console.print(f"videopath: {videopath}, filename: {filename}, meta: {meta['uuid']}, base_dir: {base_dir}, manual_frames: {manual_frames}")
-
-                    await screenshots(
-                        videopath, filename, meta['uuid'], base_dir, meta,
-                        manual_frames=manual_frames  # Pass additional kwargs directly
-                    )
-                except asyncio.CancelledError:
-                    console.print("[red]Generic screenshot capture was cancelled. Cleaning up...[/red]")
-                    await cleanup_screenshot_temp_files(meta)
-                    raise
-                except Exception as e:
-                    console.print(f"[red]Error during generic screenshot capture: {e}[/red]", highlight=False)
-                    await cleanup_screenshot_temp_files(meta)
-
-        except asyncio.CancelledError:
-            console.print("[red]Process was cancelled. Performing cleanup...[/red]")
-            await cleanup_screenshot_temp_files(meta)
-            raise
-        except Exception as e:
-            console.print(f"[red]Unexpected error occurred: {e}[/red]")
-            await cleanup_screenshot_temp_files(meta)
-        finally:
-            await asyncio.sleep(0.1)
-            await cleanup()
-            gc.collect()
-            reset_terminal()
-
-        meta['cutoff'] = int(config['DEFAULT'].get('cutoff_screens', 1))
-        if 'image_list' not in meta:
-            meta['image_list'] = []
-        if len(meta.get('image_list', [])) < meta.get('cutoff') and meta.get('skip_imghost_upload', False) is False:
-            return_dict = {}
-            try:
-                new_images, dummy_var = await upload_screens(
-                    meta, meta['screens'], 1, 0, meta['screens'], [], return_dict=return_dict
-                )
             except asyncio.CancelledError:
-                console.print("\n[red]Upload process interrupted! Cancelling tasks...[/red]")
-                return
+                console.print("[red]Process was cancelled. Performing cleanup...[/red]")
+                await cleanup_screenshot_temp_files(meta)
+                raise
             except Exception as e:
-                console.print(f"\n[red]Unexpected error during upload: {e}[/red]")
+                console.print(f"[red]Unexpected error occurred: {e}[/red]")
+                await cleanup_screenshot_temp_files(meta)
             finally:
-                reset_terminal()
-                console.print("[yellow]Cleaning up resources...[/yellow]")
+                await asyncio.sleep(0.1)
+                await cleanup()
                 gc.collect()
+                reset_terminal()
 
-        elif meta.get('skip_imghost_upload', False) is True and meta.get('image_list', False) is False:
-            meta['image_list'] = []
+            if 'image_list' not in meta:
+                meta['image_list'] = []
+            if len(meta.get('image_list', [])) < meta.get('cutoff') and meta.get('skip_imghost_upload', False) is False:
+                return_dict = {}
+                try:
+                    new_images, dummy_var = await upload_screens(
+                        meta, meta['screens'], 1, 0, meta['screens'], [], return_dict=return_dict
+                    )
+                except asyncio.CancelledError:
+                    console.print("\n[red]Upload process interrupted! Cancelling tasks...[/red]")
+                    return
+                except Exception as e:
+                    console.print(f"\n[red]Unexpected error during upload: {e}[/red]")
+                finally:
+                    reset_terminal()
+                    console.print("[yellow]Cleaning up resources...[/yellow]")
+                    gc.collect()
 
-        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
-            json.dump(meta, f, indent=4)
+            elif meta.get('skip_imghost_upload', False) is True and meta.get('image_list', False) is False:
+                meta['image_list'] = []
 
-        if 'image_list' in meta and meta['image_list']:
-            try:
-                image_data = {
-                    "image_list": meta.get('image_list', []),
-                    "image_sizes": meta.get('image_sizes', {})
-                }
+            with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", 'w') as f:
+                json.dump(meta, f, indent=4)
 
-                with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/image_data.json", 'w') as img_file:
-                    json.dump(image_data, img_file, indent=4)
+            if 'image_list' in meta and meta['image_list']:
+                try:
+                    image_data = {
+                        "image_list": meta.get('image_list', []),
+                        "image_sizes": meta.get('image_sizes', {})
+                    }
 
-                if meta.get('debug'):
-                    console.print(f"[cyan]Saved {len(meta['image_list'])} images to image_data.json")
-            except Exception as e:
-                console.print(f"[yellow]Failed to save image data: {str(e)}")
+                    with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/image_data.json", 'w') as img_file:
+                        json.dump(image_data, img_file, indent=4)
+
+                    if meta.get('debug'):
+                        console.print(f"[cyan]Saved {len(meta['image_list'])} images to image_data.json")
+                except Exception as e:
+                    console.print(f"[yellow]Failed to save image data: {str(e)}")
 
         if not meta['mkbrr']:
             meta['mkbrr'] = int(config['DEFAULT'].get('mkbrr', False))


### PR DESCRIPTION
~~Only PTP for now~~, see discussion in https://github.com/Audionut/Upload-Assistant/pull/485

I'm open to renaming or other handling of `-comps_index`

`py upload.py "path_to_movie" -comps "path_to_folder_containing_comparisons" -comps_index X` where X is the index of your upload.

As an example:
```
01-1-Source.png
02-1-Source.png
01-2-Filtered.png
02-2-Filtered.png
01-3-SoLaR.png
02-3-SoLaR.png
01-4-DON.png
02-4-DON.png
```

`-comps_index 3` would index the SoLaR images as the main images.

- [ ] HDB probably needs differing thumb size dependent on how many groups