### PR TITLE
CBR: Refactor get_audio function to handle multiple languages

### DIFF
--- a/src/trackers/CBR.py
+++ b/src/trackers/CBR.py
@@ -4,6 +4,7 @@ import asyncio
 import requests
 import platform
 import httpx
+import os
 import re
 from src.trackers.COMMON import COMMON
 from src.console import console
@@ -64,12 +65,61 @@ class CBR():
         }.get(resolution, '10')
         return resolution_id
 
+    def get_audio(self, meta):
+        if meta.get('is_disc') == "BDMV":
+            return ''
+
+        audio_languages = set()
+
+        base_dir = meta.get('base_dir', '.')
+        uuid = meta.get('uuid', 'default_uuid')
+        media_info_path = os.path.join(base_dir, 'tmp', uuid, 'MEDIAINFO.txt')
+
+        try:
+            if os.path.exists(media_info_path):
+                with open(media_info_path, 'r', encoding='utf-8') as f:
+                    media_info_text = f.read()
+
+                audio_sections = re.findall(
+                    r'Audio(?: #\d+)?\s*\n(.*?)(?=\n\n(?:Audio|Video|Text|Menu)|$)',
+                    media_info_text,
+                    re.DOTALL | re.IGNORECASE
+                )
+
+                for section in audio_sections:
+                    language_match = re.search(r'Language\s*:\s*(.+)', section, re.IGNORECASE)
+                    if language_match:
+                        lang_raw = language_match.group(1).strip()
+                        lang_clean = re.sub(r'[/\\].*|\(.*?\)', '', lang_raw).strip()
+                        if lang_clean.lower() not in ["unknown", "und"]:
+                            audio_languages.add(lang_clean.lower())
+
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            print(f"ERRO: Falha ao processar MediaInfo para verificar os idiomas nas faixas de áudio, não sendo possível determinar se é ou não DUAL/MULTI: {e}")
+
+        if len(audio_languages) == 2:
+            return ' DUAL'
+        elif len(audio_languages) >= 3:
+            return ' MULTI'
+        else:
+            return ''
+
     async def edit_name(self, meta):
         name = meta['name'].replace('DD+ ', 'DDP').replace('DD ', 'DD').replace('AAC ', 'AAC').replace('FLAC ', 'FLAC')
 
         cbr_name = name
         tag_lower = meta['tag'].lower()
         invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
+
+        audio_tag = self.get_audio(meta)
+        if audio_tag:
+            if '-' in cbr_name:
+                parts = cbr_name.rsplit('-', 1)
+                cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
+            else:
+                cbr_name += audio_tag
 
         if meta['tag'] == "" or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
             for invalid_tag in invalid_tags:


### PR DESCRIPTION
Detect and categorize audio languages as ` DUAL` (for 2 languages) or ` MULTI` (for 3 or more languages) based on the MEDIAINFO.txt