### PR TITLE
(Add) mod queue opt-in option to ULCX tracker

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -521,6 +521,7 @@ config = {
             "api_key": "ULCX api key",
             "announce_url": "https://upload.cx/announce/customannounceurl",
             # "anon" : False,
+            # "modq" : False,  # Send to modq for staff approval
         },
         # "UNIT3D_TEMPLATE": {
         #    "api_key": "UNIT3D_TEMPLATE api key",

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -65,6 +65,7 @@ class ULCX():
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)
         cat_id = await self.get_cat_id(meta['category'])
+        modq = await self.get_flag(meta, 'modq')
         type_id = await self.get_type_id(meta['type'])
         resolution_id = await self.get_res_id(meta['resolution'], meta['type'])
         await common.unit3d_edit_desc(meta, self.tracker, self.signature, comparison=True)
@@ -120,6 +121,7 @@ class ULCX():
             'featured': 0,
             'free': 0,
             'doubleup': 0,
+            'mod_queue_opt_in': modq,
             'sticky': 0,
         }
         # Internal
@@ -182,6 +184,13 @@ class ULCX():
                     distributor_id = "SKIPPED"
 
         return ulcx_name, region_id, distributor_id
+
+    async def get_flag(self, meta, flag_name):
+        config_flag = self.config['TRACKERS'][self.tracker].get(flag_name)
+        if config_flag is not None:
+            return 1 if config_flag else 0
+
+        return 1 if meta.get(flag_name, False) else 0
 
     async def search_existing(self, meta, disctype):
         if 'concert' in meta['keywords']:


### PR DESCRIPTION
Hopefully this could end up on more unit3d trackers soon but for now it's available here.