### PR TITLE
Additional bbcode editing on PTP/HDB/BHD/BLU

### DIFF
--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -224,6 +224,7 @@ class BHD():
 
     async def edit_desc(self, meta):
         base = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/DESCRIPTION.txt", 'r', encoding='utf-8').read()
+        base = base.replace("[user]", "").replace("[/user]", "")
         with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'w', encoding='utf-8') as desc:
             if meta.get('discs', []) != []:
                 discs = meta['discs']

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -51,7 +51,6 @@ class BLU():
         modq = await self.get_flag(meta, 'modq')
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        await self.edit_desc(meta)
         if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
             anon = 0
         else:
@@ -137,17 +136,6 @@ class BLU():
             console.print("[cyan]Request Data:")
             console.print(data)
         open_torrent.close()
-
-    async def edit_desc(self, meta):
-        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", encoding='utf-8') as descfile:
-            desc = descfile.read()
-            desc = desc.replace("[user]", "").replace("[/user]", "")
-            desc = desc.replace("[list]", "").replace("[/list]", "")
-            desc = desc.replace("[ul]", "").replace("[/ul]", "")
-            desc = desc.replace("[ol]", "").replace("[/ol]", "")
-        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'w', encoding='utf-8') as descfile:
-            descfile.write(desc)
-        return
 
     async def edit_name(self, meta):
         blu_name = meta['name']

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -51,6 +51,7 @@ class BLU():
         modq = await self.get_flag(meta, 'modq')
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
+        await self.edit_desc(meta)
         if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
             anon = 0
         else:
@@ -136,6 +137,17 @@ class BLU():
             console.print("[cyan]Request Data:")
             console.print(data)
         open_torrent.close()
+
+    async def edit_desc(self, meta):
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", encoding='utf-8') as descfile:
+            desc = descfile.read()
+            desc = desc.replace("[user]", "").replace("[/user]", "")
+            desc = desc.replace("[list]", "").replace("[/list]", "")
+            desc = desc.replace("[ul]", "").replace("[/ul]", "")
+            desc = desc.replace("[ol]", "").replace("[/ol]", "")
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'w', encoding='utf-8') as descfile:
+            descfile.write(desc)
+        return
 
     async def edit_name(self, meta):
         blu_name = meta['name']

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -171,6 +171,10 @@ class COMMON():
                     images = []
             desc = bbcode.convert_pre_to_code(desc)
             desc = bbcode.convert_hide_to_spoiler(desc)
+            desc = desc.replace("[user]", "").replace("[/user]", "")
+            desc = desc.replace("[list]", "").replace("[/list]", "")
+            desc = desc.replace("[ul]", "").replace("[/ul]", "")
+            desc = desc.replace("[ol]", "").replace("[/ol]", "")
             if comparison is False:
                 desc = bbcode.convert_comparison_to_collapse(desc, 1000)
             desc = desc.replace('[img]', '[img=300]')

--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -495,6 +495,11 @@ class HDB():
             desc = base
             # desc = bbcode.convert_code_to_quote(desc)
             desc = desc.replace("[code]", "[font=monospace]").replace("[/code]", "[/font]")
+            desc = desc.replace("[user]", "").replace("[/user]", "")
+            desc = desc.replace("[list]", "").replace("[/list]", "")
+            desc = desc.replace("[ul]", "").replace("[/ul]", "")
+            desc = desc.replace("[ol]", "").replace("[/ol]", "")
+            desc = desc.replace("[*]", "* ")
             desc = bbcode.convert_spoiler_to_hide(desc)
             desc = bbcode.convert_comparison_to_centered(desc, 1000)
             desc = re.sub(r"(\[img=\d+)]", "[img]", desc, flags=re.IGNORECASE)

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -652,6 +652,9 @@ class PTP():
         desc = desc.replace("[right]", "[align=right]").replace("[/right]", "[/align]")
         # desc = desc.replace("[code]", "[quote]").replace("[/code]", "[/quote]")
         desc = desc.replace("[h3]", "").replace("[/h3]", "")
+        desc = desc.replace("[list]", "").replace("[/list]", "")
+        desc = desc.replace("[ul]", "").replace("[/ul]", "")
+        desc = desc.replace("[ol]", "").replace("[/ol]", "")
         desc = re.sub(r"\[img=[^\]]+\]", "[img]", desc)
         return desc
 


### PR DESCRIPTION
When you do an encode, the general idea is now to have a folder with all the comps AND a generic description file using a superset of all the bbcodes formats. Then, you can upload to an arbitrary tracker and let UA do its magic in formatting both the description and the comparisons for the intended tracker.
This PR adds some bbcode formatting of a generic description file for PTP/HDB/BHD/BLU.
Tested with a generic description file and a comparison folder in debug mode on PTP/HDB/BHD/BLU.