### PR TITLE
Stop convert_comparison_to_centered to crush spaces in names

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -461,7 +461,8 @@ class BBCODE:
         for comp in comparisons:
             line = []
             output = []
-            comp_sources = comp.split(']', 1)[0].replace('[comparison=', '').replace(' ', '').split(',')
+            comp_sources = comp.split(']', 1)[0].replace('[comparison=', '').strip()
+            comp_sources = re.split(r"\s*,\s*", comp_sources)
             comp_images = comp.split(']', 1)[1].replace('[/comparison]', '').replace(',', '\n').replace(' ', '\n')
             comp_images = re.findall(r"(https?:\/\/.*\.(?:png|jpg))", comp_images, flags=re.IGNORECASE)
             screens_per_line = len(comp_sources)


### PR DESCRIPTION
Previously convert_comparison_to_centered was converting:
```
[comparison=    AUS spectrogram               ,         USA spectrogram            	]
```
(which is perfectly handled by PTP, for example)  into
```
[center]AUSspectrogram | USAspectrogram
```
With the submitted PR, inner spaces in names will now be preserved:
```
[center]AUS spectrogram | USA spectrogram
```
