### PR TITLE
tmdb from imdb updates

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -775,7 +775,8 @@ class Prep():
                     meta.get('search_year'),
                     filename,
                     debug=meta.get('debug', False),
-                    mode=meta.get('mode', 'discord')
+                    mode=meta.get('mode', 'discord'),
+                    category_preference=meta.get('category')
                 ),
                 search_tvmaze(
                     filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
@@ -1011,7 +1012,8 @@ class Prep():
                 meta.get('search_year'),
                 filename,
                 debug=meta.get('debug', False),
-                mode=meta.get('mode', 'discord')
+                mode=meta.get('mode', 'discord'),
+                category_preference=meta.get('category')
             )
 
             meta['category'] = category

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -16,7 +16,7 @@ TMDB_API_KEY = config['DEFAULT'].get('tmdb_api', False)
 TMDB_BASE_URL = "https://api.themoviedb.org/3"
 
 
-async def get_tmdb_from_imdb(imdb_id, tvdb_id=None, search_year=None, filename=None, debug=False, mode="discord"):
+async def get_tmdb_from_imdb(imdb_id, tvdb_id=None, search_year=None, filename=None, debug=False, mode="discord", category_preference=None):
     """Fetches TMDb ID using IMDb or TVDb ID.
 
     - Returns `(category, tmdb_id, original_language)`
@@ -42,24 +42,44 @@ async def get_tmdb_from_imdb(imdb_id, tvdb_id=None, search_year=None, filename=N
 
         return {}
 
-    # Search TMDb using IMDb ID
-    info = await _tmdb_find_by_external_source(imdb_id, "imdb_id")
-
-    if info.get("movie_results"):
-        return "MOVIE", info['movie_results'][0]['id'], info['movie_results'][0].get('original_language')
-
-    elif info.get("tv_results"):
-        return "TV", info['tv_results'][0]['id'], info['tv_results'][0].get('original_language')
-
-    console.print("[yellow]TMDb was unable to find anything with that IMDb ID, checking TVDb...")
-
-    # Check TVDb for an ID before falling back to searching IMDb
+    # Check TVDb for an ID first if present
     if tvdb_id:
         info_tvdb = await _tmdb_find_by_external_source(str(tvdb_id), "tvdb_id")
         if debug:
             console.print("TVDB INFO", info_tvdb)
         if info_tvdb.get("tv_results"):
             return "TV", info_tvdb['tv_results'][0]['id'], info_tvdb['tv_results'][0].get('original_language')
+
+    # Use IMDb ID if no TVDb ID is provided
+    info = await _tmdb_find_by_external_source(imdb_id, "imdb_id")
+
+    # Check if both movie and TV results exist
+    has_movie_results = bool(info.get("movie_results"))
+    has_tv_results = bool(info.get("tv_results"))
+
+    # If we have results in multiple categories but a category preference is set, respect that preference
+    if category_preference and has_movie_results and has_tv_results:
+        if category_preference == "MOVIE" and has_movie_results:
+            if debug:
+                console.print("[green]Found both movie and TV results, using movie based on preference")
+            return "MOVIE", info['movie_results'][0]['id'], info['movie_results'][0].get('original_language')
+        elif category_preference == "TV" and has_tv_results:
+            if debug:
+                console.print("[green]Found both movie and TV results, using TV based on preference")
+            return "TV", info['tv_results'][0]['id'], info['tv_results'][0].get('original_language')
+
+    # If no preference or preference doesn't match available results, proceed with normal logic
+    if has_movie_results:
+        if debug:
+            console.print("Movie INFO", info)
+        return "MOVIE", info['movie_results'][0]['id'], info['movie_results'][0].get('original_language')
+
+    elif has_tv_results:
+        if debug:
+            console.print("TV INFO", info)
+        return "TV", info['tv_results'][0]['id'], info['tv_results'][0].get('original_language')
+
+    console.print("[yellow]TMDb was unable to find anything with that IMDb ID, checking TVDb...")
 
     # If both TMDb and TVDb fail, fetch IMDb info and attempt a title search
     imdb_info = await get_imdb_info_api(imdb_id.replace('tt', ''), {})


### PR DESCRIPTION
I found an IMDB that was returning both movie and tv results. Why........

Changed the function to rely on tvdb id first, then use category.

Stops IMDB/TVDB from BTN becoming category `movie` with the wrong TMDB