### PR TITLE
Get edition from IMDB

### DIFF
--- a/src/edition.py
+++ b/src/edition.py
@@ -76,9 +76,9 @@ async def get_edition(video, bdinfo, filelist, manual_edition, meta):
 
             # Process the matched editions
             if matched_editions_with_attributes or matched_editions_without_attributes:
-                # Only use "Theatrical Edition" if we have at least one edition with attributes
+                # Only use "Theatrical" if we have at least one edition with attributes
                 if matched_editions_with_attributes and matched_editions_without_attributes:
-                    matched_editions = matched_editions_with_attributes + ["Theatrical Edition"]
+                    matched_editions = matched_editions_with_attributes + ["Theatrical"]
                     console.print("[cyan]Adding 'Theatrical Edition' label because we have both attribute and non-attribute editions[/cyan]")
                 else:
                     matched_editions = matched_editions_with_attributes
@@ -89,6 +89,9 @@ async def get_edition(video, bdinfo, filelist, manual_edition, meta):
                     # If multiple editions, prefix with count
                     if len(matched_editions) > 1:
                         unique_editions = list(set(matched_editions))  # Remove duplicates
+                        if "Theatrical" in unique_editions:
+                            unique_editions.remove("Theatrical")
+                            unique_editions = ["Theatrical"] + sorted(unique_editions)
                         if len(unique_editions) > 1:
                             edition = f"{len(unique_editions)}in1 " + " / ".join(unique_editions)
                         else:

--- a/src/imdb.py
+++ b/src/imdb.py
@@ -184,6 +184,22 @@ async def get_imdb_info_api(imdbID, manual_language=None, debug=False):
                 total
                 }}
             }}
+            runtimes(first: 10) {{
+                edges {{
+                    node {{
+                        id
+                        seconds
+                        displayableProperty {{
+                            value {{
+                                plainText
+                            }}
+                        }}
+                        attributes {{
+                            text
+                        }}
+                    }}
+                }}
+            }}
             akas(first: 100) {{
             edges {{
                 node {{
@@ -248,6 +264,37 @@ async def get_imdb_info_api(imdbID, manual_language=None, debug=False):
                     if name_id.startswith('nm'):
                         imdb_info['directors'].append(name_id)
                 break
+
+    editions = await safe_get(title_data, ['runtimes', 'edges'], [])
+    if editions:
+        edition_list = []
+        imdb_info['edition_details'] = {}
+
+        for edge in editions:
+            node = await safe_get(edge, ['node'], {})
+            seconds = await safe_get(node, ['seconds'], 0)
+            minutes = seconds // 60 if seconds else 0
+            displayable_property = await safe_get(node, ['displayableProperty', 'value', 'plainText'], '')
+            attributes = await safe_get(node, ['attributes'], [])
+            attribute_texts = [attr.get('text') for attr in attributes if isinstance(attr, dict)] if attributes else []
+
+            edition_display = f"{displayable_property} ({minutes} min)"
+            if attribute_texts:
+                edition_display += f" [{', '.join(attribute_texts)}]"
+
+            if seconds and displayable_property:
+                edition_list.append(edition_display)
+
+                runtime_key = str(minutes)
+                imdb_info['edition_details'][runtime_key] = {
+                    'display_name': displayable_property,
+                    'seconds': seconds,
+                    'minutes': minutes,
+                    'attributes': attribute_texts
+                }
+
+        imdb_info['editions'] = ', '.join(edition_list)
+        console.print(f"[yellow]Editions: {imdb_info['editions']}[/yellow]")
 
     akas_edges = await safe_get(title_data, ['akas', 'edges'], default=[])
     imdb_info['akas'] = [

--- a/src/prep.py
+++ b/src/prep.py
@@ -914,7 +914,7 @@ class Prep():
 
         # BDMV validation
         if meta['is_disc'] == "BDMV" and release_group:
-            if f"-{release_group}" not in video:
+            if f"{release_group}" not in video:
                 release_group = None
 
         # Format the tag


### PR DESCRIPTION
guessit, blessit, has always been useless for edition information for me.

This PR adds imdb edition information from the existing call, and matches runtime to set edition. Automagically because I'm lazy with args.
It should also automagically match all editions from multi-disc bdmv.

- [ ] tweak duration leway
- [ ] what to do when duration matches more than one edition