### PR TITLE
Add support for custom file extensions in torrent creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tmp/*
 .wdm/
 .DS_Store
 user-args.json
+venv/
+.venv/

--- a/src/args.py
+++ b/src/args.py
@@ -36,6 +36,7 @@ Common options:
   -t, --type                 Type (disc, remux, encode, webdl, etc.)
   --source                   Source (Blu-ray, BluRay, DVD, WEBDL, etc.)
   -comps, --comparison       Use comparison images from a folder (input folder path): see -comps_index
+  --include-extensions       Comma-separated list of additional file extensions to include in torrent (e.g., 'srt,sub,idx')
   -debug, --debug            Prints more information, runs everything without actually uploading
 
 Use --help for a full list of options.
@@ -167,6 +168,7 @@ class Args():
         parser.add_argument('-cleanup', '--cleanup', action='store_true', required=False, help="Clean up tmp directory")
         parser.add_argument('-fl', '--freeleech', nargs=1, required=False, help="Freeleech Percentage. Any value 1-100 works, but site search is limited to certain values", default=0, dest="freeleech")
         parser.add_argument('--infohash', nargs=1, required=False, help="V1 Info Hash")
+        parser.add_argument('--include-extensions', dest='include_extensions', nargs=1, required=False, help="Comma-separated list of additional file extensions to include in the torrent (e.g., 'srt,sub,idx')")
         args, before_args = parser.parse_known_args(input)
         args = vars(args)
         # console.print(args)


### PR DESCRIPTION
## Context
This PR follows up on #526, addressing the need to include additional media files (like subtitles and NFO files) when uploading folders. I know the original issue was closed, but this would improve the tool's features for trackers that require specific file types (some trackers for example require subtitles and not every time we see it included on the movie embbeded).

## Problem
Currently the upload assistant hardlinks everything on a folder, including already all the files on that folder, not only the media files. The problem is that some trackers have specific requirements:
- Some trackers require subtitle files (.srt) to be included
- Subtitles aren't always embedded in the media files
- Additional metadata files (like .nfo) might be needed sometimes

## Solution
This PR adds a new command-line argument `--include-extensions` that allows users to specify additional file extensions to include in the torrent creation process.

## Changes
1. Added new command-line argument:
   - `--include-extensions`: Accepts a comma-separated list of additional file extensions (e.g., 'srt,sub,idx'). Optional

2. Modified `torrentcreate.py`:
   - Enhanced file globbing to support custom extensions
   - Added support for including additional file types while maintaining existing functionality
   - Improved debug output to show include/exclude patterns
   - Maintained backward compatibility with existing behavior

3. Updated help documentation in `args.py` to reflect the new option


## Testing

Tested the command with:

```
matex@Mateus MINGW64 /d/Upload-Assistant (feat/addingin-include-extensions-param)
$ python upload.py "C:\Users\matex\Downloads\Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL" --debug
```

on a folder with three files

```
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        18/05/2025     12:42          28110 Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL.en.srt
-a----        24/02/2000     17:08      266317342 Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL.mkv
-a----        15/05/2025      1:11            937 Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL.nfo
```

It produced a .torrent with only the .mkv on it

![image](https://github.com/user-attachments/assets/06908ad3-df50-49a8-afe8-744f04480270)

![image](https://github.com/user-attachments/assets/25bea96e-27d9-416b-8760-0b7c98457f35)


After that, tested our new param:

```
python upload.py "C:\Users\matex\Downloads\Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL" --debug --include-extensions srt
```

It generated a BASE.torrent including only the .srt file (notice on the folder there was a .nfo as well

![image](https://github.com/user-attachments/assets/59e5dfba-b4b6-4c72-b625-877f847cf0f5)


Now, tested with .nfo and .srt

```
python upload.py "C:\Users\matex\Downloads\Love.Death.and.Robots.S04E01.1080p.WEB.h264-ETHEL" --debug --include-extensions srt,nfo
```

it generated the BASE.torrent inclusing all the three files on the folder

![image](https://github.com/user-attachments/assets/55003922-ddcd-4e17-9086-100346ef4519)
