### PR TITLE
Remove 'pyrobase' requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ anitopy
 cli-ui
 qbittorrent-api
 deluge-client
-pyrobase
 requests
 pyimgbox
 nest_asyncio

--- a/src/clients.py
+++ b/src/clients.py
@@ -7,7 +7,6 @@ import qbittorrentapi
 from deluge_client import DelugeRPCClient
 import transmission_rpc
 import base64
-from pyrobase.parts import Bunch
 import errno
 import asyncio
 import ssl
@@ -1110,10 +1109,10 @@ class Clients():
         if single:
             if os.path.isdir(datapath):
                 datapath = os.path.join(datapath, metainfo["info"]["name"])
-            files = [Bunch(
-                path=[os.path.abspath(datapath)],
-                length=metainfo["info"]["length"],
-            )]
+            files = [{
+                "path": [os.path.abspath(datapath)],
+                "length": metainfo["info"]["length"],
+            }]
 
         # Prepare resume data
         resume = metainfo.setdefault("libtorrent_resume", {})


### PR DESCRIPTION
It's used once, for what amounts to a glorified `dict` or `NamedTuple`.

Just use a `dict`...