### PR TITLE
refactor id handling

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -23,9 +23,10 @@ class ShortHelpFormatter(argparse.HelpFormatter):
         short_usage = "usage: upload.py [path...] [options]\n\n"
         short_options = """
 Common options:
-  -dm, --delete-meta         Deletes the cached meta file that stores arguments/processed data
   -tmdb, --tmdb              Specify the TMDb id to use with movie/ or tv/ prefix
   -imdb, --imdb              Specify the IMDb id to use
+  -tvmaze, --tvmaze          Specify the TVMaze id to use
+  -tvdb, --tvdb              Specify the TVDB id to use
   --queue (queue name)       Process an entire folder (including files/subfolders) in a queue
   -mf, --manual_frames       Comma-seperated list of frame numbers to use for screenshots
   -df, --descfile            Path to custom description file

--- a/src/imdb.py
+++ b/src/imdb.py
@@ -341,11 +341,12 @@ async def get_imdb_info_api(imdbID, manual_language=None, debug=False):
     return imdb_info
 
 
-async def search_imdb(filename, search_year):
+async def search_imdb(filename, search_year, quickie=False, category=None, debug=False):
     import re
     filename = re.sub(r'\s+[A-Z]{2}$', '', filename.strip())
-    console.print(f"[yellow]Searching IMDb (GraphQL) for {filename} and year {search_year}...[/yellow]")
-    imdbID = 0
+    if debug:
+        console.print(f"[yellow]Searching IMDb for {filename} and year {search_year}...[/yellow]")
+    imdbID = imdb_id = 0
     url = "https://api.graphql.imdb.com/"
     query = {
         "query": f"""
@@ -391,35 +392,56 @@ async def search_imdb(filename, search_year):
         return 0
 
     results = await safe_get(data, ["data", "advancedTitleSearch", "edges"], [])
-    console.print(f"[yellow]Found {len(results)} results...[/yellow]")
+    if debug:
+        console.print(f"[yellow]Found {len(results)} results...[/yellow]")
 
-    for idx, edge in enumerate(results):
-        node = await safe_get(edge, ["node"], {})
-        title = await safe_get(node, ["title"], {})
-        title_text = await safe_get(title, ["titleText", "text"], "")
-        year = await safe_get(title, ["releaseYear", "year"], None)
-        imdb_id = await safe_get(title, ["id"], "")
-        title_type = await safe_get(title, ["titleType", "text"], "")
-        plot = await safe_get(title, ["plot", "plotText", "plainText"], "")
+    if quickie:
+        if results:
+            first_result = results[0]
+            type = await safe_get(first_result, ["titleType"], "")
+            year = await safe_get(first_result, ["releaseYear", "year"], None)
+            if type and type.get("text").lower() == "tv series" and category and category.lower() == "tv":
+                imdb_id = await safe_get(first_result, ["node", "title", "id"], "")
+            elif type and type.get("text").lower() != "tv series" and category and category.lower() == "movie":
+                imdb_id = await safe_get(first_result, ["node", "title", "id"], "")
+            if imdb_id:
+                if year and search_year:
+                    if year != search_year:
+                        imdbID = 0
+                else:
+                    imdbID = int(imdb_id.replace('tt', '').strip())
+                    return imdbID
+            else:
+                imdbID = 0
+    else:
+        for idx, edge in enumerate(results):
+            node = await safe_get(edge, ["node"], {})
+            title = await safe_get(node, ["title"], {})
+            title_text = await safe_get(title, ["titleText", "text"], "")
+            year = await safe_get(title, ["releaseYear", "year"], None)
+            imdb_id = await safe_get(title, ["id"], "")
+            title_type = await safe_get(title, ["titleType", "text"], "")
+            plot = await safe_get(title, ["plot", "plotText", "plainText"], "")
 
-        console.print(f"[cyan]Result {idx+1}: {title_text} - ({year}) - {imdb_id} - Type: {title_type}[/cyan]")
-        if plot:
-            console.print(f"[green]Plot: {plot}[/green]")
+            console.print(f"[cyan]Result {idx+1}: {title_text} - ({year}) - {imdb_id} - Type: {title_type}[/cyan]")
+            if plot:
+                console.print(f"[green]Plot: {plot}[/green]")
 
-    if results:
-        console.print("[yellow]Enter the number of the correct entry, or 0 for none:[/yellow]")
-        try:
-            user_input = input("> ").strip()
-            if user_input.isdigit():
-                selection = int(user_input)
-                if 1 <= selection <= len(results):
-                    selected = results[selection - 1]
-                    imdb_id = await safe_get(selected, ["node", "title", "id"], "")
-                    if imdb_id:
-                        imdbID = int(imdb_id.replace('tt', '').strip())
-                        return imdbID
-                # If 0 or invalid, fall through to return imdbID = 0
-        except Exception as e:
-            console.print(f"[red]Error reading input: {e}[/red]")
+        if results:
+            console.print("[yellow]Enter the number of the correct entry, or 0 for none:[/yellow]")
+            try:
+                user_input = input("> ").strip()
+                if user_input.isdigit():
+                    selection = int(user_input)
+                    if 1 <= selection <= len(results):
+                        selected = results[selection - 1]
+                        imdb_id = await safe_get(selected, ["node", "title", "id"], "")
+                        if imdb_id:
+                            imdbID = int(imdb_id.replace('tt', '').strip())
+                            return imdbID
+
+            except Exception as e:
+                console.print(f"[red]Error reading input: {e}[/red]")
+                imdb_id = 0
 
     return imdbID

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -639,7 +639,7 @@ async def imdb_tmdb(meta, filename):
 
 async def get_tv_data(meta, base_dir, tvdb_api=None, tvdb_token=None):
     if not meta.get('tv_pack', False) and meta.get('episode_int') != 0:
-        if not meta.get('auto_episode_title') or not meta.get('overview_meta') or meta.get('original_language') != "en":
+        if not meta.get('auto_episode_title') or not meta.get('overview_meta'):
             # prioritze tvdb metadata if available
             if tvdb_api and tvdb_token and not meta.get('we_checked_tvdb', False):
                 if meta['debug']:
@@ -690,7 +690,7 @@ async def get_tv_data(meta, base_dir, tvdb_api=None, tvdb_token=None):
                             meta['search_year'] = ""
 
             # fallback to tvmaze data if tvdb data is available
-            if meta.get('auto_episode_title') is None or meta.get('overview_meta') is None and not meta.get('we_asked_tvmaze', False):
+            if meta.get('auto_episode_title') is None or meta.get('overview_meta') is None and (not meta.get('we_asked_tvmaze', False) and meta.get('episode_overview', None)):
                 tvmaze_episode_data = await get_tvmaze_episode_data(meta.get('tvmaze_id'), meta.get('season_int'), meta.get('episode_int'))
                 if tvmaze_episode_data:
                     meta['tvmaze_episode_data'] = tvmaze_episode_data
@@ -703,7 +703,7 @@ async def get_tv_data(meta, base_dir, tvdb_api=None, tvdb_token=None):
                         meta['overview_meta'] = tvmaze_episode_data.get('overview', None)
 
             # fallback to tmdb data if no other data is not available
-            if (meta.get('auto_episode_title') is None or meta.get('overview_meta') is None):
+            if (meta.get('auto_episode_title') is None or meta.get('overview_meta') is None) and (not meta.get('we_checked_tmdb', False) and meta.get('episode_overview', None)):
                 if 'tvdb_episode_int' in meta and meta.get('tvdb_episode_int') != 0 and meta.get('tvdb_episode_int') != meta.get('episode_int'):
                     episode = meta.get('episode_int')
                     season = meta.get('tvdb_season_int')

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -619,11 +619,25 @@ async def imdb_tmdb(meta, filename):
     if meta['category'] == 'TV':
         if len(results) > 2:
             tvmaze_result = results[2]
-            if isinstance(tvmaze_result, int):
+            if isinstance(tvmaze_result, tuple) and len(tvmaze_result) == 3:
+                # Handle tuple return: (tvmaze_id, imdbID, tvdbID)
+                tvmaze_id, imdb_id, tvdb_id = tvmaze_result
+                meta['tvmaze_id'] = tvmaze_id if isinstance(tvmaze_id, int) else 0
+
+                # Set tvdb_id if not already set and we got a valid one
+                if not meta.get('tvdb_id', 0) and isinstance(tvdb_id, int) and tvdb_id > 0:
+                    meta['tvdb_id'] = tvdb_id
+                    if meta.get('debug'):
+                        console.print(f"[green]Set TVDb ID from TVMaze: {tvdb_id}[/green]")
+
+            elif isinstance(tvmaze_result, int):
                 meta['tvmaze_id'] = tvmaze_result
             elif isinstance(tvmaze_result, Exception):
                 console.print(f"[red]TVMaze API call failed: {tvmaze_result}[/red]")
                 meta['tvmaze_id'] = 0  # Set default value if an exception occurred
+            else:
+                console.print(f"[yellow]Unexpected TVMaze result type: {type(tvmaze_result)}[/yellow]")
+                meta['tvmaze_id'] = 0
 
         # Process TMDb episode details if they were included
         if len(results) > 3:

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -548,7 +548,8 @@ async def imdb_tmdb(meta, filename):
             poster=meta.get('poster'),
             debug=meta.get('debug', False),
             mode=meta.get('mode', 'cli'),
-            tvdb_id=meta.get('tvdb_id', 0)
+            tvdb_id=meta.get('tvdb_id', 0),
+            quickie_search=meta.get('quickie_search', False)
         ),
         get_imdb_info_api(
             meta['imdb_id'],

--- a/src/prep.py
+++ b/src/prep.py
@@ -609,7 +609,8 @@ class Prep():
             meta['imdb_id'] = await search_imdb(filename, meta['search_year'], quickie=False, category=meta.get('category', None), debug=meta.get('debug', False))
 
         # Ensure IMDb info is retrieved if it wasn't already fetched
-        if meta.get('imdb_info', None) is None and int(meta['imdb_id']) != 0:
+        # rerun if imdb_mismatch, since it means tmdb return and quickie search did not match and we'll prefer tmdb return
+        if (meta.get('imdb_info', None) is None and int(meta['imdb_id']) != 0) or meta.get('imdb_mismatch'):
             imdb_info = await get_imdb_info_api(meta['imdb_id'], manual_language=meta.get('manual_language'), debug=meta.get('debug', False))
             meta['imdb_info'] = imdb_info
             meta['tv_year'] = imdb_info.get('tv_year', None)

--- a/src/prep.py
+++ b/src/prep.py
@@ -526,6 +526,7 @@ class Prep():
             meta['category'] = category
             meta['tmdb_id'] = int(tmdb_id)
             meta['imdb_id'] = int(imdb_result)
+            meta['quickie_search'] = True
 
         # If we have an IMDb ID but no TMDb ID, fetch TMDb ID from IMDb
         elif meta.get('imdb_id') != 0 and meta.get('tmdb_id') == 0:

--- a/src/prep.py
+++ b/src/prep.py
@@ -26,6 +26,7 @@ try:
     import traceback
     import os
     import re
+    import asyncio
     from guessit import guessit
     import ntpath
     from pathlib import Path
@@ -510,31 +511,21 @@ class Prep():
         if meta.get("not_anime", False) and meta.get("category") == "TV":
             meta = await get_season_episode(video, meta)
 
-        # if we have all of the ids, search everything all at once
-        if int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0 and int(meta['tmdb_id']) != 0 and int(meta['tvmaze_id']) != 0:
-            meta = await all_ids(meta, tvdb_api, tvdb_token)
-
-        # Check if IMDb, TMDb, and TVDb IDs are all present
-        elif int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0 and int(meta['tmdb_id']) != 0:
-            meta = await imdb_tmdb_tvdb(meta, filename, tvdb_api, tvdb_token)
-
-        # Check if both IMDb and TVDB IDs are present
-        elif int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0:
-            meta = await imdb_tvdb(meta, filename, tvdb_api, tvdb_token)
-
-        # Check if both IMDb and TMDb IDs are present
-        elif int(meta['imdb_id']) != 0 and int(meta['tmdb_id']) != 0:
-            meta = await imdb_tmdb(meta, filename)
-
-        # Get TMDB and IMDb metadata only if IDs are still missing, first checking mediainfo
+        # Run a check against mediainfo to see if it has tmdb/imdb
         if meta.get('tmdb_id') == 0 and meta.get('imdb_id') == 0:
             meta['category'], meta['tmdb_id'], meta['imdb_id'] = await get_tmdb_imdb_from_mediainfo(
                 mi, meta['category'], meta['is_disc'], meta['tmdb_id'], meta['imdb_id']
             )
 
-        # if we're still missing both ids, lets search with the filename
+        # run a search to find tmdb and imdb ids if we don't have them
         if meta.get('tmdb_id') == 0 and meta.get('imdb_id') == 0:
-            meta = await get_tmdb_id(filename, meta['search_year'], meta, meta['category'], untouched_filename)
+            tmdb_task = get_tmdb_id(filename, meta.get('search_year', ''), meta.get('category', None), untouched_filename, attempted=0, debug=meta['debug'], secondary_title=secondary_title)
+            imdb_task = search_imdb(filename, meta.get('search_year', ''), quickie=True, category=meta.get('category', None), debug=meta['debug'])
+            tmdb_result, imdb_result = await asyncio.gather(tmdb_task, imdb_task)
+            tmdb_id, category = tmdb_result
+            meta['category'] = category
+            meta['tmdb_id'] = int(tmdb_id)
+            meta['imdb_id'] = int(imdb_result)
 
         # If we have an IMDb ID but no TMDb ID, fetch TMDb ID from IMDb
         elif meta.get('imdb_id') != 0 and meta.get('tmdb_id') == 0:
@@ -551,6 +542,22 @@ class Prep():
             meta['category'] = category
             meta['tmdb_id'] = int(tmdb_id)
             meta['original_language'] = original_language
+
+        # if we have all of the ids, search everything all at once
+        if int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0 and int(meta['tmdb_id']) != 0 and int(meta['tvmaze_id']) != 0:
+            meta = await all_ids(meta, tvdb_api, tvdb_token)
+
+        # Check if IMDb, TMDb, and TVDb IDs are all present
+        elif int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0 and int(meta['tmdb_id']) != 0:
+            meta = await imdb_tmdb_tvdb(meta, filename, tvdb_api, tvdb_token)
+
+        # Check if both IMDb and TVDB IDs are present
+        elif int(meta['imdb_id']) != 0 and int(meta['tvdb_id']) != 0:
+            meta = await imdb_tvdb(meta, filename, tvdb_api, tvdb_token)
+
+        # Check if both IMDb and TMDb IDs are present
+        elif int(meta['imdb_id']) != 0 and int(meta['tmdb_id']) != 0:
+            meta = await imdb_tmdb(meta, filename)
 
         # we have tmdb id one way or another, so lets get data if needed
         if int(meta['tmdb_id']) != 0:
@@ -596,23 +603,9 @@ class Prep():
                     console.print(f"[bold red]{error_msg}[/bold red]")
                     raise RuntimeError(error_msg) from e
 
-        # Search TVMaze only if it's a TV category and tvmaze_id is still missing
-        if meta['category'] == "TV":
-            if meta.get('tvmaze_id', 0) == 0:
-                meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await search_tvmaze(
-                    filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
-                    manual_date=meta.get('manual_date'),
-                    tvmaze_manual=meta.get('tvmaze_manual'),
-                    debug=meta.get('debug', False),
-                    return_full_tuple=True
-                )
-        else:
-            meta.setdefault('tvmaze_id', 0)
-
-        # If we got to here and still no IMDb ID, search for it
-        # bad filenames are bad
+        # if the quickie search and tmdb return didn't yield an IMDb ID, try again with prompts
         if meta.get('imdb_id') == 0:
-            meta['imdb_id'] = await search_imdb(filename, meta['search_year'])
+            meta['imdb_id'] = await search_imdb(filename, meta['search_year'], quickie=False, category=meta.get('category', None), debug=meta.get('debug', False))
 
         # Ensure IMDb info is retrieved if it wasn't already fetched
         if meta.get('imdb_info', None) is None and int(meta['imdb_id']) != 0:
@@ -641,6 +634,16 @@ class Prep():
             meta['aka'] = ""
 
         if meta['category'] == "TV":
+            if meta.get('tvmaze_id', 0) == 0:
+                meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await search_tvmaze(
+                    filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
+                    manual_date=meta.get('manual_date'),
+                    tvmaze_manual=meta.get('tvmaze_manual'),
+                    debug=meta.get('debug', False),
+                    return_full_tuple=True
+                )
+            else:
+                meta.setdefault('tvmaze_id', 0)
             # if it was skipped earlier, make sure we have the season/episode data
             if not meta.get('not_anime', False):
                 meta = await get_season_episode(video, meta)

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1,5 +1,5 @@
 from src.console import console
-from src.imdb import get_imdb_aka_api, get_imdb_info_api, search_imdb
+from src.imdb import get_imdb_aka_api, get_imdb_info_api
 from src.args import Args
 from data.config import config
 import re
@@ -131,10 +131,7 @@ async def get_tmdb_from_imdb(imdb_id, tvdb_id=None, search_year=None, filename=N
     return category, tmdb_id, original_language
 
 
-async def get_tmdb_id(filename, search_year, meta, category, untouched_filename="", attempted=0):
-    if meta['debug']:
-        console.print("[bold cyan]Fetching TMDB ID...[/bold cyan]")
-
+async def get_tmdb_id(filename, search_year, category, untouched_filename="", attempted=0, debug=False, secondary_title=None):
     search_results = {"results": []}
     secondary_results = {"results": []}
 
@@ -142,7 +139,7 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
         try:
             # Primary search attempt with year
             if category == "MOVIE":
-                if meta.get('debug', False):
+                if debug:
                     console.print(f"[green]Searching TMDb for movie:[/] [cyan]{filename}[/cyan] (Year: {search_year})")
 
                 params = {
@@ -160,11 +157,10 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                     response.raise_for_status()
                     search_results = response.json()
                 except Exception:
-                    console.print(f"[bold red]Failed to fetch movie data: {response.status_code}[/bold red]")
-                    return meta
+                    console.print(f"[bold red]Failure with primary movie search: {response.status_code}[/bold red]")
 
             elif category == "TV":
-                if meta.get('debug', False):
+                if debug:
                     console.print(f"[green]Searching TMDb for TV show:[/] [cyan]{filename}[/cyan] (Year: {search_year})")
 
                 params = {
@@ -182,31 +178,32 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                     response.raise_for_status()
                     search_results = response.json()
                 except Exception:
-                    console.print(f"[bold red]Failed to fetch TV data: {response.status_code}[/bold red]")
-                    return meta
+                    console.print(f"[bold red]Failed with primary TV search: {response.status_code}[/bold red]")
 
-            if meta.get('debug', False):
+            if debug:
                 console.print(f"[yellow]Search results (primary): {json.dumps(search_results.get('results', [])[:2], indent=2)}[/yellow]")
 
             # Check if results were found
             if search_results.get('results'):
-                meta['tmdb_id'] = search_results['results'][0]['id']
-                return meta
+                tmdb_id = search_results['results'][0]['id']
+                return tmdb_id, category
 
             # If no results and we have a secondary title, try searching with that
-            if not search_results.get('results') and meta.get('secondary_title') and attempted < 3:
-                console.print(f"[yellow]No results found for primary title. Trying secondary title: {meta['secondary_title']}[/yellow]")
+            if not search_results.get('results') and secondary_title and attempted < 3:
+                console.print(f"[yellow]No results found for primary title. Trying secondary title: {secondary_title}[/yellow]")
                 secondary_meta = await get_tmdb_id(
-                    meta['secondary_title'],
+                    secondary_title,
                     search_year,
-                    meta,
                     category,
                     untouched_filename,
-                    attempted + 1
+                    attempted + 1,
+                    debug=debug,
+                    secondary_title=secondary_title
                 )
 
                 if secondary_meta.get('tmdb_id', 0) != 0:
-                    return secondary_meta
+                    tmdb_id = secondary_meta['tmdb_id']
+                    return tmdb_id, category
 
         except Exception as e:
             console.print(f"[bold red]TMDb search error:[/bold red] {e}")
@@ -216,7 +213,7 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
         console.print("[yellow]Retrying without year...[/yellow]")
         try:
             if category == "MOVIE":
-                if meta.get('debug', False):
+                if debug:
                     console.print(f"[green]Searching TMDb for movie:[/] [cyan]{filename}[/cyan] (Without year)")
 
                 params = {
@@ -231,11 +228,10 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                     response.raise_for_status()
                     search_results = response.json()
                 except Exception:
-                    console.print(f"[bold red]Failed to fetch movie data: {response.status_code}[/bold red]")
-                    return meta
+                    console.print(f"[bold red]Failed with secondary movie search: {response.status_code}[/bold red]")
 
             elif category == "TV":
-                if meta.get('debug', False):
+                if debug:
                     console.print(f"[green]Searching TMDb for TV show:[/] [cyan]{filename}[/cyan] (Without year)")
 
                 params = {
@@ -250,28 +246,27 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                     response.raise_for_status()
                     search_results = response.json()
                 except Exception:
-                    console.print(f"[bold red]Failed to fetch TV data: {response.status_code}[/bold red]")
-                    return meta
+                    console.print(f"[bold red]Failed secondary TV search: {response.status_code}[/bold red]")
 
-            if meta.get('debug', False):
+            if debug:
                 console.print(f"[yellow]Search results (secondary): {json.dumps(search_results.get('results', [])[:2], indent=2)}[/yellow]")
 
             # Check if results were found
             if search_results.get('results'):
-                meta['tmdb_id'] = search_results['results'][0]['id']
-                return meta
+                tmdb_id = search_results['results'][0]['id']
+                return tmdb_id, category
 
             # Try with secondary title without year
-            if not search_results.get('results') and meta.get('secondary_title') and attempted < 3:
-                console.print(f"[yellow]No results found for primary title without year. Trying secondary title: {meta['secondary_title']}[/yellow]")
+            if not search_results.get('results') and secondary_title and attempted < 3:
+                console.print(f"[yellow]No results found for primary title without year. Trying secondary title: {secondary_title}[/yellow]")
 
                 if category == "MOVIE":
-                    if meta.get('debug', False):
-                        console.print(f"[green]Searching TMDb for movie with secondary title:[/] [cyan]{meta['secondary_title']}[/cyan] (Without year)")
+                    if debug:
+                        console.print(f"[green]Searching TMDb for movie with secondary title:[/] [cyan]{secondary_title}[/cyan] (Without year)")
 
                     params = {
                         "api_key": TMDB_API_KEY,
-                        "query": meta['secondary_title'],
+                        "query": secondary_title,
                         "language": "en-US",
                         "include_adult": "true"
                     }
@@ -281,16 +276,15 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                         response.raise_for_status()
                         secondary_results = response.json()
                     except Exception:
-                        console.print(f"[bold red]Failed to fetch movie data: {response.status_code}[/bold red]")
-                        return meta
+                        console.print(f"[bold red]Failed with secondary title movie search: {response.status_code}[/bold red]")
 
                 elif category == "TV":
-                    if meta.get('debug', False):
-                        console.print(f"[green]Searching TMDb for TV show with secondary title:[/] [cyan]{meta['secondary_title']}[/cyan] (Without year)")
+                    if debug:
+                        console.print(f"[green]Searching TMDb for TV show with secondary title:[/] [cyan]{secondary_title}[/cyan] (Without year)")
 
                     params = {
                         "api_key": TMDB_API_KEY,
-                        "query": meta['secondary_title'],
+                        "query": secondary_title,
                         "language": "en-US",
                         "include_adult": "true"
                     }
@@ -300,16 +294,14 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                         response.raise_for_status()
                         secondary_results = response.json()
                     except Exception:
-                        console.print(f"[bold red]Failed to fetch TV data: {response.status_code}[/bold red]")
-                        return meta
+                        console.print(f"[bold red]Failed with secondary title TV search: {response.status_code}[/bold red]")
 
-                if meta.get('debug', False):
+                if debug:
                     console.print(f"[yellow]Secondary title search results: {json.dumps(secondary_results.get('results', [])[:2], indent=2)}[/yellow]")
 
                 if secondary_results.get('results'):
-                    meta['tmdb_id'] = secondary_results['results'][0]['id']
-                    console.print(f"[green]Found match using secondary title: {meta['secondary_title']}[/green]")
-                    return meta
+                    tmdb_id = secondary_results['results'][0]['id']
+                    return tmdb_id, category
 
         except Exception as e:
             console.print(f"[bold red]Secondary search error:[/bold red] {e}")
@@ -318,7 +310,7 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
         if attempted < 1:
             new_category = "TV" if category == "MOVIE" else "MOVIE"
             console.print(f"[bold yellow]Switching category to {new_category} and retrying...[/bold yellow]")
-            return await get_tmdb_id(filename, search_year, meta, new_category, untouched_filename, attempted + 1)
+            return await get_tmdb_id(filename, search_year, new_category, untouched_filename, attempted + 1, debug=debug, secondary_title=secondary_title)
 
         # Last attempt: Try parsing a better title
         if attempted == 1:
@@ -327,38 +319,18 @@ async def get_tmdb_id(filename, search_year, meta, category, untouched_filename=
                     guessit(untouched_filename, {"excludes": ["country", "language"]})['title']
                 )['anime_title']
                 console.print(f"[bold yellow]Trying parsed title: {parsed_title}[/bold yellow]")
-                return await get_tmdb_id(parsed_title, search_year, meta, meta['category'], untouched_filename, attempted + 2)
+                return await get_tmdb_id(parsed_title, search_year, category, untouched_filename, attempted + 2, debug=debug, secondary_title=secondary_title)
             except KeyError:
                 console.print("[bold red]Failed to parse title for TMDb search.[/bold red]")
 
         # No match found, prompt user if in CLI mode
         console.print(f"[bold red]Unable to find TMDb match for {filename}[/bold red]")
 
-        meta['imdb_id'] = await search_imdb(filename, meta['search_year'])
-        console.print(f"[yellow]IMDB ID: {meta['imdb_id']}[/yellow]")
-        if meta['imdb_id'] != 0:
-            category, tmdb_id, original_language = await get_tmdb_from_imdb(
-                meta['imdb_id'],
-                meta.get('tvdb_id'),
-                meta.get('search_year'),
-                filename,
-                debug=meta.get('debug', False),
-                mode=meta.get('mode', 'discord'),
-                category_preference=meta.get('category')
-            )
-            if tmdb_id != 0:
-                meta['tmdb_id'] = tmdb_id
-                meta['category'] = category
-                meta['original_language'] = original_language
-                return meta
+        tmdb_id = cli_ui.ask_string("Please enter TMDb ID in this format: tv/12345 or movie/12345")
+        parser = Args(config=config)
+        category, tmdb_id = parser.parse_tmdb_id(id=tmdb_id, category=category)
 
-        if meta.get('mode', 'discord') == 'cli':
-            tmdb_id = cli_ui.ask_string("Please enter TMDb ID in this format: tv/12345 or movie/12345")
-            parser = Args(config=config)
-            meta['category'], meta['tmdb_id'] = parser.parse_tmdb_id(id=tmdb_id, category=meta.get('category'))
-            meta['tmdb_manual'] = meta['tmdb_id']
-
-        return meta
+        return tmdb_id, category
 
 
 async def tmdb_other_meta(
@@ -465,6 +437,9 @@ async def tmdb_other_meta(
             original_title = media_data.get('original_title', title)
             year = datetime.strptime(media_data['release_date'], '%Y-%m-%d').year if media_data['release_date'] else search_year
             runtime = media_data.get('runtime', 60)
+            if not imdb_id:
+                imdb_id_str = str(media_data.get('imdb_id', '')).replace('tt', '')
+                imdb_id = int(imdb_id_str) if imdb_id_str.isdigit() else 0
             tmdb_type = 'Movie'
         else:  # TV show
             title = media_data['name']
@@ -639,7 +614,7 @@ async def tmdb_other_meta(
     # Check if AKA is too similar to title and clear it if needed
     if retrieved_aka:
         difference = SequenceMatcher(None, title.lower(), retrieved_aka[5:].lower()).ratio()
-        if difference >= 0.9 or retrieved_aka[5:].strip() == "" or retrieved_aka[5:].strip().lower() in title.lower():
+        if difference >= 0.7 or retrieved_aka[5:].strip() == "" or retrieved_aka[5:].strip().lower() in title.lower():
             retrieved_aka = ""
         if year and f"({year})" in retrieved_aka:
             retrieved_aka = retrieved_aka.replace(f"({year})", "").strip()

--- a/src/tvmaze.py
+++ b/src/tvmaze.py
@@ -109,6 +109,12 @@ async def search_tvmaze(filename, year, imdbID, tvdbID, manual_date=None, tvmaze
         if debug:
             console.print(f"[cyan]Automatically selected show: {selected_show.get('name')} (TVmaze ID: {tvmaze_id})[/cyan]")
 
+    if 'externals' in selected_show:
+        if 'thetvdb' in selected_show['externals'] and not tvdbID:
+            tvdbID = selected_show['externals']['thetvdb']
+            if tvdbID:
+                tvdbID = int(tvdbID)
+                return_full_tuple = True
     if debug:
         console.print(f"[cyan]Returning TVmaze ID: {tvmaze_id} (type: {type(tvmaze_id).__name__}), IMDb ID: {imdbID} (type: {type(imdbID).__name__}), TVDB ID: {tvdbID} (type: {type(tvdbID).__name__})[/cyan]")
 

--- a/src/tvmaze.py
+++ b/src/tvmaze.py
@@ -9,6 +9,8 @@ async def search_tvmaze(filename, year, imdbID, tvdbID, manual_date=None, tvmaze
     - If `return_full_tuple=True`, returns `(tvmaze_id, imdbID, tvdbID)`.
     - Otherwise, only returns `tvmaze_id`.
     """
+    if debug:
+        console.print(f"[cyan]Searching TVMaze for TVDB {tvdbID} or IMDB {imdbID} or {filename} ({year})[/cyan]")
     # Convert TVDB ID to integer
     try:
         tvdbID = int(tvdbID) if tvdbID not in (None, '', '0') else 0


### PR DESCRIPTION
When no imdb/tmdb input, attempts to grab that data before the concurrent retrieval functions. Doesn't save as much time as I was hoping, but a noticeable effect in any event.

Put the episode data retrieval behind the `episode_overview` config, since if False, that data is not needed and just slows the process. TVDB is unaffected if the keys are present, since that provides other benefits.

Don't return early if there is a TMDB lookup error, try the other methods instead.