### PR TITLE
Set default value for FrameRate

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -169,7 +169,7 @@ async def get_resolution(guess, folder_id, base_dir):
         except Exception:
             width = 0
             height = 0
-        framerate = mi['media']['track'][1].get('FrameRate', '')
+        framerate = mi['media']['track'][1].get('FrameRate', '24')
         if int(float(framerate)) > 30:
             hfr = True
         try:


### PR DESCRIPTION
If you have another suggested value different than 24 pls let me know.
Fails due to empty string casting to int


error logs:

```

Gathering info for Dragon Knight 4
Error in gather_prep: list index out of range
Traceback (most recent call last):
  File "/Upload-Assistant/upload.py", line 97, in process_meta
    meta = await prep.gather_prep(meta=meta, mode='cli')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Upload-Assistant/src/prep.py", line 277, in gather_prep
    meta['resolution'], meta['hfr'] = await get_resolution(guessit(video), meta['uuid'], base_dir)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Upload-Assistant/src/video.py", line 172, in get_resolution
    framerate = mi['media']['track'][1].get('FrameRate', '')
                ~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range

we are not uploading.......

```