### PR TITLE
Fix: Subtitle language check ignores English (DP)

### DIFF
--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -238,7 +238,7 @@ class DP():
                     has_nordic_sub = False
                     for language in subtitle_section:
                         language = language.lower().strip()
-                        if language in (nordic_languages or english_languages):
+                        if language in (nordic_languages + english_languages):
                             has_nordic_sub = True
                             break
 


### PR DESCRIPTION
replaces the `or` operator with the `+` operator to properly combine the two lists before checking for membership.