### PR TITLE
Explicitly restore backspace character (^H)

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -388,6 +388,7 @@ def reset_terminal():
         if hasattr(sys.stdin, 'isatty') and sys.stdin.isatty() and not sys.stdin.closed:
             try:
                 subprocess.run(["stty", "sane"], check=False)
+                subprocess.run(["stty", "erase", "^H"], check=False) # explicitly restore backspace character
                 if hasattr(termios, 'tcflush'):
                     termios.tcflush(sys.stdin.fileno(), termios.TCIOFLUSH)
                 subprocess.run(["stty", "-ixon"], check=False)

--- a/upload.py
+++ b/upload.py
@@ -388,7 +388,7 @@ def reset_terminal():
         if hasattr(sys.stdin, 'isatty') and sys.stdin.isatty() and not sys.stdin.closed:
             try:
                 subprocess.run(["stty", "sane"], check=False)
-                subprocess.run(["stty", "erase", "^H"], check=False) # explicitly restore backspace character
+                subprocess.run(["stty", "erase", "^H"], check=False)  # explicitly restore backspace character
                 if hasattr(termios, 'tcflush'):
                     termios.tcflush(sys.stdin.fileno(), termios.TCIOFLUSH)
                 subprocess.run(["stty", "-ixon"], check=False)


### PR DESCRIPTION
My backspace just breaks/stopped working after running UA. This has been going on for a while but I got some free time to look into this. 

My current terminal has this:
```
$ stty -a
...
intr = ^C; quit = ^\; erase = ^H;
...
```
after running `upload.py`, the output changed to this (note `erase`):
```
$ stty -a
...
intr = ^C; quit = ^\; erase = ^?;
...
```
UA somehow changed my `erase` key to `^?` and `stty sane` restored it to default correctly, but it does not stick, pressing `backspace` and I'll get `^H` in my terminal again. By explicitly forcing it and set it to `^H`, the config stuck and backspace behavior was returned to normal. Also works on Windows (try typing Ctrl + H in `cmd`, it will do backspace).