### PR TITLE
is_scene - Fix crash when is_all_lowercase is not defined

### DIFF
--- a/src/is_scene.py
+++ b/src/is_scene.py
@@ -7,6 +7,7 @@ from src.console import console
 
 async def is_scene(video, meta, imdb=None, lower=False):
     scene = False
+    is_all_lowercase = False
     base = os.path.basename(video)
     match = re.match(r"^(.+)\.[a-zA-Z0-9]{3}$", os.path.basename(video))
 


### PR DESCRIPTION
Fixes a bug that caused a crash in the `is_scene` function.

The `is_all_lowercase` variable was not being initialized if the input filename didn't have an extension, causing an `UnboundLocalError`.

I've initialized it to `False` at the start of the function to prevent this.