### PR TITLE
ASC - changes and fixes

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -291,6 +291,7 @@ config = {
             "link_dir_name": "",
             # Set uploader_status to True if you have uploader permissions to automatically approve your uploads
             "uploader_status": False,
+            # anon is not an option when uploading to ASC
             # for ASC to work you need to export cookies from https://cliente.amigos-share.club/ using https://addons.mozilla.org/en-US/firefox/addon/export-cookies-txt/
             # cookies need to be in netscape format and need to be in data/cookies/ASC.txt
             "announce_url": "https://amigos-share.club/announce.php?passkey=PASSKEY",

--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -3,7 +3,6 @@ import os
 import re
 import requests
 import cli_ui
-import unicodedata
 from datetime import datetime
 from src.exceptions import UploadException
 from bs4 import BeautifulSoup

--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -3,6 +3,7 @@ import os
 import re
 import requests
 import cli_ui
+import unicodedata
 from datetime import datetime
 from src.exceptions import UploadException
 from bs4 import BeautifulSoup
@@ -456,19 +457,28 @@ class ASC(COMMON):
             if poster_path:
                 data['capa'] = poster_path
 
-            # Name
-            nome_base = asc_data.get('Title') if asc_data and asc_data.get('Title') else self.get_title(meta)
+            # Title
+            # The site database is incompatible with non-ASCII characters in the title
+            def is_safe_ascii(text):
+                if not text:
+                    return False
+                return bool(re.match(r'^[ -~]+$', text))
 
-            if meta.get('category') == 'TV':
-                season, episode = self.get_season_and_episode(meta)
-                season_episode_str = ""
-                if season and not episode:
-                    season_episode_str = f" - {season}"
-                elif season and episode:
-                    season_episode_str = f" - {season}{episode}"
-                data['name'] = f"{nome_base}{season_episode_str}"
+            title_from_asc = asc_data.get('Title') if asc_data else None
+
+            if is_safe_ascii(title_from_asc):
+                nome_base = title_from_asc
+
+                if meta.get('category') == 'TV':
+                    season, episode = self.get_season_and_episode(meta)
+                    season_episode_str = ""
+                    if season:
+                        season_episode_str = f" - {season}{episode or ''}"
+                    data['name'] = f"{nome_base}{season_episode_str}"
+                else:
+                    data['name'] = nome_base
             else:
-                data['name'] = nome_base
+                data['name'] = self.get_title(meta)
 
             # Year
             ano = asc_data.get('Year') if asc_data and asc_data.get('Year') else meta.get('year')
@@ -528,8 +538,8 @@ class ASC(COMMON):
             raise
 
     async def upload(self, meta, disctype):
-        if not await self.anonymous_warning(meta):
-            return
+        if meta.get('anon'):
+            console.print(f"[yellow]Aviso: Você solicitou um upload anônimo, mas o tracker {self.tracker} não suporta essa opção.[/yellow][red] O envio não será anônimo.[/red]")
 
         await COMMON(config=self.config).edit_torrent(meta, self.tracker, self.source_flag)
 
@@ -552,28 +562,13 @@ class ASC(COMMON):
         self.session.cookies.update(await self.parseCookieFile(cookie_file))
 
         with open(torrent_path, 'rb') as torrent_file:
-            files = {'torrent': (f"{self.tracker}_placeholder.torrent", torrent_file, "application/x-bittorrent")}
+            files = {'torrent': (f"{self.tracker}.{meta.get('infohash', '')}.placeholder.torrent", torrent_file, "application/x-bittorrent")}
             response = self.session.post(upload_url, data=data, files=files, timeout=60)
 
         if "foi enviado com sucesso" in response.text:
             await self.successful_upload(response.text, meta)
         else:
             self.failed_upload(response, meta)
-
-    async def anonymous_warning(self, meta):
-        if meta.get('anon'):
-            console.print(f"[bold yellow]Aviso: Você solicitou um upload anônimo, mas o tracker '{self.tracker}' não suporta esta opção.[/bold yellow]")
-
-            should_continue = cli_ui.ask_yes_no(
-                "Deseja continuar com o upload de forma pública (não-anônima)?",
-                default=False
-            )
-
-            if not should_continue:
-                console.print(f"[red]Upload para o tracker '{self.tracker}' cancelado pelo usuário.[/red]")
-                return False
-
-        return True
 
     def get_upload_url(self, meta):
         if meta.get('anime'):

--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -537,9 +537,6 @@ class ASC(COMMON):
             raise
 
     async def upload(self, meta, disctype):
-        if meta.get('anon'):
-            console.print(f"[yellow]Aviso: Você solicitou um upload anônimo, mas o tracker {self.tracker} não suporta essa opção.[/yellow][red] O envio não será anônimo.[/red]")
-
         await COMMON(config=self.config).edit_torrent(meta, self.tracker, self.source_flag)
 
         data = await self.prepare_form_data(meta)

--- a/src/trackerstatus.py
+++ b/src/trackerstatus.py
@@ -87,6 +87,10 @@ async def process_all_trackers(meta):
                     meta['ptp_groupID'] = groupID
                     dupes = await ptp.search_existing(groupID, local_meta, disctype)
 
+                if tracker_name == "ASC" and meta.get('anon', 'false'):
+                    console.print("PT: [yellow]Aviso: Você solicitou um upload anônimo, mas o ASC não suporta essa opção.[/yellow][red] O envio não será anônimo.[/red]")
+                    console.print("EN: [yellow]Warning: You requested an anonymous upload, but ASC does not support this option.[/yellow][red] The upload will not be anonymous.[/red]")
+
                 if ('skipping' not in local_meta or local_meta['skipping'] is None) and tracker_name != "TL":
                     dupes = await filter_dupes(dupes, local_meta, tracker_name)
                     local_meta, is_dupe = await helper.dupe_check(dupes, local_meta, tracker_name)


### PR DESCRIPTION
- Changes the way anonymous uploads are handled; it no longer interrupts the user and instead just prints a warning.
- Fixes an issue where the tracker would detect a duplicate if multiple users were uploading with the tool simultaneously. Using the infohash as the filename is likely the best way to prevent this.
- Fixes an issue where the site's database would throw a silent error when titles contained non-ASCII characters.