### PR TITLE
Fix LT edit name

### DIFF
--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -92,7 +92,7 @@ class LT():
             audios = [
                 audio for audio in meta['mediainfo']['media']['track'][2:]
                 if audio.get('@type') == 'Audio'
-                and audio.get('Language') != {}
+                and isinstance(audio.get('Language'), str)
                 and audio.get('Language') in {'es-419', 'es', 'es-mx', 'es-ar', 'es-cl', 'es-ve', 'es-bo', 'es-co',
                                               'es-cr', 'es-do', 'es-ec', 'es-sv', 'es-gt', 'es-hn', 'es-ni', 'es-pa',
                                               'es-py', 'es-pe', 'es-pr', 'es-uy'}


### PR DESCRIPTION
When audio track has no Language  it will be an empty dict "Language": {} in meta.json
And raise the error TypeError: unhashable type: 'dict' when it tries to compare it with str

