### PR TITLE
Handles "None" imdb_id string

### DIFF
--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -441,6 +441,8 @@ async def tmdb_other_meta(
             runtime = media_data.get('runtime', 60)
             if quickie_search or not imdb_id:
                 imdb_id_str = str(media_data.get('imdb_id', '')).replace('tt', '')
+                if imdb_id_str == "None":
+                    imdb_id_str = ""
                 if imdb_id and imdb_id_str and (int(imdb_id_str) != imdb_id):
                     imdb_mismatch = True
                 imdb_id = int(imdb_id_str) if imdb_id_str.isdigit() else 0


### PR DESCRIPTION
Prevents errors when the imdb_id string is "None" by converting it to an empty string.

This ensures that the subsequent check to convert to integer does not fail, and that the imdb_id is correctly treated as missing.