### PR TITLE
Fix variable reuse

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -152,8 +152,8 @@ async def get_video(videoloc, mode):
                     for f in filelist:
                         if "sample" in os.path.basename(f).lower():
                             console.print("[green]Filelist:[/green]")
-                            for f in filelist:
-                                console.print(f"[cyan]{f}")
+                            for tf in filelist:
+                                console.print(f"[cyan]{tf}")
                             console.print(f"[bold red]Possible sample file detected in filelist!: [yellow]{f}")
                             if cli_ui.ask_yes_no("Do you want to remove it?", default="yes"):
                                 filelist.remove(f)


### PR DESCRIPTION
As it is now, if sample file logic is triggered, the script will print the file list, and prompt deletion of the last file printed.


```
Gathering info for 
Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3.mkv
Filelist:
Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3/Sample.mkv
Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3/Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3.mkv
Possible sample file detected in filelist!: 
Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3/Warrior.2011.1080p.BluRay.DTS.x264.D-Z0N3.mkv
```