### PR TITLE
Add image restriction to DigitalCore

### DIFF
--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -4,6 +4,7 @@ import re
 import requests
 from src.exceptions import UploadException
 from src.console import console
+from src.rehostimages import check_hosts
 from .COMMON import COMMON
 
 
@@ -176,6 +177,13 @@ class DC(COMMON):
 
     async def upload(self, meta, disctype):
         await self.edit_torrent(meta, self.tracker, self.source_flag)
+        approved_image_hosts = ['imgbox', 'imgbb']
+        url_host_mapping = {
+            "ibb.co": "imgbb",
+            "imgbox.com": "imgbox",
+        }
+
+        await check_hosts(meta, self.tracker, url_host_mapping=url_host_mapping, img_host_index=1, approved_image_hosts=approved_image_hosts)
 
         cat_id = await self.get_category_id(meta)
 

--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -49,7 +49,10 @@ class DC(COMMON):
             desc_parts.append(manual_desc)
 
         # Screenshots
-        images = meta.get('image_list', [])
+        if f'{self.tracker}_images_key' in meta:
+            images = meta[f'{self.tracker}_images_key']
+        else:
+            images = meta['image_list']
         if images:
             screenshots_block = "[center][b]Screenshots[/b]\n\n"
             for image in images:

--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -177,10 +177,14 @@ class DC(COMMON):
 
     async def upload(self, meta, disctype):
         await self.edit_torrent(meta, self.tracker, self.source_flag)
-        approved_image_hosts = ['imgbox', 'imgbb']
+        approved_image_hosts = ['imgbox', 'imgbb', "bhd", "imgur", "postimg", "digitalcore"]
         url_host_mapping = {
             "ibb.co": "imgbb",
             "imgbox.com": "imgbox",
+            "beyondhd.co": "bhd", 
+            "imgur.com": "imgur",
+            "postimg.cc": "postimg",
+            "digitalcore.club": "digitalcore"
         }
 
         await check_hosts(meta, self.tracker, url_host_mapping=url_host_mapping, img_host_index=1, approved_image_hosts=approved_image_hosts)


### PR DESCRIPTION
The website has a CSP that only allows images from:

- https://img.digitalcore.club
- https://i.imgur.com
- https://i.postimg.cc
- https://beyondhd.co
- https://images2.imgbox.com
- https://thumbs2.imgbox.com
- https://i.ibb.co
- https://image.tmdb.org

Out of these, UA only supports imgbb and imgbox, so we keep those.
