### PR TITLE
Get correct discord config in upload.py

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -53,7 +53,7 @@ from src.prep import Prep  # noqa E402
 client = Clients(config=config)
 parser = Args(config)
 use_discord = False
-discord_config = config.get('discord')
+discord_config = config.get('DISCORD')
 if discord_config:
     use_discord = discord_config.get('use_discord', False)
 


### PR DESCRIPTION
Current `upload.py` is looking for `discord` (all lowercase) from `config.py` while Discord config section is `DISCORD`, therefore, `use_discord` is always `False`. This fix will now follow the `use_discord` key from `config.py`