### PR TITLE
get_tracker_data.py - lower HUNO priority

### DIFF
--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -21,7 +21,7 @@ async def get_tracker_data(video, meta, search_term=None, search_file_folder=Non
         tracker_keys = {
             'ptp': 'PTP',
             'btn': 'BTN',
-            'bhd': 'BHD',            
+            'bhd': 'BHD',
             'hdb': 'HDB',
             'blu': 'BLU',
             'aither': 'AITHER',

--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -19,16 +19,16 @@ async def get_tracker_data(video, meta, search_term=None, search_file_folder=Non
     if search_term:
         # Check if a specific tracker is already set in meta
         tracker_keys = {
-            'ptp': 'PTP',
+            'aither': 'AITHER',
+            'blu': 'BLU',
+            'lst': 'LST',
+            'ulcx': 'ULCX',
+            'oe': 'OE',
+            'huno': 'HUNO',
             'btn': 'BTN',
             'bhd': 'BHD',
             'hdb': 'HDB',
-            'blu': 'BLU',
-            'aither': 'AITHER',
-            'lst': 'LST',
-            'oe': 'OE',
-            'ulcx': 'ULCX',
-            'huno': 'HUNO',
+            'ptp': 'PTP',
         }
 
         specific_tracker = [tracker_keys[key] for key in tracker_keys if meta.get(key) is not None]

--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -21,14 +21,14 @@ async def get_tracker_data(video, meta, search_term=None, search_file_folder=Non
         tracker_keys = {
             'ptp': 'PTP',
             'btn': 'BTN',
-            'bhd': 'BHD',
-            'huno': 'HUNO',
+            'bhd': 'BHD',            
             'hdb': 'HDB',
             'blu': 'BLU',
             'aither': 'AITHER',
             'lst': 'LST',
             'oe': 'OE',
             'ulcx': 'ULCX',
+            'huno': 'HUNO',
         }
 
         specific_tracker = [tracker_keys[key] for key in tracker_keys if meta.get(key) is not None]


### PR DESCRIPTION
I'm having an issue where the distributor and region information is missing because it's matching HUNO first. Since HUNO doesn't store region and distributor IDs, the final metadata ends up without this information, even though there are other IDs in the client from sites that do store it (like BLU).