### PR TITLE
Give screenshots some spaces to breathe

### DIFF
--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -29,7 +29,7 @@ class BHD():
         self.source_flag = 'BHD'
         self.upload_url = 'https://beyond-hd.me/api/upload/'
         self.torrent_url = 'https://beyond-hd.me/details/'
-        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
+        self.signature = "\n"
         self.banned_groups = ['Sicario', 'TOMMY', 'x0r', 'nikt0', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD', 'Telly', 'AOC', 'WKS', 'SasukeducK']
         pass
 
@@ -258,6 +258,11 @@ class BHD():
                             desc.write(f"[spoiler={os.path.basename(each['largest_evo'])}][code][{each['evo_mi']}[/code][/spoiler]\n")
                             desc.write("\n")
             desc.write(base.replace("[img]", "[img width=300]"))
+            try:
+                # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use default
+                screensPerRow = int(self.config['DEFAULT']['screens_per_row'])
+            except Exception:
+                screensPerRow = 2
             if meta.get('comparison') and meta.get('comparison_groups'):
                 desc.write("[center]")
                 comparison_groups = meta.get('comparison_groups', {})
@@ -292,13 +297,13 @@ class BHD():
             else:
                 images = meta['image_list']
             if len(images) > 0:
-                desc.write("[align=center]")
+                desc.write("[align=center]SCREENSHOTS:\n\n")
                 for each in range(len(images[:int(meta['screens'])])):
                     web_url = images[each]['web_url']
                     img_url = images[each]['img_url']
                     if (each == len(images) - 1):
                         desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]")
-                    elif (each + 1) % 2 == 0:
+                    elif (each + 1) % screensPerRow == 0:
                         desc.write(f"[url={web_url}][img width=350]{img_url}[/img][/url]\n")
                         desc.write("\n")
                     else:

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -297,7 +297,7 @@ class BHD():
             else:
                 images = meta['image_list']
             if len(images) > 0:
-                desc.write("[align=center]SCREENSHOTS:\n\n")
+                desc.write("[align=center]")
                 for each in range(len(images[:int(meta['screens'])])):
                     web_url = images[each]['web_url']
                     img_url = images[each]['img_url']

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -29,7 +29,7 @@ class BHD():
         self.source_flag = 'BHD'
         self.upload_url = 'https://beyond-hd.me/api/upload/'
         self.torrent_url = 'https://beyond-hd.me/details/'
-        self.signature = "\n"
+        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
         self.banned_groups = ['Sicario', 'TOMMY', 'x0r', 'nikt0', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD', 'Telly', 'AOC', 'WKS', 'SasukeducK']
         pass
 

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -259,8 +259,8 @@ class BHD():
                             desc.write("\n")
             desc.write(base.replace("[img]", "[img width=300]"))
             try:
-                # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use default
-                screensPerRow = int(self.config['DEFAULT']['screens_per_row'])
+                # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use 2 as default
+                screensPerRow = int(self.config['DEFAULT'].get('screens_per_row', 2))
             except Exception:
                 screensPerRow = 2
             if meta.get('comparison') and meta.get('comparison_groups'):

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -90,7 +90,7 @@ class COMMON():
             # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use default
             screensPerRow = int(self.config['DEFAULT']['screens_per_row'])
         except Exception:
-            screensPerRow = None
+            screensPerRow = 2
         try:
             # If custom signature set and isn't empty, use that instead of the signature parameter
             custom_signature = self.config['TRACKERS'][tracker].get('custom_signature', signature)

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -200,7 +200,7 @@ class COMMON():
                 for img_index in range(len(images[:int(meta['screens'])])):
                     web_url = images[img_index]['web_url']
                     raw_url = images[img_index]['raw_url']
-                    descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url]")
+                    descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url] ")
 
                     # If screensPerRow is set and we have reached that number of screenshots, add a new line
                     if screensPerRow and (img_index + 1) % screensPerRow == 0:
@@ -246,9 +246,9 @@ class COMMON():
                                 for img in meta[new_images_key]:
                                     web_url = img['web_url']
                                     raw_url = img['raw_url']
-                                    image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                    image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                                     descfile.write(image_str)
-                                descfile.write("[/center]\n\n")
+                                descfile.write("[/center]\n ")
                             else:
                                 descfile.write("[center]\n\n")
                                 # Use the summary corresponding to the current bdinfo
@@ -279,9 +279,9 @@ class COMMON():
                                     for img in uploaded_images:
                                         web_url = img['web_url']
                                         raw_url = img['raw_url']
-                                        image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                        image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                                         descfile.write(image_str)
-                                    descfile.write("[/center]\n\n")
+                                    descfile.write("[/center]\n")
 
                                 meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
                                 with open(meta_filename, 'w') as f:
@@ -321,7 +321,7 @@ class COMMON():
                         for img_index in range(len(images[:int(meta['screens'])])):
                             web_url = images[img_index]['web_url']
                             raw_url = images[img_index]['raw_url']
-                            image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                            image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                             descfile.write(image_str)
 
                             # If screensPerRow is set and we have reached that number of screenshots, add a new line
@@ -419,9 +419,9 @@ class COMMON():
                                     for img in uploaded_images:
                                         web_url = img['web_url']
                                         raw_url = img['raw_url']
-                                        image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                        image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                                         descfile.write(image_str)
-                                    descfile.write("[/center]\n\n")
+                                    descfile.write("[/center]\n")
 
                                 # Save the updated meta to `meta.json` after upload
                                 meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
@@ -467,7 +467,7 @@ class COMMON():
                 for img_index in range(len(images[:int(meta['screens'])])):
                     web_url = images[img_index]['web_url']
                     raw_url = images[img_index]['raw_url']
-                    descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url]")
+                    descfile.write(f"[url={web_url}][img={self.config['DEFAULT'].get('thumbnail_size', '350')}]{raw_url}[/img][/url] ")
                     if screensPerRow and (img_index + 1) % screensPerRow == 0:
                         descfile.write("\n")
                 descfile.write("[/center]")
@@ -583,7 +583,7 @@ class COMMON():
                             for img_index in range(len(images)):
                                 web_url = images[img_index]['web_url']
                                 raw_url = images[img_index]['raw_url']
-                                image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                                 descfile.write(image_str)
                                 char_count += len(image_str)
 
@@ -599,10 +599,10 @@ class COMMON():
                             for img in meta[new_images_key]:
                                 web_url = img['web_url']
                                 raw_url = img['raw_url']
-                                image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url]"
+                                image_str = f"[url={web_url}][img={thumb_size}]{raw_url}[/img][/url] "
                                 descfile.write(image_str)
                                 char_count += len(image_str)
-                            descfile.write("[/center]\n\n")
+                            descfile.write("[/center]\n")
                             char_count += len("[/center]\n\n")
 
                 if other_files_spoiler_open:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -87,8 +87,8 @@ class COMMON():
         except Exception as e:
             console.print(f"[yellow]Warning: Error setting custom description header: {str(e)}[/yellow]")
         try:
-            # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use default
-            screensPerRow = int(self.config['DEFAULT']['screens_per_row'])
+            # If screensPerRow is set, use that to determine how many screenshots should be on each row. Otherwise, use 2 as default
+            screensPerRow = int(self.config['DEFAULT'].get('screens_per_row', 2))
         except Exception:
             screensPerRow = 2
         try:


### PR DESCRIPTION
Like what was done with BHD screenshots (consistent spacing between screenshots, 1 space between columns, 1 space between lines), the same will apply to other UNIT3D trackers as well: https://slow.pics/c/vJ7frGJb