### PR TITLE
Better matching of files against foldered torrents

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -1564,7 +1564,9 @@ class Clients():
 
                     if is_disc in ("", None) and len(meta.get('filelist', [])) == 1:
                         file_name = os.path.basename(meta['filelist'][0])
-                        if (torrent_name == meta['uuid'] or torrent_name == file_name) and len(torrent.files) == 1:
+                        if (torrent_name == file_name) and len(torrent.files) == 1:
+                            is_match = True
+                        elif torrent_name == meta['uuid']:
                             is_match = True
                     else:
                         if torrent_name == meta['uuid']:


### PR DESCRIPTION
When UA runs on a file in a folder and the only torrents in client are foldered.