### PR TITLE
Skip torrents for AL if they don't have a MAL ID

### DIFF
--- a/src/trackers/AL.py
+++ b/src/trackers/AL.py
@@ -290,6 +290,9 @@ class AL():
             return audio_codec_str
 
     async def upload(self, meta, disctype):
+        if not meta["mal"]:
+            console.print("[bold red]MAL ID is missing, cannot upload to AL.[/bold red]")
+            return
         title = await self.get_mal_data(meta['mal'], meta)
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)

--- a/src/trackers/AL.py
+++ b/src/trackers/AL.py
@@ -290,9 +290,6 @@ class AL():
             return audio_codec_str
 
     async def upload(self, meta, disctype):
-        if not meta["mal"]:
-            console.print("[bold red]MAL ID is missing, cannot upload to AL.[/bold red]")
-            return
         title = await self.get_mal_data(meta['mal'], meta)
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)
@@ -379,6 +376,10 @@ class AL():
         open_torrent.close()
 
     async def search_existing(self, meta, disctype):
+        if not meta["mal"]:
+            console.print("[bold red]MAL ID is missing, cannot upload to AL.[/bold red]")
+            meta["skipping"] = "AL"
+            return
         dupes = []
         params = {
             'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),


### PR DESCRIPTION
The `await self.get_mal_data` function will crash anyways if the ID is None.