### PR TITLE
add support for multiple announce links

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -382,7 +382,8 @@ config = {
             "link_dir_name": "",
             "username": "",
             "password": "",
-            "announce_url": "https://digitalcore.club/tracker.php/<PASSKEY>/announce",
+            # You can find your passkey at Settings -> Security -> Passkey
+            "passkey": "",
             "anon": False,
         },
         "DP": {
@@ -675,7 +676,8 @@ config = {
             # If you are not going to use the API, you will need to export cookies from https://www.torrentleech.org/ using https://addons.mozilla.org/en-US/firefox/addon/export-cookies-txt/.
             # cookies need to be in netscape format and need to be in data/cookies/TL.txt
             "api_upload": True,
-            "announce_key": "TL announce key",
+            # You can find your passkey at your profile (https://www.torrentleech.org/profile/[YourUserName]/view) -> Torrent Passkey
+            "passkey": "",
         },
         "TOCA": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -46,7 +46,14 @@ class COMMON():
     async def add_tracker_torrent(self, meta, tracker, source_flag, new_tracker, comment):
         if os.path.exists(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent"):
             new_torrent = Torrent.read(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent")
-            new_torrent.metainfo['announce'] = new_tracker
+
+            # handle trackers with multiple announce links
+            if isinstance(new_tracker, list):
+                new_torrent.metainfo['announce'] = new_tracker[0]
+                new_torrent.metainfo['announce-list'] = [new_tracker]
+            else:
+                new_torrent.metainfo['announce'] = new_tracker
+
             new_torrent.metainfo['comment'] = comment
             new_torrent.metainfo['info']['source'] = source_flag
             Torrent.copy(new_torrent).write(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent", overwrite=True)

--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -20,7 +20,9 @@ class DC(COMMON):
 
         self.session = requests.Session()
         self.session.headers.update({'User-Agent': 'Mozilla/5.0'})
-        self.api_key = self.config['TRACKERS'][self.tracker].get('announce_url').replace('https://digitalcore.club/tracker.php/', '').replace('/announce', '')
+        self.api_key = self.config['TRACKERS'][self.tracker].get('passkey')
+        self.announce_url_1 = f'https://tracker.digitalcore.club/announce/{self.api_key}'
+        self.announce_url_2 = f'https://trackerprxy.digitalcore.club/announce/{self.api_key}'
         self.username = self.config['TRACKERS'][self.tracker].get('username')
         self.password = self.config['TRACKERS'][self.tracker].get('password')
         self.auth_cookies = None
@@ -271,8 +273,11 @@ class DC(COMMON):
                         details_url = f"{self.base_url}/torrent/{torrent_id}/" if torrent_id else self.base_url
                         if torrent_id:
                             meta['tracker_status'][self.tracker]['torrent_id'] = torrent_id
-                        announce_url = self.config['TRACKERS'][self.tracker].get('announce_url')
-                        await self.add_tracker_torrent(meta, self.tracker, self.source_flag, announce_url, details_url)
+                        announce_list = [
+                            self.announce_url_1,
+                            self.announce_url_2
+                        ]
+                        await self.add_tracker_torrent(meta, self.tracker, self.source_flag, announce_list, details_url)
                     else:
                         raise UploadException(f"{json_response.get('message', 'Unknown API error.')}")
                 else:

--- a/src/trackers/TL.py
+++ b/src/trackers/TL.py
@@ -40,8 +40,9 @@ class TL():
         self.banned_groups = [""]
         self.session = httpx.AsyncClient(timeout=60.0)
         self.api_upload = self.config['TRACKERS'][self.tracker].get('api_upload')
-        self.announce_key = self.config['TRACKERS'][self.tracker]['announce_key']
-        self.config['TRACKERS'][self.tracker]['announce_url'] = f"https://tracker.torrentleech.org/a/{self.announce_key}/announce"
+        self.passkey = self.config['TRACKERS'][self.tracker]['passkey']
+        self.announce_url_1 = f'https://tracker.torrentleech.org/a/{self.passkey}/announce'
+        self.announce_url_2 = f'https://tracker.tleechreload.org/a/{self.passkey}/announce'
         self.session.headers.update({
             'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
         })
@@ -343,9 +344,12 @@ class TL():
                         torrent_url = f"{self.base_url}/torrent/{torrent_id}"
                         meta['tracker_status'][self.tracker]['status_message'] = torrent_url
 
-                        announce_url = self.config['TRACKERS'][self.tracker].get('announce_url')
+                        announce_list = [
+                            self.announce_url_1,
+                            self.announce_url_2
+                        ]
                         common = COMMON(config=self.config)
-                        await common.add_tracker_torrent(meta, self.tracker, self.source_flag, announce_url, torrent_url)
+                        await common.add_tracker_torrent(meta, self.tracker, self.source_flag, announce_list, torrent_url)
 
                     else:
                         console.print("[bold red]Upload failed: No success redirect found.[/bold red]")


### PR DESCRIPTION
I noticed that sometimes DC wasn't registering all my seeded torrents, so I figured it was the missing proxy announce link when uploading torrents via UA. 

These changes allow you to add an announce list to trackers that require it.

This also changes the DC announce link because it appears to have changed, although the old one still works.