### PR TITLE
DC - API update

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -380,10 +380,10 @@ config = {
         "DC": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
             "link_dir_name": "",
-            "username": "",
-            "password": "",
             # You can find your passkey at Settings -> Security -> Passkey
             "passkey": "",
+            # You can find your api key at Settings -> Security -> API Key -> Generate API Key
+            "api_key": "",
             "anon": False,
         },
         "DP": {


### PR DESCRIPTION
DC updated its API a few hours ago:

```
How to use your API Key
Authentication

    HTTP Headers (recommended):
        X-API-KEY: YOUR_API_KEY
        Authorization: Bearer YOUR_API_KEY
        Authorization: ApiKey YOUR_API_KEY
    Query String:
        ?apikey=YOUR_API_KEY
        ?api_key=YOUR_API_KEY
    POST Body (form-data or x-www-form-urlencoded):
        apikey=YOUR_API_KEY
        api_key=YOUR_API_KEY

Allowed API Routes:

    GET /api/v1/torrents – List torrents
    GET /api/v1/torrents/search – Search
    GET /api/v1/torrents/torrents_exact_search – Exact search
    POST /api/v1/torrents/upload – Upload torrent
    GET /api/v1/torrents/download/<torrentid> – Download torrent file

Examples:

# List torrents
curl -H "X-API-KEY: YOUR_API_KEY" https://digitalcore.club/api/v1/torrents

# Exact search
curl -H "Authorization: Bearer YOUR_API_KEY" "https://digitalcore.club/api/v1/torrents/torrents_exact_search?searchText=ubuntu"

# Download torrent
curl -H "X-API-KEY: YOUR_API_KEY" https://digitalcore.club/api/v1/torrents/download/12345

# Upload torrent
curl -X POST https://digitalcore.club/api/v1/torrents/upload \
  -H "X-API-KEY: YOUR_API_KEY" \
  -F "category=1" \
  -F "imdbId=tt1234567" \
  -F "nfo=This is the nfo" \
  -F "mediainfo=Full mediainfo here" \
  -F "file=@/path/to/torrent.torrent" \
  -F "reqid=0" \
  -F "section=new" \
  -F "frileech=1" \
  -F "unrar=0" \
  -F "anonymousUpload=1" \
  -F "p2p=0"

Compatible with Radarr, Sonarr, Prowlarr, curl, Postman, etc.

```