### PR TITLE
Catch conformance error from mediainfo and warn users

### DIFF
--- a/src/exportmi.py
+++ b/src/exportmi.py
@@ -366,3 +366,22 @@ def validate_mediainfo(base_dir, folder_id, path, filelist, debug):
             console.print("[yellow]Unique ID not found in General section.[/yellow]")
 
     return bool(unique_id)
+
+
+async def get_conformance_error(meta):
+    if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
+        general_track = next((track for track in meta['mediainfo']['media']['track']
+                              if track.get('@type') == 'General'), None)
+        if general_track and general_track.get('extra', {}).get('ConformanceErrors', {}):
+            try:
+                return True
+            except ValueError:
+                if meta['debug']:
+                    console.print(f"[red]Unexpected value: {general_track['extra']['ConformanceErrors']}[/red]")
+                return True
+        else:
+            if meta['debug']:
+                console.print("[green]No Conformance errors found in MediaInfo General track[/green]")
+            return False
+    else:
+        return False

--- a/src/prep.py
+++ b/src/prep.py
@@ -320,11 +320,11 @@ class Prep():
         meta['filename'] = filename
         meta['bdinfo'] = bdinfo
 
-        conform = await get_conformance_error(meta)
-        if conform:
-            upload = cli_ui.ask_yes_no(f"Found Conformance errors in mediainfo, proceed to upload anyway?", default=False)
+        conform_issues = await get_conformance_error(meta)
+        if conform_issues:
+            upload = cli_ui.ask_yes_no("Found Conformance errors in mediainfo, proceed to upload anyway?", default=False)
             if upload is False:
-                console.print(f"[red]Not uploading. Check if the file finished downloading and can be played properly.[/red]")
+                console.print("[red]Not uploading. Check if the file finished downloading and can be played properly.")
                 tmp_dir = f"{meta['base_dir']}/tmp/{meta['uuid']}"
                 if os.path.exists(tmp_dir):
                     try:
@@ -338,8 +338,8 @@ class Prep():
                         console.print(f"[red]Error cleaning up temporary metadata files: {e}[/red]", highlight=False)
                 sys.exit(0)
             else:
-                console.print(f"Proceeding...")
-        
+                console.print("Proceeding...")
+
         meta['valid_mi'] = True
         if not meta['is_disc'] and not meta.get('emby', False):
             valid_mi = validate_mediainfo(base_dir, folder_id, path=meta['path'], filelist=meta['filelist'], debug=meta['debug'])

--- a/src/prep.py
+++ b/src/prep.py
@@ -322,10 +322,11 @@ class Prep():
 
         conform_issues = await get_conformance_error(meta)
         if conform_issues:
-            upload = cli_ui.ask_yes_no("Found Conformance errors in mediainfo, proceed to upload anyway?", default=False)
+            upload = cli_ui.ask_yes_no("Found Conformance errors in mediainfo (possible cause: corrupted file, incomplete download, new codec, etc...), proceed to upload anyway?", default=False)
             if upload is False:
-                console.print("[red]Not uploading. Check if the file finished downloading and can be played properly (not corrupted).")
+                console.print("[red]Not uploading. Check if the file has finished downloading and can be played back properly (uncorrupted).")
                 tmp_dir = f"{meta['base_dir']}/tmp/{meta['uuid']}"
+                # Cleanup meta so we don't reuse it later
                 if os.path.exists(tmp_dir):
                     try:
                         for file in os.listdir(tmp_dir):
@@ -336,7 +337,8 @@ class Prep():
                                 console.print(f"[yellow]Removed temporary metadata file: {file_path}[/yellow]")
                     except Exception as e:
                         console.print(f"[red]Error cleaning up temporary metadata files: {e}[/red]", highlight=False)
-                sys.exit(0)
+                # Exit with error code for automation
+                sys.exit(1)
             else:
                 console.print("Proceeding...")
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -15,7 +15,7 @@ from src.apply_overrides import get_source_override
 from src.is_scene import is_scene
 from src.audio import get_audio_v2
 from src.edition import get_edition
-from src.video import get_video_codec, get_video_encode, get_uhd, get_hdr, get_video, get_resolution, get_type, is_3d, is_sd, get_video_duration
+from src.video import get_video_codec, get_video_encode, get_uhd, get_hdr, get_video, get_resolution, get_type, is_3d, is_sd, get_video_duration, get_conformance_error
 from src.tags import get_tag, tag_override
 from src.get_disc import get_disc, get_dvd_size
 from src.get_source import get_source

--- a/src/prep.py
+++ b/src/prep.py
@@ -324,7 +324,7 @@ class Prep():
         if conform_issues:
             upload = cli_ui.ask_yes_no("Found Conformance errors in mediainfo, proceed to upload anyway?", default=False)
             if upload is False:
-                console.print("[red]Not uploading. Check if the file finished downloading and can be played properly.")
+                console.print("[red]Not uploading. Check if the file finished downloading and can be played properly (not corrupted).")
                 tmp_dir = f"{meta['base_dir']}/tmp/{meta['uuid']}"
                 if os.path.exists(tmp_dir):
                     try:

--- a/src/video.py
+++ b/src/video.py
@@ -304,7 +304,7 @@ async def get_video_duration(meta):
 async def get_conformance_error(meta):
     if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
         general_track = next((track for track in meta['mediainfo']['media']['track']
-                              if track.get('@type') == 'General'), None):
+                              if track.get('@type') == 'General'), None)
         if general_track and general_track.get('extra',{}).get('ConformanceErrors', {}):
             try:
                 return True

--- a/src/video.py
+++ b/src/video.py
@@ -299,22 +299,3 @@ async def get_video_duration(meta):
             return None
     else:
         return None
-
-
-async def get_conformance_error(meta):
-    if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
-        general_track = next((track for track in meta['mediainfo']['media']['track']
-                              if track.get('@type') == 'General'), None)
-        if general_track and general_track.get('extra', {}).get('ConformanceErrors', {}):
-            try:
-                return True
-            except ValueError:
-                if meta['debug']:
-                    console.print(f"[red]Unexpected value: {general_track['extra']['ConformanceErrors']}[/red]")
-                return True
-        else:
-            if meta['debug']:
-                console.print("[green]No Conformance errors found in MediaInfo General track[/green]")
-            return False
-    else:
-        return False

--- a/src/video.py
+++ b/src/video.py
@@ -305,7 +305,7 @@ async def get_conformance_error(meta):
     if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
         general_track = next((track for track in meta['mediainfo']['media']['track']
                               if track.get('@type') == 'General'), None)
-        if general_track and general_track.get('extra',{}).get('ConformanceErrors', {}):
+        if general_track and general_track.get('extra', {}).get('ConformanceErrors', {}):
             try:
                 return True
             except ValueError:

--- a/src/video.py
+++ b/src/video.py
@@ -300,10 +300,11 @@ async def get_video_duration(meta):
     else:
         return None
 
+
 async def get_conformance_error(meta):
     if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
         general_track = next((track for track in meta['mediainfo']['media']['track']
-                              if track.get('@type') == 'General'), None)
+                              if track.get('@type') == 'General'), None):
         if general_track and general_track.get('extra',{}).get('ConformanceErrors', {}):
             try:
                 return True

--- a/src/video.py
+++ b/src/video.py
@@ -299,3 +299,21 @@ async def get_video_duration(meta):
             return None
     else:
         return None
+
+async def get_conformance_error(meta):
+    if not meta.get('is_disc') == "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
+        general_track = next((track for track in meta['mediainfo']['media']['track']
+                              if track.get('@type') == 'General'), None)
+        if general_track and general_track.get('extra',{}).get('ConformanceErrors', {}):
+            try:
+                return True
+            except ValueError:
+                if meta['debug']:
+                    console.print(f"[red]Unexpected value: {general_track['extra']['ConformanceErrors']}[/red]")
+                return True
+        else:
+            if meta['debug']:
+                console.print("[green]No Conformance errors found in MediaInfo General track[/green]")
+            return False
+    else:
+        return False


### PR DESCRIPTION
In cases where UA is executed too early before the download finishes or there's an issue with the file, warn users to double-check before proceeding with upload.

Not sure if there's a situation where conformance errors could be wrongly reported by MediaInfo, hence this is just a warning, not a hard stop.

Example:

```
General
Unique ID                                : 114357455792027941594255263657427451072 (0x560871E18497749080468D06DC2FBCC0)
Complete name                            : C:\Users\ppkho\Downloads\[WakuTomete] Princess Session Orchestra - 18 (WEB 1080p AVC E-AC3) [3D7914C2].mkv
Format                                   : Matroska
Format version                           : Version 4 / Version 2
File size                                : 877 MiB
Duration                                 : 23 min 50 s
Overall bit rate                         : 5 142 kb/s
Frame rate                               : 23.976 FPS
Title                                    : [WakuTomete] Princess Session Orchestra - 18 (WEB 1080p AVC E-AC3)
Writing application                      : mkvmerge 83.0 ('Circle Of Friends') 64-bit
Writing library                          : libebml v1.4.5 + libmatroska v1.7.1
Attachments                              : Fontin_Sans.otf / Fontin_Sans_BI.otf / KGNothingYouCouldSay.ttf / Berate the Elementary.ttf / Chisholm Heliport.ttf / CormorantInfant-Light.ttf / FOT-TsukuAVintageMinLR.otf
Conformance errors                       : 2
 0x8538067                               : Yes
  0x941A469                              : Yes
   0x21A7                                : Yes
    0xFFFFFFFF                           : Yes
     General compliance                  : Element size 34989062 is more than maximal permitted size 11 (offset 0x921BFA)
   0xFFFFFFFF                            : Yes
    General compliance                   : Element size 34989051 is more than maximal permitted size 6214012 (offset 0x921C05)

Video
ID                                       : 1
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L4
Format settings                          : CABAC / 4 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 4 frames
Codec ID                                 : V_MPEG4/ISO/AVC
Duration                                 : 23 min 50 s
Bit rate mode                            : Constant
Nominal bit rate                         : 10 000 kb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 23.976 (24000/1001) FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 0.201
Language                                 : Japanese
Default                                  : Yes
Forced                                   : No
Color range                              : Limited
Color primaries                          : BT.709
Transfer characteristics                 : BT.709
Matrix coefficients                      : BT.709
...
[snip]
```