### PR TITLE
feat(fnp): A ton of fixes

### DIFF
--- a/src/trackers/FNP.py
+++ b/src/trackers/FNP.py
@@ -11,7 +11,7 @@ from src.trackers.COMMON import COMMON
 from src.console import console
 
 
-class FNP():
+class FNP:
     """
     Edit for Tracker:
         Edit BASE.torrent with announce and source
@@ -28,7 +28,7 @@ class FNP():
         self.search_url = 'https://fearnopeer.com/api/torrents/filter'
         self.torrent_url = 'https://fearnopeer.com/torrents/'
         self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
-        self.banned_groups = ["4K4U, BiTOR,	d3g, FGT, FRDS, FTUApps, GalaxyRG, LAMA, MeGusta, NeoNoir, PSA, RARBG, YAWNiX, YTS, YIFY, x0r"]
+        self.banned_groups = ["4K4U", "BiTOR", "d3g", "FGT", "FRDS", "FTUApps", "GalaxyRG", "LAMA", "MeGusta", "NeoNoir", "PSA", "RARBG", "YAWNiX", "YTS", "YIFY", "x0r"]
         pass
 
     async def get_cat_id(self, category_name):
@@ -50,111 +50,120 @@ class FNP():
         }.get(type, '0')
         return type_id
 
-    async def get_res_id(self, resolution):
-        resolution_id = {
-            '4320p': '1',
-            '2160p': '2',
-            '1080p': '3',
-            '1080i': '4',
-            '720p': '5',
-            '576p': '6',
-            '576i': '7',
-            '480p': '8',
-            '480i': '9'
-        }.get(resolution, '10')
-        return resolution_id
+    async def get_res_id(self, resolution, disctype):
+        if disctype == 'DVD':
+            return '14'
+        elif disctype == 'BD':
+            return '3'
+        else:
+            resolution_id = {
+                '4320p': '1',
+                '2160p': '2',
+                '1080p': '3',
+                '1080i': '4',
+                '720p': '5',
+                '576p': '6',
+                '576i': '7',
+                '480p': '8',
+                '480i': '9',
+            }.get(resolution, '10')
+            return resolution_id
 
     async def upload(self, meta, disctype):
         common = COMMON(config=self.config)
         await common.edit_torrent(meta, self.tracker, self.source_flag)
+
         cat_id = await self.get_cat_id(meta['category'])
         type_id = await self.get_type_id(meta['type'])
-        resolution_id = await self.get_res_id(meta['resolution'])
+        
+        resolution_id = await self.get_res_id(meta['resolution'], disctype)
+
         await common.unit3d_edit_desc(meta, self.tracker, self.signature)
         region_id = await common.unit3d_region_ids(meta.get('region'))
         distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
-            anon = 0
-        else:
-            anon = 1
+        
+        anon = 1 if meta.get('anon', 1) or self.config['TRACKERS'][self.tracker].get('anon', False) else 0
 
-        if meta['bdinfo'] is not None:
-            mi_dump = None
-            bd_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8').read()
-        else:
-            mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8').read()
-            bd_dump = None
-        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8').read()
-        open_torrent = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent", 'rb')
-        files = {'torrent': open_torrent}
-        base_dir = meta['base_dir']
-        uuid = meta['uuid']
-        specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
-        nfo_files = glob.glob(specified_dir_path)
-        nfo_file = None
-        if nfo_files:
-            nfo_file = open(nfo_files[0], 'rb')
-        if nfo_file:
-            files['nfo'] = ("nfo_file.nfo", nfo_file, "text/plain")
-        data = {
-            'name': meta['name'],
-            'description': desc,
-            'mediainfo': mi_dump,
-            'bdinfo': bd_dump,
-            'category_id': cat_id,
-            'type_id': type_id,
-            'resolution_id': resolution_id,
-            'tmdb': meta['tmdb'],
-            'imdb': meta['imdb'],
-            'tvdb': meta['tvdb_id'],
-            'mal': meta['mal_id'],
-            'igdb': 0,
-            'anonymous': anon,
-            'stream': meta['stream'],
-            'sd': meta['sd'],
-            'keywords': meta['keywords'],
-            'personal_release': int(meta.get('personalrelease', False)),
-            'internal': 0,
-            'featured': 0,
-            'free': 0,
-            'doubleup': 0,
-            'sticky': 0,
-        }
-        # Internal
-        if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
-            if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
-                data['internal'] = 1
+        mi_dump = None
+        bd_dump = None
+        
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8') as desc_file:
+            desc = desc_file.read()
 
-        if region_id != 0:
-            data['region_id'] = region_id
-        if distributor_id != 0:
-            data['distributor_id'] = distributor_id
-        if meta.get('category') == "TV":
-            data['season_number'] = meta.get('season_int', '0')
-            data['episode_number'] = meta.get('episode_int', '0')
-        headers = {
-            'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
-        }
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        }
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent", 'rb') as open_torrent:
+            files = {'torrent': open_torrent}
 
-        if meta['debug'] is False:
-            response = requests.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
-            try:
-                meta['tracker_status'][self.tracker]['status_message'] = response.json()
-                # adding torrent link to comment of torrent file
-                t_id = response.json()['data'].split(".")[1].split("/")[3]
-                meta['tracker_status'][self.tracker]['torrent_id'] = t_id
-                await common.add_tracker_torrent(meta, self.tracker, self.source_flag, self.config['TRACKERS'][self.tracker].get('announce_url'), "https://fearnopeer.com/torrents/" + t_id)
-            except Exception:
-                console.print("It may have uploaded, go check")
-                return
-        else:
-            console.print("[cyan]Request Data:")
-            console.print(data)
-            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
-        open_torrent.close()
+            if meta['bdinfo'] is not None:
+                with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8') as bd_file:
+                    bd_dump = bd_file.read()
+            else:
+                with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8') as mi_file:
+                    mi_dump = mi_file.read()
+
+            nfo_file = None
+            specified_dir_path = os.path.join(meta['base_dir'], "tmp", meta['uuid'], "*.nfo")
+            nfo_files = glob.glob(specified_dir_path)
+            if nfo_files:
+                nfo_file = open(nfo_files[0], 'rb')
+                files['nfo'] = ("nfo_file.nfo", nfo_file, "text/plain")
+
+            data = {
+                'name': meta['name'],
+                'description': desc,
+                'mediainfo': mi_dump,
+                'bdinfo': bd_dump,
+                'category_id': cat_id,
+                'type_id': type_id,
+                'resolution_id': resolution_id,
+                'tmdb': meta['tmdb'],
+                'imdb': meta['imdb'],
+                'tvdb': meta['tvdb_id'],
+                'mal': meta['mal_id'],
+                'igdb': 0,
+                'anonymous': anon,
+                'stream': meta['stream'],
+                'sd': meta['sd'],
+                'keywords': meta['keywords'],
+                'personal_release': int(meta.get('personalrelease', False)),
+                'internal': 0,
+                'featured': 0,
+                'free': 0,
+                'doubleup': 0,
+                'sticky': 0,
+            }
+            if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
+                if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
+                    data['internal'] = 1
+
+            if region_id != 0:
+                data['region_id'] = region_id
+            if distributor_id != 0:
+                data['distributor_id'] = distributor_id
+            if meta.get('category') == "TV":
+                data['season_number'] = meta.get('season_int', '0')
+                data['episode_number'] = meta.get('episode_int', '0')
+
+            headers = {
+                'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
+            }
+            params = {
+                'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip()
+            }
+
+            if meta['debug'] is False:
+                response = requests.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
+                try:
+                    meta['tracker_status'][self.tracker]['status_message'] = response.json()
+                    t_id = response.json()['data'].split(".")[1].split("/")[3]
+                    meta['tracker_status'][self.tracker]['torrent_id'] = t_id
+                    await common.add_tracker_torrent(meta, self.tracker, self.source_flag, self.config['TRACKERS'][self.tracker].get('announce_url'), "https://fearnopeer.com/torrents/" + t_id)
+                except Exception:
+                    console.print("It may have uploaded, go check")
+                    return
+            else:
+                console.print("[cyan]Request Data:")
+                console.print(data)
+                meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
 
     async def search_existing(self, meta, disctype):
         dupes = []
@@ -163,7 +172,7 @@ class FNP():
             'tmdbId': meta['tmdb'],
             'categories[]': await self.get_cat_id(meta['category']),
             'types[]': await self.get_type_id(meta['type']),
-            'resolutions[]': await self.get_res_id(meta['resolution']),
+            'resolutions[]': await self.get_res_id(meta['resolution'], disctype),
             'name': ""
         }
         if meta['category'] == 'TV':
@@ -187,5 +196,4 @@ class FNP():
         except Exception as e:
             console.print(f"[bold red]Unexpected error: {e}")
             await asyncio.sleep(5)
-
         return dupes


### PR DESCRIPTION
Resolves an issue where Blu-ray and DVD torrents were not being categorized correctly (according to iVy)
Adds `disctype` as a parameter to `get_res_id` to determine the correct ID
`DVD` returns a hardcoded ID of `14`.
`BD` returns a hardcoded ID of `3`.
Fixes a syntax error in the `search_existing` function by adding the `disctype` argument to the `get_res_id` call

Still needs testing & fixing. Like the Ids that DVD and BD report. Also the resolution map should be checked.