### PR TITLE
Fix BHD tracker matching

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -1903,7 +1903,7 @@ async def match_tracker_url(tracker_urls, meta):
         'blu': ["https://blutopia.cc"],
         'hdb': ["https://hdbits.org"],
         'btn': ["https://broadcasthe.net"],
-        'bhd': ["https://beyond-hd.me"],
+        'bhd': ["https://beyond-hd.me", "tracker.beyond-hd.me"],
         'huno': ["https://hawke.uno"],
         'ulcx': ["https://upload.cx"],
         'rf': ["https://reelflix.xyz"],


### PR DESCRIPTION
A lot of BHD torrents use https://tracker.beyond-hd.me - hence many times they're often not getting caught as already present in the client, this should fix it