### PR TITLE
continue queue in case that torrent exists on give trackers

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -250,7 +250,7 @@ async def process_meta(meta, base_dir, bot=None):
                 removed.append(tracker)
         if removed:
             console.print(f"[yellow]Removing trackers already in your client: {', '.join(removed)}[/yellow]")
-    if not meta['trackers'] and not 'queue' in meta and meta.get('queue') is not None:
+    if not meta['trackers'] and 'queue' not in meta and meta.get('queue') is not None:
         console.print("[red]No trackers remain after removal.[/red]")
         successful_trackers = 0
         meta['skip_uploading'] = 10


### PR DESCRIPTION
in case of processing queue to a single tracker, if a queue item is already present on the tracker, the queue exits. this will allow the next item to be processed.