### PR TITLE
generalize taoe release group recognition

### DIFF
--- a/src/tags.py
+++ b/src/tags.py
@@ -44,6 +44,8 @@ async def get_tag(video, meta):
         try:
             parsed = guessit(video)
             release_group = parsed.get('release_group')
+            if "TAoE" in release_group:
+                release_group = "TAoE"
             if meta['debug']:
                 console.print(f"Guessit match: {release_group}")
 


### PR DESCRIPTION
in its current state, when a tracker bans release group "TAoE", the upload assistant misses it as the group often lists the individual as well, for example -JBENT[TAoE].  This change will generalize recognizing the group simply as TAoE allowing bans to be enforced.