### PR TITLE
Update titles of remux for HDB

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -195,6 +195,8 @@ class HDB():
         hdb_name = hdb_name.replace('PQ10', 'HDR')
         hdb_name = hdb_name.replace('Dubbed', '').replace('Dual-Audio', '')
         hdb_name = hdb_name.replace('REMUX', 'Remux')
+        hdb_name = hdb_name.replace('BluRay Remux', 'Remux')
+        hdb_name = hdb_name.replace('UHD Remux', 'Remux')
         hdb_name = ' '.join(hdb_name.split())
         hdb_name = re.sub(r"[^0-9a-zA-ZÀ-ÿ. :&+'\-\[\]]+", "", hdb_name)
         hdb_name = hdb_name.replace(' .', '.').replace('..', '.')


### PR DESCRIPTION
I have recently noted that UA gives wrong titles for UHD remuxes on HDB. It writes:
`Sur mes lèvres 2001 2160p UHD Remux DoVi HDR10 HEVC DTS-HD MA 5.1-CiNEPHiLES`
where it should be:
`Sur mes lèvres 2001 2160p Remux DoVi HDR10 HEVC DTS-HD MA 5.1-CiNEPHiLES`
This is something new, as it was not happening before.
The proposed PR fixes that.