### PR TITLE
fix(AvistaZ sites) - languages, resolution, naming, rules

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -335,6 +335,9 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
+            # If True, the script will check for rules compliance.
+            # Set to False to skip this check.
+            "check_for_rules": True,
         },
         "BHD": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
@@ -399,6 +402,9 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
+            # If True, the script will check for rules compliance.
+            # Set to False to skip this check.
+            "check_for_rules": True,
         },
         "DC": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
@@ -584,6 +590,9 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
+            # If True, the script will check for rules compliance.
+            # Set to False to skip this check.
+            "check_for_rules": True,
         },
         "PT": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -333,8 +333,6 @@ config = {
             # cookies need to be in netscape format and need to be in data/cookies/AZ.txt
             "announce_url": "https://tracker.avistaz.to/<PASSKEY>/announce",
             "anon": False,
-            # Set false to use imgbox links if available
-            "img_rehost": True,
             # If True, the script performs a basic rules compliance check (e.g., codecs, region).
             # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
@@ -400,8 +398,6 @@ config = {
             # cookies need to be in netscape format and need to be in data/cookies/CZ.txt
             "announce_url": "https://tracker.cinemaz.to/<PASSKEY>/announce",
             "anon": False,
-            # Set false to use imgbox links if available
-            "img_rehost": True,
             # If True, the script performs a basic rules compliance check (e.g., codecs, region).
             # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
@@ -588,8 +584,6 @@ config = {
             # cookies need to be in netscape format and need to be in data/cookies/PHD.txt
             "announce_url": "https://tracker.privatehd.to/<PASSKEY>/announce",
             "anon": False,
-            # Set false to use imgbox links if available
-            "img_rehost": True,
             # If True, the script performs a basic rules compliance check (e.g., codecs, region).
             # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -335,8 +335,8 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
-            # If True, the script will check for rules compliance.
-            # Set to False to skip this check.
+            # If True, the script performs a basic rules compliance check (e.g., codecs, region).
+            # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
         },
         "BHD": {
@@ -402,8 +402,8 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
-            # If True, the script will check for rules compliance.
-            # Set to False to skip this check.
+            # If True, the script performs a basic rules compliance check (e.g., codecs, region).
+            # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
         },
         "DC": {
@@ -590,8 +590,8 @@ config = {
             "anon": False,
             # Set false to use imgbox links if available
             "img_rehost": True,
-            # If True, the script will check for rules compliance.
-            # Set to False to skip this check.
+            # If True, the script performs a basic rules compliance check (e.g., codecs, region).
+            # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
         },
         "PT": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiofiles
 aiohttp
 anitopy
+bbcode
 beautifulsoup4
 bencode.py
 cli-ui

--- a/src/languages.py
+++ b/src/languages.py
@@ -158,7 +158,7 @@ async def process_desc_language(meta, desc=None, tracker=None):
                             meta['tracker_status'][tracker]['skip_upload'] = True
 
                     if meta['audio_languages']:
-                        meta['audio_languages'] = [lang.split()[0] for lang in meta['audio_languages']]
+                        meta['audio_languages'] = [lang for lang in meta['audio_languages']]
 
                 if (not meta.get('unattended_subtitle_skip', False) or not meta.get('unattended_audio_skip', False)) and (not subtitle_languages or subtitle_languages is None):
                     if 'text' in parsed_info:
@@ -193,7 +193,7 @@ async def process_desc_language(meta, desc=None, tracker=None):
                                 meta['tracker_status'][tracker]['skip_upload'] = True
 
                         if meta['subtitle_languages']:
-                            meta['subtitle_languages'] = [lang.split()[0] for lang in meta['subtitle_languages']]
+                            meta['subtitle_languages'] = [lang for lang in meta['subtitle_languages']]
 
                     if meta.get('hardcoded-subs', False):
                         if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):

--- a/src/languages.py
+++ b/src/languages.py
@@ -158,7 +158,7 @@ async def process_desc_language(meta, desc=None, tracker=None):
                             meta['tracker_status'][tracker]['skip_upload'] = True
 
                     if meta['audio_languages']:
-                        meta['audio_languages'] = [lang for lang in meta['audio_languages']]
+                        meta['audio_languages'] = [lang.split()[0] for lang in meta['audio_languages']]
 
                 if (not meta.get('unattended_subtitle_skip', False) or not meta.get('unattended_audio_skip', False)) and (not subtitle_languages or subtitle_languages is None):
                     if 'text' in parsed_info:
@@ -193,7 +193,7 @@ async def process_desc_language(meta, desc=None, tracker=None):
                                 meta['tracker_status'][tracker]['skip_upload'] = True
 
                         if meta['subtitle_languages']:
-                            meta['subtitle_languages'] = [lang for lang in meta['subtitle_languages']]
+                            meta['subtitle_languages'] = [lang.split()[0] for lang in meta['subtitle_languages']]
 
                     if meta.get('hardcoded-subs', False):
                         if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -331,11 +331,15 @@ class AZTrackerBase():
 
                 tracks = data.get('media', {}).get('track', [])
 
+                missing_audio_languages = []
+
                 for track in tracks:
                     track_type = track.get('@type')
                     language_code = track.get('Language')
 
                     if not language_code:
+                        if track_type == 'Audio':
+                            missing_audio_languages.append(track)
                         continue
 
                     target_id = self.lang_map.get(language_code.lower())
@@ -349,6 +353,17 @@ class AZTrackerBase():
                             audio_ids.add(target_id)
                         elif track_type == 'Text':
                             subtitle_ids.add(target_id)
+
+                if missing_audio_languages:
+                    console.print('No audio language/s found for the following tracks:')
+                    console.print('You must enter (comma-separated) languages for all audio tracks, eg: English, Spanish: ')
+                    user_input = console.input('[bold yellow]Enter languages: [/bold yellow]')
+
+                    langs = [lang.strip() for lang in user_input.split(',')]
+                    for lang in langs:
+                        target_id = self.lang_map.get(lang.lower())
+                        if target_id:
+                            audio_ids.add(target_id)
 
             except FileNotFoundError:
                 print(f'Warning: MediaInfo.json not found for uuid {meta.get("uuid")}. No languages will be processed.')

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -604,6 +604,14 @@ class AZTrackerBase():
             elif self.tracker == 'PHD':
                 tags.insert(0, '1448')
 
+        if self.config['TRACKERS'][self.tracker].get('internal', False):
+            if self.tracker == 'AZ':
+                tags.insert(0, '943')
+            elif self.tracker == 'CZ':
+                tags.insert(0, '938')
+            elif self.tracker == 'PHD':
+                tags.insert(0, '415')
+
         return tags
 
     async def edit_desc(self, meta):
@@ -616,15 +624,16 @@ class AZTrackerBase():
             with open(base_desc_path, 'r', encoding='utf-8') as file:
                 manual_desc = file.read()
 
-            console.print('\n[green]Found existing description:[/green]\n')
-            print(manual_desc)
-            user_input = input('Do you want to use this description? (y/n): ')
+            if manual_desc:
+                console.print('\n[green]Found existing description:[/green]\n')
+                print(manual_desc)
+                user_input = input('Do you want to use this description? (y/n): ')
 
-            if user_input.lower() == 'y':
-                description_parts.append(manual_desc)
-                console.print('Using existing description.')
-            else:
-                console.print('Ignoring existing description.')
+                if user_input.lower() == 'y':
+                    description_parts.append(manual_desc)
+                    console.print('Using existing description.')
+                else:
+                    console.print('Ignoring existing description.')
 
         raw_bbcode_desc = '\n\n'.join(filter(None, description_parts))
 

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -681,8 +681,7 @@ class AZTrackerBase():
                         match = re.search(r'/(\d+)$', redirect_url)
                         if not match:
                             console.print(f"{self.tracker}: Could not extract 'task_id' from redirect URL: {redirect_url}")
-                            meta['skipping'] = f'{self.tracker}'
-                            return
+                            console.print(f'{self.tracker}: The cookie appears to be expired or invalid.')
 
                         task_id = match.group(1)
 

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -380,9 +380,12 @@ class AZTrackerBase():
                             audio_ids.add(target_id)
                         elif track_type == 'Text':
                             subtitle_ids.add(target_id)
+                    else:
+                        if track_type == 'Audio':
+                            missing_audio_languages.append(track)
 
                 if missing_audio_languages:
-                    console.print('No audio language/s found for the following tracks:')
+                    console.print('No audio language/s found.')
                     console.print('You must enter (comma-separated) languages for all audio tracks, eg: English, Spanish: ')
                     user_input = console.input('[bold yellow]Enter languages: [/bold yellow]')
 

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -256,8 +256,7 @@ class AZTrackerBase():
         if self.config['TRACKERS'][self.tracker].get('check_for_rules', True):
             warnings = await self.rules(meta)
             if warnings:
-                console.print(f"{self.tracker}: [red]Rule check returned the following warning(s):[/red] \n")
-                console.print(f"{meta[f'{self.tracker.lower()}_rule']}\n")
+                console.print(f"{self.tracker}: [red]Rule check returned the following warning(s):[/red]\n\n{warnings}")
                 if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
                     choice = input('Do you want to continue anyway? [y/N]: ').strip().lower()
                     if choice != 'y':
@@ -614,9 +613,18 @@ class AZTrackerBase():
         description_parts = []
 
         if os.path.exists(base_desc_path):
-            with open(base_desc_path, 'r', encoding='utf-8') as f:
-                manual_desc = f.read()
-            description_parts.append(manual_desc)
+            with open(base_desc_path, 'r', encoding='utf-8') as file:
+                manual_desc = file.read()
+
+            console.print('\n[green]Found existing description:[/green]\n')
+            print(manual_desc)
+            user_input = input('Do you want to use this description? (y/n): ')
+
+            if user_input.lower() == 'y':
+                description_parts.append(manual_desc)
+                console.print('Using existing description.')
+            else:
+                console.print('Ignoring existing description.')
 
         raw_bbcode_desc = '\n\n'.join(filter(None, description_parts))
 

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -138,7 +138,7 @@ class AZTrackerBase():
 
                 if user_choice in ['y', 'yes']:
                     console.print(f'{self.tracker}: Trying to add to database...')
-                    added_successfully = await self.add_media_to_db(meta, title, category, imdb_id, tmdb_id, self.tracker)
+                    added_successfully = await self.add_media_to_db(meta, title, category, imdb_id, tmdb_id)
                     if not added_successfully:
                         console.print(f'{self.tracker}: Failed to add media. Aborting.')
                         break
@@ -1020,21 +1020,21 @@ class AZTrackerBase():
 
         if self.tracker == 'PHD':
             self.all_lang_map.update({
-                ('Brazilian Portuguese', 'por', 'pt'): '187',
+                ('Portuguese (BR)', 'por', 'pt-br'): '187',
                 ('Filipino', 'fil', 'fil'): '189',
                 ('Mooré', 'mos', 'mos'): '188',
             })
 
         if self.tracker == 'AZ':
             self.all_lang_map.update({
-                ('Brazilian Portuguese', 'por', 'pt'): '189',
+                ('Portuguese (BR)', 'por', 'pt-br'): '189',
                 ('Filipino', 'fil', 'fil'): '188',
                 ('Mooré', 'mos', 'mos'): '187',
             })
 
         if self.tracker == 'CZ':
             self.all_lang_map.update({
-                ('Brazilian Portuguese', 'por', 'pt'): '187',
+                ('Portuguese (BR)', 'por', 'pt-br'): '187',
                 ('Mooré', 'mos', 'mos'): '188',
                 ('Filipino', 'fil', 'fil'): '189',
                 ('Bissa', 'bib', 'bib'): '190',

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -63,6 +63,11 @@ class AZTrackerBase():
     def get_video_quality(self, meta):
         resolution = meta.get('resolution')
 
+        if self.tracker != 'PHD':
+            resolution_int = int(resolution.lower().replace('p', '').replace('i', ''))
+            if resolution_int < 720 or meta.get('sd', False):
+                return '1'
+
         keyword_map = {
             '1080i': '7',
             '1080p': '3',

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -78,7 +78,7 @@ class AZ(AZTrackerBase):
                 'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
                 'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
                 'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
             ]
             oceania = [
                 'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -203,3 +203,11 @@ class AZ(AZTrackerBase):
                 return False
 
         return True
+
+    def edit_name(self, meta):
+        upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')
+
+        if meta.get('has_encode_settings', False):
+            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
+
+        return upload_name

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -202,10 +202,3 @@ class AZ(AZTrackerBase):
 
             return True
 
-    def edit_name(self, meta):
-        upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')
-
-        if meta.get('has_encode_settings', False):
-            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
-
-        return upload_name

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -142,11 +142,6 @@ class AZ(AZTrackerBase):
                                     )
                     return False
 
-                resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-                if resolution < 600:
-                    meta['az_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
-                    return False
-
             '''
             Audio Codecs:
                 Allowed: MP3, AAC, HE-AAC, AC3 (Dolby Digital), E-AC3, Dolby TrueHD, DTS, DTS-HD (MA), FLAC

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -16,193 +16,196 @@ class AZ(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        meta['az_rule'] = ''
-        warning = f'{self.tracker} RULE WARNING: '
-
-        is_disc = False
-        if meta.get('is_disc', ''):
-            is_disc = True
-
-        video_codec = meta.get('video_codec', '')
-        if video_codec:
-            video_codec = video_codec.strip().lower()
-
-        video_encode = meta.get('video_encode', '')
-        if video_encode:
-            video_encode = video_encode.strip().lower()
-
-        type = meta.get('type', '')
-        if type:
-            type = type.strip().lower()
-
-        source = meta.get('source', '')
-        if source:
-            source = source.strip().lower()
-
-        # This also checks the rule 'FANRES content is not allowed'
-        if meta['category'] not in ('MOVIE', 'TV'):
-            meta['az_rule'] = (
-                warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                'Anything else, like games, music, software and porn is not allowed!'
-            )
-            return False
-
-        if meta.get('anime', False):
-            meta['az_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-            return False
-
-        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-        africa = [
-            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-        ]
-        america = [
-            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-        ]
-        asia = [
-            'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
-            'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
-            'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
-            'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
-        ]
-        europe = [
-            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-            'SI', 'SJ', 'SK', 'SM', 'UA', 'VA'
-        ]
-        oceania = [
-            'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
-            'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
-        ]
-
-        az_allowed_countries = [
-            'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
-            'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
-        ]
-
-        phd_countries = [
-            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-        ]
-
-        all_countries = africa + america + asia + europe + oceania
-        cinemaz_countries = list(set(all_countries) - set(phd_countries) - set(az_allowed_countries))
-
-        origin_countries_codes = meta.get('origin_country', [])
-
-        if any(code in phd_countries for code in origin_countries_codes):
-            meta['az_rule'] = (
-                warning + 'DO NOT upload content from major English speaking countries '
-                '(USA, UK, Canada, etc). Upload this to our sister site PrivateHD.to instead.'
-            )
-            return False
-
-        elif any(code in cinemaz_countries for code in origin_countries_codes):
-            meta['az_rule'] = (
-                warning + 'DO NOT upload non-allowed Asian or Western content. '
-                'Upload this content to our sister site CinemaZ.to instead.'
-            )
-            return False
-
-        if not is_disc:
-            ext = os.path.splitext(meta['filelist'][0])[1].lower()
-            allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4', '.avi': 'AVI'}
-            container = allowed_extensions.get(ext)
-            if container is None:
-                meta['az_rule'] = warning + 'Allowed containers: MKV, MP4, AVI.'
-                return False
-
-        '''
-        Video Codecs:
-            Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid
-            Exceptions:
-                MPEG2 for Full DVD discs and HDTV recordings
-                VC-1/MPEG2 for Bluray only if that's what is on the disc
-            Not Allowed: Any codec not mentioned above is not allowed!
-        '''
-        if not is_disc:
-            if video_codec not in ('avc', 'h.264', 'h.265', 'x264', 'x265', 'hevc', 'divx', 'xvid'):
-                meta['az_rule'] = (
-                                warning +
-                                f'Video codec not allowed in your upload: {video_codec}.\n'
-                                'Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid\n'
-                                'Exceptions:\n'
-                                '    MPEG2 for Full DVD discs and HDTV recordings\n'
-                                "    VC-1/MPEG2 for Bluray only if that's what is on the disc"
-                                )
-                return False
-
-        resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-        if resolution < 600:
-            meta['az_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
-            return False
-
-        '''
-        Audio Codecs:
-            Allowed: MP3, AAC, HE-AAC, AC3 (Dolby Digital), E-AC3, Dolby TrueHD, DTS, DTS-HD (MA), FLAC
-            Not Allowed: Any codec not mentioned above is not allowed!
-            Exceptions: Source is OPUS and upload is untouched from the source
-                Note: AC3(DD) / E-AC3 (DDP) will not trump existing AAC uploads with same audio bitrate and channels.
-                (Considering all else is equal and only audio codecs are different)
-        '''
-        if is_disc:
-            pass
+        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
+            return True
         else:
-            allowed_keywords = [
-                'AC3', 'Audio Layer III', 'MP3', 'Dolby Digital', 'Dolby TrueHD',
-                'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby', 'PCM', 'LPCM'
-            ]
+            meta['az_rule'] = ''
+            warning = f'{self.tracker} RULE WARNING: '
 
-            is_untouched_opus = False
-            audio_field = meta.get('audio', '')
-            if isinstance(audio_field, str) and 'opus' in audio_field.lower() and bool(meta.get('untouched', False)):
-                is_untouched_opus = True
+            is_disc = False
+            if meta.get('is_disc', ''):
+                is_disc = True
 
-            audio_tracks = []
-            media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
-            for track in media_tracks:
-                if track.get('@type') == 'Audio':
-                    codec_info = track.get('Format_Commercial_IfAny') or track.get('Format')
-                    codec = codec_info if isinstance(codec_info, str) else ''
-                    audio_tracks.append({
-                        'codec': codec,
-                        'language': track.get('Language', '')
-                    })
+            video_codec = meta.get('video_codec', '')
+            if video_codec:
+                video_codec = video_codec.strip().lower()
 
-            invalid_codecs = []
-            for track in audio_tracks:
-                codec = track['codec']
-                if not codec:
-                    continue
+            video_encode = meta.get('video_encode', '')
+            if video_encode:
+                video_encode = video_encode.strip().lower()
 
-                if 'opus' in codec.lower():
-                    if is_untouched_opus:
-                        continue
-                    else:
-                        invalid_codecs.append(codec)
-                        continue
+            type = meta.get('type', '')
+            if type:
+                type = type.strip().lower()
 
-                is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
-                if not is_allowed:
-                    invalid_codecs.append(codec)
+            source = meta.get('source', '')
+            if source:
+                source = source.strip().lower()
 
-            if invalid_codecs:
-                unique_invalid_codecs = sorted(list(set(invalid_codecs)))
+            # This also checks the rule 'FANRES content is not allowed'
+            if meta['category'] not in ('MOVIE', 'TV'):
                 meta['az_rule'] = (
-                    warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
-                    f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, MP3, etc.\n'
-                    f'Exceptions: Untouched Opus from source; Uncompressed codecs from Blu-ray discs (PCM, LPCM).'
+                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                    'Anything else, like games, music, software and porn is not allowed!'
                 )
                 return False
 
-        return True
+            if meta.get('anime', False):
+                meta['az_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
+                return False
+
+            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+
+            africa = [
+                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+            ]
+            america = [
+                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+            ]
+            asia = [
+                'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
+                'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
+                'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
+                'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
+            ]
+            europe = [
+                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+            ]
+            oceania = [
+                'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
+                'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
+            ]
+
+            az_allowed_countries = [
+                'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
+                'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
+            ]
+
+            phd_countries = [
+                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+            ]
+
+            all_countries = africa + america + asia + europe + oceania
+            cinemaz_countries = list(set(all_countries) - set(phd_countries) - set(az_allowed_countries))
+
+            origin_countries_codes = meta.get('origin_country', [])
+
+            if any(code in phd_countries for code in origin_countries_codes):
+                meta['az_rule'] = (
+                    warning + 'DO NOT upload content from major English speaking countries '
+                    '(USA, UK, Canada, etc). Upload this to our sister site PrivateHD.to instead.'
+                )
+                return False
+
+            elif any(code in cinemaz_countries for code in origin_countries_codes):
+                meta['az_rule'] = (
+                    warning + 'DO NOT upload non-allowed Asian or Western content. '
+                    'Upload this content to our sister site CinemaZ.to instead.'
+                )
+                return False
+
+            if not is_disc:
+                ext = os.path.splitext(meta['filelist'][0])[1].lower()
+                allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4', '.avi': 'AVI'}
+                container = allowed_extensions.get(ext)
+                if container is None:
+                    meta['az_rule'] = warning + 'Allowed containers: MKV, MP4, AVI.'
+                    return False
+
+            '''
+            Video Codecs:
+                Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid
+                Exceptions:
+                    MPEG2 for Full DVD discs and HDTV recordings
+                    VC-1/MPEG2 for Bluray only if that's what is on the disc
+                Not Allowed: Any codec not mentioned above is not allowed!
+            '''
+            if not is_disc:
+                if video_codec not in ('avc', 'h.264', 'h.265', 'x264', 'x265', 'hevc', 'divx', 'xvid'):
+                    meta['az_rule'] = (
+                                    warning +
+                                    f'Video codec not allowed in your upload: {video_codec}.\n'
+                                    'Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid\n'
+                                    'Exceptions:\n'
+                                    '    MPEG2 for Full DVD discs and HDTV recordings\n'
+                                    "    VC-1/MPEG2 for Bluray only if that's what is on the disc"
+                                    )
+                    return False
+
+                resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
+                if resolution < 600:
+                    meta['az_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
+                    return False
+
+            '''
+            Audio Codecs:
+                Allowed: MP3, AAC, HE-AAC, AC3 (Dolby Digital), E-AC3, Dolby TrueHD, DTS, DTS-HD (MA), FLAC
+                Not Allowed: Any codec not mentioned above is not allowed!
+                Exceptions: Source is OPUS and upload is untouched from the source
+                    Note: AC3(DD) / E-AC3 (DDP) will not trump existing AAC uploads with same audio bitrate and channels.
+                    (Considering all else is equal and only audio codecs are different)
+            '''
+            if is_disc:
+                pass
+            else:
+                allowed_keywords = [
+                    'AC3', 'Audio Layer III', 'MP3', 'Dolby Digital', 'Dolby TrueHD',
+                    'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby', 'PCM', 'LPCM'
+                ]
+
+                is_untouched_opus = False
+                audio_field = meta.get('audio', '')
+                if isinstance(audio_field, str) and 'opus' in audio_field.lower() and bool(meta.get('untouched', False)):
+                    is_untouched_opus = True
+
+                audio_tracks = []
+                media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
+                for track in media_tracks:
+                    if track.get('@type') == 'Audio':
+                        codec_info = track.get('Format_Commercial_IfAny') or track.get('Format')
+                        codec = codec_info if isinstance(codec_info, str) else ''
+                        audio_tracks.append({
+                            'codec': codec,
+                            'language': track.get('Language', '')
+                        })
+
+                invalid_codecs = []
+                for track in audio_tracks:
+                    codec = track['codec']
+                    if not codec:
+                        continue
+
+                    if 'opus' in codec.lower():
+                        if is_untouched_opus:
+                            continue
+                        else:
+                            invalid_codecs.append(codec)
+                            continue
+
+                    is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
+                    if not is_allowed:
+                        invalid_codecs.append(codec)
+
+                if invalid_codecs:
+                    unique_invalid_codecs = sorted(list(set(invalid_codecs)))
+                    meta['az_rule'] = (
+                        warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
+                        f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, MP3, etc.\n'
+                        f'Exceptions: Untouched Opus from source; Uncompressed codecs from Blu-ray discs (PCM, LPCM).'
+                    )
+                    return False
+
+            return True
 
     def edit_name(self, meta):
         upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -16,189 +16,164 @@ class AZ(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
-            return True
+        warnings = []
+
+        is_disc = False
+        if meta.get('is_disc', ''):
+            is_disc = True
+
+        video_codec = meta.get('video_codec', '')
+        if video_codec:
+            video_codec = video_codec.strip().lower()
+
+        video_encode = meta.get('video_encode', '')
+        if video_encode:
+            video_encode = video_encode.strip().lower()
+
+        type = meta.get('type', '')
+        if type:
+            type = type.strip().lower()
+
+        source = meta.get('source', '')
+        if source:
+            source = source.strip().lower()
+
+        # This also checks the rule 'FANRES content is not allowed'
+        if meta['category'] not in ('MOVIE', 'TV'):
+            warnings.append(
+                'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                'Anything else, like games, music, software and porn is not allowed!'
+            )
+
+        if meta.get('anime', False):
+            warnings.append("Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime.")
+
+        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+
+        africa = [
+            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+        ]
+        america = [
+            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+        ]
+        asia = [
+            'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
+            'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
+            'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
+            'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
+        ]
+        europe = [
+            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+            'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
+        ]
+        oceania = [
+            'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
+            'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
+        ]
+
+        az_allowed_countries = [
+            'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
+            'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
+        ]
+
+        phd_countries = [
+            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+        ]
+
+        all_countries = africa + america + asia + europe + oceania
+        cinemaz_countries = list(set(all_countries) - set(phd_countries) - set(az_allowed_countries))
+
+        origin_countries_codes = meta.get('origin_country', [])
+
+        if any(code in phd_countries for code in origin_countries_codes):
+            warnings.append(
+                'DO NOT upload content from major English speaking countries '
+                '(USA, UK, Canada, etc). Upload this to our sister site PrivateHD.to instead.'
+            )
+
+        elif any(code in cinemaz_countries for code in origin_countries_codes):
+            warnings.append(
+                'DO NOT upload non-allowed Asian or Western content. '
+                'Upload this content to our sister site CinemaZ.to instead.'
+            )
+
+        if not is_disc:
+            ext = os.path.splitext(meta['filelist'][0])[1].lower()
+            allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4', '.avi': 'AVI'}
+            container = allowed_extensions.get(ext)
+            if container is None:
+                warnings.append('Allowed containers: MKV, MP4, AVI.')
+
+        if not is_disc:
+            if video_codec not in ('avc', 'h.264', 'h.265', 'x264', 'x265', 'hevc', 'divx', 'xvid'):
+                warnings.append(
+                    f'Video codec not allowed in your upload: {video_codec}.\n'
+                    'Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid\n'
+                    'Exceptions:\n'
+                    '    MPEG2 for Full DVD discs and HDTV recordings\n'
+                    "    VC-1/MPEG2 for Bluray only if that's what is on the disc"
+                )
+
+        if is_disc:
+            pass
         else:
-            meta['az_rule'] = ''
-            warning = f'{self.tracker} RULE WARNING: '
-
-            is_disc = False
-            if meta.get('is_disc', ''):
-                is_disc = True
-
-            video_codec = meta.get('video_codec', '')
-            if video_codec:
-                video_codec = video_codec.strip().lower()
-
-            video_encode = meta.get('video_encode', '')
-            if video_encode:
-                video_encode = video_encode.strip().lower()
-
-            type = meta.get('type', '')
-            if type:
-                type = type.strip().lower()
-
-            source = meta.get('source', '')
-            if source:
-                source = source.strip().lower()
-
-            # This also checks the rule 'FANRES content is not allowed'
-            if meta['category'] not in ('MOVIE', 'TV'):
-                meta['az_rule'] = (
-                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                    'Anything else, like games, music, software and porn is not allowed!'
-                )
-                return False
-
-            if meta.get('anime', False):
-                meta['az_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-                return False
-
-            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-            africa = [
-                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-            ]
-            america = [
-                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-            ]
-            asia = [
-                'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
-                'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
-                'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
-                'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
-            ]
-            europe = [
-                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
-            ]
-            oceania = [
-                'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
-                'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
+            allowed_keywords = [
+                'AC3', 'Audio Layer III', 'MP3', 'Dolby Digital', 'Dolby TrueHD',
+                'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby'
             ]
 
-            az_allowed_countries = [
-                'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
-                'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
-            ]
+            is_untouched_opus = False
+            audio_field = meta.get('audio', '')
+            if isinstance(audio_field, str) and 'opus' in audio_field.lower() and bool(meta.get('untouched', False)):
+                is_untouched_opus = True
 
-            phd_countries = [
-                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-            ]
+            audio_tracks = []
+            media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
+            for track in media_tracks:
+                if track.get('@type') == 'Audio':
+                    codec_info = track.get('Format_Commercial_IfAny') or track.get('Format')
+                    codec = codec_info if isinstance(codec_info, str) else ''
+                    audio_tracks.append({
+                        'codec': codec,
+                        'language': track.get('Language', '')
+                    })
 
-            all_countries = africa + america + asia + europe + oceania
-            cinemaz_countries = list(set(all_countries) - set(phd_countries) - set(az_allowed_countries))
+            invalid_codecs = []
+            for track in audio_tracks:
+                codec = track['codec']
+                if not codec:
+                    continue
 
-            origin_countries_codes = meta.get('origin_country', [])
-
-            if any(code in phd_countries for code in origin_countries_codes):
-                meta['az_rule'] = (
-                    warning + 'DO NOT upload content from major English speaking countries '
-                    '(USA, UK, Canada, etc). Upload this to our sister site PrivateHD.to instead.'
-                )
-                return False
-
-            elif any(code in cinemaz_countries for code in origin_countries_codes):
-                meta['az_rule'] = (
-                    warning + 'DO NOT upload non-allowed Asian or Western content. '
-                    'Upload this content to our sister site CinemaZ.to instead.'
-                )
-                return False
-
-            if not is_disc:
-                ext = os.path.splitext(meta['filelist'][0])[1].lower()
-                allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4', '.avi': 'AVI'}
-                container = allowed_extensions.get(ext)
-                if container is None:
-                    meta['az_rule'] = warning + 'Allowed containers: MKV, MP4, AVI.'
-                    return False
-
-            '''
-            Video Codecs:
-                Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid
-                Exceptions:
-                    MPEG2 for Full DVD discs and HDTV recordings
-                    VC-1/MPEG2 for Bluray only if that's what is on the disc
-                Not Allowed: Any codec not mentioned above is not allowed!
-            '''
-            if not is_disc:
-                if video_codec not in ('avc', 'h.264', 'h.265', 'x264', 'x265', 'hevc', 'divx', 'xvid'):
-                    meta['az_rule'] = (
-                                    warning +
-                                    f'Video codec not allowed in your upload: {video_codec}.\n'
-                                    'Allowed: H264/x264/AVC, H265/x265/HEVC, DivX/Xvid\n'
-                                    'Exceptions:\n'
-                                    '    MPEG2 for Full DVD discs and HDTV recordings\n'
-                                    "    VC-1/MPEG2 for Bluray only if that's what is on the disc"
-                                    )
-                    return False
-
-            '''
-            Audio Codecs:
-                Allowed: MP3, AAC, HE-AAC, AC3 (Dolby Digital), E-AC3, Dolby TrueHD, DTS, DTS-HD (MA), FLAC
-                Not Allowed: Any codec not mentioned above is not allowed!
-                Exceptions: Source is OPUS and upload is untouched from the source
-                    Note: AC3(DD) / E-AC3 (DDP) will not trump existing AAC uploads with same audio bitrate and channels.
-                    (Considering all else is equal and only audio codecs are different)
-            '''
-            if is_disc:
-                pass
-            else:
-                allowed_keywords = [
-                    'AC3', 'Audio Layer III', 'MP3', 'Dolby Digital', 'Dolby TrueHD',
-                    'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby', 'PCM', 'LPCM'
-                ]
-
-                is_untouched_opus = False
-                audio_field = meta.get('audio', '')
-                if isinstance(audio_field, str) and 'opus' in audio_field.lower() and bool(meta.get('untouched', False)):
-                    is_untouched_opus = True
-
-                audio_tracks = []
-                media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
-                for track in media_tracks:
-                    if track.get('@type') == 'Audio':
-                        codec_info = track.get('Format_Commercial_IfAny') or track.get('Format')
-                        codec = codec_info if isinstance(codec_info, str) else ''
-                        audio_tracks.append({
-                            'codec': codec,
-                            'language': track.get('Language', '')
-                        })
-
-                invalid_codecs = []
-                for track in audio_tracks:
-                    codec = track['codec']
-                    if not codec:
+                if 'opus' in codec.lower():
+                    if is_untouched_opus:
+                        continue
+                    else:
+                        invalid_codecs.append(codec)
                         continue
 
-                    if 'opus' in codec.lower():
-                        if is_untouched_opus:
-                            continue
-                        else:
-                            invalid_codecs.append(codec)
-                            continue
+                is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
+                if not is_allowed:
+                    invalid_codecs.append(codec)
 
-                    is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
-                    if not is_allowed:
-                        invalid_codecs.append(codec)
+            if invalid_codecs:
+                unique_invalid_codecs = sorted(list(set(invalid_codecs)))
+                warnings.append(
+                    f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
+                    f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, MP3, etc.\n'
+                    f'Exceptions: Untouched Opus from source; Uncompressed codecs from Blu-ray discs (PCM, LPCM).'
+                )
 
-                if invalid_codecs:
-                    unique_invalid_codecs = sorted(list(set(invalid_codecs)))
-                    meta['az_rule'] = (
-                        warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
-                        f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, MP3, etc.\n'
-                        f'Exceptions: Untouched Opus from source; Uncompressed codecs from Blu-ray discs (PCM, LPCM).'
-                    )
-                    return False
+        if warnings:
+            all_warnings = '\n\n'.join(filter(None, warnings))
+            meta['az_rule'] = all_warnings
 
-            return True
-
+        return warnings

--- a/src/trackers/AZ.py
+++ b/src/trackers/AZ.py
@@ -174,6 +174,6 @@ class AZ(AZTrackerBase):
 
         if warnings:
             all_warnings = '\n\n'.join(filter(None, warnings))
-            meta['az_rule'] = all_warnings
+            return all_warnings
 
-        return warnings
+        return

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -130,12 +130,6 @@ class CZ(AZTrackerBase):
                 )
                 return False
 
-            if not meta.get('is_disc', False):
-                resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-                if resolution < 600:
-                    meta['cz_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
-                    return False
-
             return True
 
     def edit_name(self, meta):

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
 from datetime import datetime
 from src.trackers.COMMON import COMMON
 from src.trackers.AVISTAZ_NETWORK import AZTrackerBase
@@ -131,19 +130,3 @@ class CZ(AZTrackerBase):
                 return False
 
             return True
-
-    def edit_name(self, meta):
-        upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')
-
-        if meta.get('has_encode_settings', False):
-            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
-
-        tag_lower = meta['tag'].lower()
-        invalid_tags = ['nogrp', 'nogroup', 'unknown', '-unk-']
-
-        if meta['tag'] == '' or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
-            for invalid_tag in invalid_tags:
-                upload_name = re.sub(f'-{invalid_tag}', '', upload_name, flags=re.IGNORECASE)
-            upload_name = f'{upload_name}-NoGroup'
-
-        return upload_name

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -17,122 +17,126 @@ class CZ(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        meta['cz_rule'] = ''
-        warning = f'{self.tracker} RULE WARNING: '
+        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
+            return True
+        else:
+            meta['cz_rule'] = ''
+            warning = f'{self.tracker} RULE WARNING: '
 
-        # This also checks the rule 'FANRES content is not allowed'
-        if meta['category'] not in ('MOVIE', 'TV'):
-            meta['cz_rule'] = (
-                warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                'Anything else, like games, music, software and porn is not allowed!'
-            )
-            return False
-
-        if meta.get('anime', False):
-            meta['cz_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-            return False
-
-        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-        africa = [
-            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-        ]
-
-        america = [
-            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-        ]
-
-        europe = [
-            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-            'SI', 'SJ', 'SK', 'SM', 'UA', 'VA'
-        ]
-
-        # Countries that belong on PrivateHD (unless they are old)
-        phd_countries = [
-            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-        ]
-
-        # Countries that belong on AvistaZ
-        az_countries = [
-            'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
-            'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
-        ]
-
-        # Countries normally allowed on CinemaZ
-        set_phd = set(phd_countries)
-        set_europe = set(europe)
-        set_america = set(america)
-        middle_east = [
-            'AE', 'BH', 'CY', 'EG', 'IR', 'IQ', 'IL', 'JO', 'KW', 'LB', 'OM', 'PS', 'QA', 'SA', 'SY', 'TR', 'YE'
-        ]
-
-        # Combine all allowed regions for CinemaZ
-        cz_allowed_countries = list(
-            (set_europe - {'GB', 'IE'}) |  # Europe excluding UK and Ireland
-            (set_america - set_phd) |      # All of America excluding the PHD countries
-            set(africa) |                  # All of Africa
-            set(middle_east) |             # Middle East countries
-            {'RU'}                         # Russia
-        )
-
-        origin_countries_codes = meta.get('origin_country', [])
-        year = meta.get('year')
-        is_older_than_50_years = False
-
-        if isinstance(year, int):
-            current_year = datetime.now().year
-            if (current_year - year) >= 50:
-                is_older_than_50_years = True
-
-        # Case 1: The content is from a major English-speaking country
-        if any(code in phd_countries for code in origin_countries_codes):
-            if is_older_than_50_years:
-                # It's old, so it's ALLOWED on CinemaZ
-                pass
-            else:
-                # It's new, so redirect to PrivateHD
+            # This also checks the rule 'FANRES content is not allowed'
+            if meta['category'] not in ('MOVIE', 'TV'):
                 meta['cz_rule'] = (
-                    warning + 'DO NOT upload recent mainstream English content. '
-                    'Upload this to our sister site PrivateHD.to instead.'
+                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                    'Anything else, like games, music, software and porn is not allowed!'
                 )
                 return False
 
-        # Case 2: The content is Asian, redirect to AvistaZ
-        elif any(code in az_countries for code in origin_countries_codes):
-            meta['cz_rule'] = (
-                warning + 'DO NOT upload Asian content. '
-                'Upload this to our sister site AvistaZ.to instead.'
+            if meta.get('anime', False):
+                meta['cz_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
+                return False
+
+            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+
+            africa = [
+                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+            ]
+
+            america = [
+                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+            ]
+
+            europe = [
+                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+            ]
+
+            # Countries that belong on PrivateHD (unless they are old)
+            phd_countries = [
+                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+            ]
+
+            # Countries that belong on AvistaZ
+            az_countries = [
+                'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
+                'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
+            ]
+
+            # Countries normally allowed on CinemaZ
+            set_phd = set(phd_countries)
+            set_europe = set(europe)
+            set_america = set(america)
+            middle_east = [
+                'AE', 'BH', 'CY', 'EG', 'IR', 'IQ', 'IL', 'JO', 'KW', 'LB', 'OM', 'PS', 'QA', 'SA', 'SY', 'TR', 'YE'
+            ]
+
+            # Combine all allowed regions for CinemaZ
+            cz_allowed_countries = list(
+                (set_europe - {'GB', 'IE'}) |  # Europe excluding UK and Ireland
+                (set_america - set_phd) |      # All of America excluding the PHD countries
+                set(africa) |                  # All of Africa
+                set(middle_east) |             # Middle East countries
+                {'RU'}                         # Russia
             )
-            return False
 
-        # Case 3: The content is from one of the normally allowed CZ regions
-        elif any(code in cz_allowed_countries for code in origin_countries_codes):
-            # It's from a valid region, so it's ALLOWED on CinemaZ
-            pass
+            origin_countries_codes = meta.get('origin_country', [])
+            year = meta.get('year')
+            is_older_than_50_years = False
 
-        # Case 4: Fallback for any other case (e.g., country not in any list)
-        else:
-            meta['cz_rule'] = (
-                warning + 'This content is not allowed. CinemaZ accepts content from Europe (excluding UK/IE), '
-                'Africa, the Middle East, Russia, and the Americas (excluding recent mainstream English content).'
-            )
-            return False
+            if isinstance(year, int):
+                current_year = datetime.now().year
+                if (current_year - year) >= 50:
+                    is_older_than_50_years = True
 
-        resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-        if resolution < 600:
-            meta['cz_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
-            return False
+            # Case 1: The content is from a major English-speaking country
+            if any(code in phd_countries for code in origin_countries_codes):
+                if is_older_than_50_years:
+                    # It's old, so it's ALLOWED on CinemaZ
+                    pass
+                else:
+                    # It's new, so redirect to PrivateHD
+                    meta['cz_rule'] = (
+                        warning + 'DO NOT upload recent mainstream English content. '
+                        'Upload this to our sister site PrivateHD.to instead.'
+                    )
+                    return False
 
-        return True
+            # Case 2: The content is Asian, redirect to AvistaZ
+            elif any(code in az_countries for code in origin_countries_codes):
+                meta['cz_rule'] = (
+                    warning + 'DO NOT upload Asian content. '
+                    'Upload this to our sister site AvistaZ.to instead.'
+                )
+                return False
+
+            # Case 3: The content is from one of the normally allowed CZ regions
+            elif any(code in cz_allowed_countries for code in origin_countries_codes):
+                # It's from a valid region, so it's ALLOWED on CinemaZ
+                pass
+
+            # Case 4: Fallback for any other case (e.g., country not in any list)
+            else:
+                meta['cz_rule'] = (
+                    warning + 'This content is not allowed. CinemaZ accepts content from Europe (excluding UK/IE), '
+                    'Africa, the Middle East, Russia, and the Americas (excluding recent mainstream English content).'
+                )
+                return False
+
+            if not meta.get('is_disc', False):
+                resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
+                if resolution < 600:
+                    meta['cz_rule'] = warning + 'Video: A minimum resolution of 600 pixel width.'
+                    return False
+
+            return True
 
     def edit_name(self, meta):
         upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -122,6 +122,6 @@ class CZ(AZTrackerBase):
 
         if warnings:
             all_warnings = '\n\n'.join(filter(None, warnings))
-            meta['az_rule'] = all_warnings
+            return all_warnings
 
-        return warnings
+        return

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -55,7 +55,7 @@ class CZ(AZTrackerBase):
                 'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
                 'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
                 'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
             ]
 
             # Countries that belong on PrivateHD (unless they are old)

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -137,6 +137,9 @@ class CZ(AZTrackerBase):
     def edit_name(self, meta):
         upload_name = meta.get('name').replace(meta['aka'], '').replace('Dubbed', '').replace('Dual-Audio', '')
 
+        if meta.get('has_encode_settings', False):
+            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
+
         tag_lower = meta['tag'].lower()
         invalid_tags = ['nogrp', 'nogroup', 'unknown', '-unk-']
 

--- a/src/trackers/CZ.py
+++ b/src/trackers/CZ.py
@@ -16,117 +16,112 @@ class CZ(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
-            return True
-        else:
-            meta['cz_rule'] = ''
-            warning = f'{self.tracker} RULE WARNING: '
+        warnings = []
 
-            # This also checks the rule 'FANRES content is not allowed'
-            if meta['category'] not in ('MOVIE', 'TV'):
-                meta['cz_rule'] = (
-                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                    'Anything else, like games, music, software and porn is not allowed!'
-                )
-                return False
-
-            if meta.get('anime', False):
-                meta['cz_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-                return False
-
-            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-            africa = [
-                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-            ]
-
-            america = [
-                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-            ]
-
-            europe = [
-                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
-            ]
-
-            # Countries that belong on PrivateHD (unless they are old)
-            phd_countries = [
-                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-            ]
-
-            # Countries that belong on AvistaZ
-            az_countries = [
-                'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
-                'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
-            ]
-
-            # Countries normally allowed on CinemaZ
-            set_phd = set(phd_countries)
-            set_europe = set(europe)
-            set_america = set(america)
-            middle_east = [
-                'AE', 'BH', 'CY', 'EG', 'IR', 'IQ', 'IL', 'JO', 'KW', 'LB', 'OM', 'PS', 'QA', 'SA', 'SY', 'TR', 'YE'
-            ]
-
-            # Combine all allowed regions for CinemaZ
-            cz_allowed_countries = list(
-                (set_europe - {'GB', 'IE'}) |  # Europe excluding UK and Ireland
-                (set_america - set_phd) |      # All of America excluding the PHD countries
-                set(africa) |                  # All of Africa
-                set(middle_east) |             # Middle East countries
-                {'RU'}                         # Russia
+        # This also checks the rule 'FANRES content is not allowed'
+        if meta['category'] not in ('MOVIE', 'TV'):
+            warnings.append(
+                'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                'Anything else, like games, music, software and porn is not allowed!'
             )
 
-            origin_countries_codes = meta.get('origin_country', [])
-            year = meta.get('year')
-            is_older_than_50_years = False
+        if meta.get('anime', False):
+            warnings.append("Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime.")
 
-            if isinstance(year, int):
-                current_year = datetime.now().year
-                if (current_year - year) >= 50:
-                    is_older_than_50_years = True
+        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 
-            # Case 1: The content is from a major English-speaking country
-            if any(code in phd_countries for code in origin_countries_codes):
-                if is_older_than_50_years:
-                    # It's old, so it's ALLOWED on CinemaZ
-                    pass
-                else:
-                    # It's new, so redirect to PrivateHD
-                    meta['cz_rule'] = (
-                        warning + 'DO NOT upload recent mainstream English content. '
-                        'Upload this to our sister site PrivateHD.to instead.'
-                    )
-                    return False
+        africa = [
+            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+        ]
 
-            # Case 2: The content is Asian, redirect to AvistaZ
-            elif any(code in az_countries for code in origin_countries_codes):
-                meta['cz_rule'] = (
-                    warning + 'DO NOT upload Asian content. '
-                    'Upload this to our sister site AvistaZ.to instead.'
-                )
-                return False
+        america = [
+            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+        ]
 
-            # Case 3: The content is from one of the normally allowed CZ regions
-            elif any(code in cz_allowed_countries for code in origin_countries_codes):
-                # It's from a valid region, so it's ALLOWED on CinemaZ
+        europe = [
+            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+            'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
+        ]
+
+        # Countries that belong on PrivateHD (unless they are old)
+        phd_countries = [
+            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+        ]
+
+        # Countries that belong on AvistaZ
+        az_countries = [
+            'BD', 'BN', 'BT', 'CN', 'HK', 'ID', 'IN', 'JP', 'KH', 'KP', 'KR', 'LA', 'LK',
+            'MM', 'MN', 'MO', 'MY', 'NP', 'PH', 'PK', 'SG', 'TH', 'TL', 'TW', 'VN'
+        ]
+
+        # Countries normally allowed on CinemaZ
+        set_phd = set(phd_countries)
+        set_europe = set(europe)
+        set_america = set(america)
+        middle_east = [
+            'AE', 'BH', 'CY', 'EG', 'IR', 'IQ', 'IL', 'JO', 'KW', 'LB', 'OM', 'PS', 'QA', 'SA', 'SY', 'TR', 'YE'
+        ]
+
+        # Combine all allowed regions for CinemaZ
+        cz_allowed_countries = list(
+            (set_europe - {'GB', 'IE'}) |  # Europe excluding UK and Ireland
+            (set_america - set_phd) |      # All of America excluding the PHD countries
+            set(africa) |                  # All of Africa
+            set(middle_east) |             # Middle East countries
+            {'RU'}                         # Russia
+        )
+
+        origin_countries_codes = meta.get('origin_country', [])
+        year = meta.get('year')
+        is_older_than_50_years = False
+
+        if isinstance(year, int):
+            current_year = datetime.now().year
+            if (current_year - year) >= 50:
+                is_older_than_50_years = True
+
+        # Case 1: The content is from a major English-speaking country
+        if any(code in phd_countries for code in origin_countries_codes):
+            if is_older_than_50_years:
+                # It's old, so it's ALLOWED on CinemaZ
                 pass
-
-            # Case 4: Fallback for any other case (e.g., country not in any list)
             else:
-                meta['cz_rule'] = (
-                    warning + 'This content is not allowed. CinemaZ accepts content from Europe (excluding UK/IE), '
-                    'Africa, the Middle East, Russia, and the Americas (excluding recent mainstream English content).'
+                # It's new, so redirect to PrivateHD
+                warnings.append(
+                    'DO NOT upload recent mainstream English content. '
+                    'Upload this to our sister site PrivateHD.to instead.'
                 )
-                return False
 
-            return True
+        # Case 2: The content is Asian, redirect to AvistaZ
+        elif any(code in az_countries for code in origin_countries_codes):
+            warnings.append(
+                'DO NOT upload Asian content. '
+                'Upload this to our sister site AvistaZ.to instead.'
+            )
+
+        # Case 3: The content is from one of the normally allowed CZ regions
+        elif any(code in cz_allowed_countries for code in origin_countries_codes):
+            # It's from a valid region, so it's ALLOWED on CinemaZ
+            pass
+
+        # Case 4: Fallback for any other case (e.g., country not in any list)
+        else:
+            warnings.append(
+                'This content is not allowed. CinemaZ accepts content from Europe (excluding UK/IE), '
+                'Africa, the Middle East, Russia, and the Americas (excluding recent mainstream English content).'
+            )
+
+        if warnings:
+            all_warnings = '\n\n'.join(filter(None, warnings))
+            meta['az_rule'] = all_warnings
+
+        return warnings

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -91,7 +91,7 @@ class PHD(AZTrackerBase):
                 'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
                 'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
                 'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
             ]
 
             oceania = [

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -18,413 +18,416 @@ class PHD(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        meta['phd_rule'] = ''
-        warning = f'{self.tracker} RULE WARNING: '
-        rule = ''
-
-        is_bd_disc = False
-        if meta.get('is_disc', '') == 'BDMV':
-            is_bd_disc = True
-
-        video_codec = meta.get('video_codec', '')
-        if video_codec:
-            video_codec = video_codec.strip().lower()
-
-        video_encode = meta.get('video_encode', '')
-        if video_encode:
-            video_encode = video_encode.strip().lower()
-
-        type = meta.get('type', '')
-        if type:
-            type = type.strip().lower()
-
-        source = meta.get('source', '')
-        if source:
-            source = source.strip().lower()
-
-        # This also checks the rule 'FANRES content is not allowed'
-        if meta['category'] not in ('MOVIE', 'TV'):
-            meta['phd_rule'] = (
-                warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                'Anything else, like games, music, software and porn is not allowed!'
-            )
-            return False
-
-        if meta.get('anime', False):
-            meta['phd_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-            return False
-
-        year = meta.get('year')
-        current_year = datetime.now().year
-        is_older_than_50_years = (current_year - year) >= 50
-        if is_older_than_50_years:
-            meta['phd_rule'] = warning + 'Upload movies/series 50+ years old to our sister site CinemaZ.to instead.'
-            return False
-
-        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-        africa = [
-            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-        ]
-
-        america = [
-            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-        ]
-
-        asia = [
-            'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
-            'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
-            'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
-            'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
-        ]
-
-        europe = [
-            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-            'SI', 'SJ', 'SK', 'SM', 'UA', 'VA'
-        ]
-
-        oceania = [
-            'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
-            'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
-        ]
-
-        phd_allowed_countries = [
-            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-        ]
-
-        all_countries = africa + america + europe + oceania
-        cinemaz_countries = list(set(all_countries) - set(phd_allowed_countries))
-
-        origin_countries_codes = meta.get('origin_country', [])
-
-        if any(code in phd_allowed_countries for code in origin_countries_codes):
+        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
             return True
+        else:
+            meta['phd_rule'] = ''
+            warning = f'{self.tracker} RULE WARNING: '
+            rule = ''
 
-        # CinemaZ
-        elif any(code in cinemaz_countries for code in origin_countries_codes):
-            meta['phd_rule'] = warning + 'Upload European (EXCLUDING United Kingdom and Ireland), South American and African content to our sister site CinemaZ.to instead.'
-            return False
+            is_bd_disc = False
+            if meta.get('is_disc', '') == 'BDMV':
+                is_bd_disc = True
 
-        # AvistaZ
-        elif any(code in asia for code in origin_countries_codes):
-            origin_country_str = ', '.join(origin_countries_codes)
-            meta['phd_rule'] = (
-                warning + 'DO NOT upload content originating from countries shown in this map (https://imgur.com/nIB9PM1).\n'
-                'In case of doubt, message the staff first. Upload Asian content to our sister site Avistaz.to instead.\n'
-                f'Origin country for your upload: {origin_country_str}'
-            )
-            return False
+            video_codec = meta.get('video_codec', '')
+            if video_codec:
+                video_codec = video_codec.strip().lower()
 
-        elif not any(code in phd_allowed_countries for code in origin_countries_codes):
-            meta['phd_rule'] = (
-                warning + 'Only upload content to PrivateHD from all major English speaking countries.\n'
-                'Including United States, Canada, UK, Ireland, Australia, and New Zealand.'
-            )
-            return False
+            video_encode = meta.get('video_encode', '')
+            if video_encode:
+                video_encode = video_encode.strip().lower()
 
-        # Tags
-        tag = meta.get('tag', '')
-        if tag:
-            tag = tag.strip().lower()
-            if tag in ('rarbg', 'fgt', 'grym', 'tbs'):
-                meta['phd_rule'] = warning + 'Do not upload RARBG, FGT, Grym or TBS. Existing uploads by these groups can be trumped at any time.'
+            type = meta.get('type', '')
+            if type:
+                type = type.strip().lower()
+
+            source = meta.get('source', '')
+            if source:
+                source = source.strip().lower()
+
+            # This also checks the rule 'FANRES content is not allowed'
+            if meta['category'] not in ('MOVIE', 'TV'):
+                meta['phd_rule'] = (
+                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                    'Anything else, like games, music, software and porn is not allowed!'
+                )
                 return False
 
-            if tag == 'evo' and source != 'web':
-                meta['phd_rule'] = warning + 'Do not upload non-web EVO releases. Existing uploads by this group can be trumped at any time.'
+            if meta.get('anime', False):
+                meta['phd_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
                 return False
 
-        if meta.get('sd', '') == 1:
-            meta['phd_rule'] = warning + 'SD (Standard Definition) content is forbidden.'
-            return False
-
-        if not is_bd_disc:
-            ext = os.path.splitext(meta['filelist'][0])[1].lower()
-            allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4'}
-            container = allowed_extensions.get(ext)
-            if container is None:
-                meta['phd_rule'] = warning + 'Allowed containers: MKV, MP4.'
+            year = meta.get('year')
+            current_year = datetime.now().year
+            is_older_than_50_years = (current_year - year) >= 50
+            if is_older_than_50_years:
+                meta['phd_rule'] = warning + 'Upload movies/series 50+ years old to our sister site CinemaZ.to instead.'
                 return False
 
-        # Video codec
-        '''
-        Video Codecs:
-            Allowed:
-                1 - BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265
-                2 - BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
-                3 - WEB (Untouched): H.264, H.265, VP9
-                4 - WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
-                5 - x265 encodes must be 10-bit
-                6 - H.264/x264 only allowed for 1080p and below.
-                7 - Not Allowed: Any codec not mentioned above is not allowed.
-        '''
-        # 1
-        if type == 'remux':
-            if video_codec not in ('mpeg-2', 'vc-1', 'h.264', 'h.265', 'avc'):
-                meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265'
+            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+
+            africa = [
+                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+            ]
+
+            america = [
+                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+            ]
+
+            asia = [
+                'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
+                'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
+                'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
+                'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
+            ]
+
+            europe = [
+                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+                'SI', 'SJ', 'SK', 'SM', 'UA', 'VA', 'XC'
+            ]
+
+            oceania = [
+                'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
+                'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
+            ]
+
+            phd_allowed_countries = [
+                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+            ]
+
+            all_countries = africa + america + europe + oceania
+            cinemaz_countries = list(set(all_countries) - set(phd_allowed_countries))
+
+            origin_countries_codes = meta.get('origin_country', [])
+
+            if any(code in phd_allowed_countries for code in origin_countries_codes):
+                return True
+
+            # CinemaZ
+            elif any(code in cinemaz_countries for code in origin_countries_codes):
+                meta['phd_rule'] = warning + 'Upload European (EXCLUDING United Kingdom and Ireland), South American and African content to our sister site CinemaZ.to instead.'
                 return False
 
-        # 2
-        if type == 'encode' and source == 'bluray':
-            if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
-                meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
+            # AvistaZ
+            elif any(code in asia for code in origin_countries_codes):
+                origin_country_str = ', '.join(origin_countries_codes)
+                meta['phd_rule'] = (
+                    warning + 'DO NOT upload content originating from countries shown in this map (https://imgur.com/nIB9PM1).\n'
+                    'In case of doubt, message the staff first. Upload Asian content to our sister site Avistaz.to instead.\n'
+                    f'Origin country for your upload: {origin_country_str}'
+                )
                 return False
 
-        # 3
-        if type in ('webdl', 'web-dl') and source == 'web':
-            if video_encode not in ('h.264', 'h.265', 'vp9'):
-                meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Untouched): H.264, H.265, VP9'
+            elif not any(code in phd_allowed_countries for code in origin_countries_codes):
+                meta['phd_rule'] = (
+                    warning + 'Only upload content to PrivateHD from all major English speaking countries.\n'
+                    'Including United States, Canada, UK, Ireland, Australia, and New Zealand.'
+                )
                 return False
 
-        # 4
-        if type == 'encode' and source == 'web':
-            if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
-                meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
-                return False
-
-        # 5
-        if type == 'encode':
-            if video_encode == 'x265':
-                if meta.get('bit_depth', '') != '10':
-                    meta['phd_rule'] = warning + 'Allowed Video Codecs for x265 encodes must be 10-bit'
+            # Tags
+            tag = meta.get('tag', '')
+            if tag:
+                tag = tag.strip().lower()
+                if tag in ('rarbg', 'fgt', 'grym', 'tbs'):
+                    meta['phd_rule'] = warning + 'Do not upload RARBG, FGT, Grym or TBS. Existing uploads by these groups can be trumped at any time.'
                     return False
 
-        # 6
-        resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-        if resolution > 1080:
-            if video_encode in ('h.264', 'x264'):
-                meta['phd_rule'] = warning + 'H.264/x264 only allowed for 1080p and below.'
+                if tag == 'evo' and source != 'web':
+                    meta['phd_rule'] = warning + 'Do not upload non-web EVO releases. Existing uploads by this group can be trumped at any time.'
+                    return False
+
+            if meta.get('sd', '') == 1:
+                meta['phd_rule'] = warning + 'SD (Standard Definition) content is forbidden.'
                 return False
 
-        # 7
-        if video_codec not in ('avc', 'mpeg-2', 'vc-1', 'avc', 'h.264', 'vp9', 'h.265', 'x264', 'x265', 'hevc'):
-            meta['phd_rule'] = warning + f'Video codec not allowed in your upload: {video_codec}.'
-            return False
+            if not is_bd_disc:
+                ext = os.path.splitext(meta['filelist'][0])[1].lower()
+                allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4'}
+                container = allowed_extensions.get(ext)
+                if container is None:
+                    meta['phd_rule'] = warning + 'Allowed containers: MKV, MP4.'
+                    return False
 
-        # Audio codec
-        '''
-        Audio Codecs:
-            1 - Allowed: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.
-            2 - Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.
-            3 - TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.
-            4 - Not Allowed: Any codec not mentioned above is not allowed.
-        '''
-        if is_bd_disc:
-            pass
-        else:
+            # Video codec
+            '''
+            Video Codecs:
+                Allowed:
+                    1 - BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265
+                    2 - BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
+                    3 - WEB (Untouched): H.264, H.265, VP9
+                    4 - WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
+                    5 - x265 encodes must be 10-bit
+                    6 - H.264/x264 only allowed for 1080p and below.
+                    7 - Not Allowed: Any codec not mentioned above is not allowed.
+            '''
             # 1
-            allowed_keywords = ['AC3', 'Dolby Digital', 'Dolby TrueHD', 'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby']
+            if type == 'remux':
+                if video_codec not in ('mpeg-2', 'vc-1', 'h.264', 'h.265', 'avc'):
+                    meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265'
+                    return False
 
             # 2
-            forbidden_keywords = ['LPCM', 'PCM', 'Linear PCM']
-
-            audio_tracks = []
-            media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
-            for track in media_tracks:
-                if track.get('@type') == 'Audio':
-                    codec_info = track.get('Format_Commercial_IfAny')
-                    codec = codec_info if isinstance(codec_info, str) else ''
-                    audio_tracks.append({
-                        'codec': codec,
-                        'language': track.get('Language', '')
-                    })
+            if type == 'encode' and source == 'bluray':
+                if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
+                    meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
+                    return False
 
             # 3
-            original_language = meta.get('original_language', '')
-
-            if original_language:
-                # Filter to only have audio tracks that are in the original language
-                original_language_tracks = [
-                    track for track in audio_tracks if track.get('language', '').lower() == original_language.lower()
-                ]
-
-                # Now checks are only done on the original language track list
-                if original_language_tracks:
-                    has_truehd_atmos = any(
-                        'truehd' in track['codec'].lower() and 'atmos' in track['codec'].lower()
-                        for track in original_language_tracks
-                    )
-
-                    # Check if there is an AC-3 compatibility track in the same language
-                    has_ac3_compat_track = any(
-                        'ac-3' in track['codec'].lower() or 'dolby digital' in track['codec'].lower()
-                        for track in original_language_tracks
-                    )
-
-                    if has_truehd_atmos and not has_ac3_compat_track:
-                        meta['phd_rule'] = (
-                            warning + f'A TrueHD Atmos track was detected in the original language ({original_language}), '
-                            f'but no AC-3 (Dolby Digital) compatibility track was found for that same language.\n'
-                            'Rule: TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.'
-                        )
-                        return False
+            if type in ('webdl', 'web-dl') and source == 'web':
+                if video_encode not in ('h.264', 'h.265', 'vp9'):
+                    meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Untouched): H.264, H.265, VP9'
+                    return False
 
             # 4
-            invalid_codecs = []
-            for track in audio_tracks:
-                codec = track['codec']
-                if not codec:
-                    continue
+            if type == 'encode' and source == 'web':
+                if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
+                    meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
+                    return False
 
-                is_forbidden = any(kw.lower() in codec.lower() for kw in forbidden_keywords)
-                if is_forbidden:
-                    invalid_codecs.append(codec)
-                    continue
+            # 5
+            if type == 'encode':
+                if video_encode == 'x265':
+                    if meta.get('bit_depth', '') != '10':
+                        meta['phd_rule'] = warning + 'Allowed Video Codecs for x265 encodes must be 10-bit'
+                        return False
 
-                is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
-                if not is_allowed:
-                    invalid_codecs.append(codec)
+            # 6
+            resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
+            if resolution > 1080:
+                if video_encode in ('h.264', 'x264'):
+                    meta['phd_rule'] = warning + 'H.264/x264 only allowed for 1080p and below.'
+                    return False
 
-            if invalid_codecs:
-                unique_invalid_codecs = sorted(list(set(invalid_codecs)))
-                meta['phd_rule'] = (
-                    warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
-                    f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.\n'
-                    f'Dolby Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.'
-                )
+            # 7
+            if video_codec not in ('avc', 'mpeg-2', 'vc-1', 'avc', 'h.264', 'vp9', 'h.265', 'x264', 'x265', 'hevc'):
+                meta['phd_rule'] = warning + f'Video codec not allowed in your upload: {video_codec}.'
                 return False
 
-        def ask_yes_no(prompt_text):
-            while True:
-                answer = input(f'{prompt_text} (y/n): ').lower()
-                if answer in ['y', 'n']:
-                    return answer
-                else:
-                    print("Invalid input. Please enter 'y' or 'n'.")
+            # Audio codec
+            '''
+            Audio Codecs:
+                1 - Allowed: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.
+                2 - Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.
+                3 - TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.
+                4 - Not Allowed: Any codec not mentioned above is not allowed.
+            '''
+            if is_bd_disc:
+                pass
+            else:
+                # 1
+                allowed_keywords = ['AC3', 'Dolby Digital', 'Dolby TrueHD', 'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby']
 
-        # Quality check
-        '''
-        Minimum quality:
-            Only upload proper encodes. Any encodes where the size and/or the bitrate imply a bad quality of the encode will be deleted. Indication of a proper encode:
-                Or a minimum x265 video bitrate  of:
-                    720p HDTV/WEB-DL/WEBRip/HDRip: 1500 Kbps
-                    720p BluRay encode: 2000 Kbps
-                    1080p HDTV/WEB-DL/WEBRip/HDRip: 2500 Kbps
-                    1080p BluRay encode: 3500 Kbps
-                Depending on the content, for example an animation movie or series, a lower bitrate (x264) can be allowed.
-            Video must at least be 720p
-            The above bitrates are subject to staff discretion and uploads may be nuked even if they fulfill the above criteria.
-        '''
-        BITRATE_RULES = {
-            ('x265', 'web', 720): 1500000,
-            ('x265', 'web', 1080): 2500000,
-            ('x265', 'bluray', 720): 2000000,
-            ('x265', 'bluray', 1080): 3500000,
+                # 2
+                forbidden_keywords = ['LPCM', 'PCM', 'Linear PCM']
 
-            ('x264', 'web', 720): 2500000,
-            ('x264', 'web', 1080): 4500000,
-            ('x264', 'bluray', 720): 3500000,
-            ('x264', 'bluray', 1080): 6000000,
-        }
+                audio_tracks = []
+                media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
+                for track in media_tracks:
+                    if track.get('@type') == 'Audio':
+                        codec_info = track.get('Format_Commercial_IfAny')
+                        codec = codec_info if isinstance(codec_info, str) else ''
+                        audio_tracks.append({
+                            'codec': codec,
+                            'language': track.get('Language', '')
+                        })
 
-        WEB_SOURCES = ('hdtv', 'web', 'hdrip')
+                # 3
+                original_language = meta.get('original_language', '')
 
-        if type == 'encode':
-            bitrate = 0
-            for track in media_tracks:
-                if track.get('@type') == 'Video':
-                    bitrate = int(track.get('BitRate'))
-                    break
+                if original_language:
+                    # Filter to only have audio tracks that are in the original language
+                    original_language_tracks = [
+                        track for track in audio_tracks if track.get('language', '').lower() == original_language.lower()
+                    ]
 
-            source_type = None
-            if source in WEB_SOURCES:
-                source_type = 'web'
-            elif source == 'bluray':
-                source_type = 'bluray'
-
-            if source_type:
-                rule_key = (video_encode, source_type, resolution)
-
-                if rule_key in BITRATE_RULES:
-                    min_bitrate = BITRATE_RULES[rule_key]
-
-                    if bitrate < min_bitrate:
-                        quality_rule_text = (
-                            'Only upload proper encodes.\n'
-                            'Any encodes where the size and/or the bitrate imply a bad quality will be deleted.'
+                    # Now checks are only done on the original language track list
+                    if original_language_tracks:
+                        has_truehd_atmos = any(
+                            'truehd' in track['codec'].lower() and 'atmos' in track['codec'].lower()
+                            for track in original_language_tracks
                         )
-                        rule = (
-                            f'Your upload was rejected due to low quality.\n'
-                            f'Minimum bitrate for {resolution}p {source.upper()} {video_encode.upper()} is {min_bitrate / 1000} Kbps.'
+
+                        # Check if there is an AC-3 compatibility track in the same language
+                        has_ac3_compat_track = any(
+                            'ac-3' in track['codec'].lower() or 'dolby digital' in track['codec'].lower()
+                            for track in original_language_tracks
                         )
-                        meta['phd_rule'] = (warning + quality_rule_text + rule)
 
-        if resolution < 720:
-            rule = 'Video must be at least 720p.'
-            meta['phd_rule'] = (warning + rule)
+                        if has_truehd_atmos and not has_ac3_compat_track:
+                            meta['phd_rule'] = (
+                                warning + f'A TrueHD Atmos track was detected in the original language ({original_language}), '
+                                f'but no AC-3 (Dolby Digital) compatibility track was found for that same language.\n'
+                                'Rule: TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.'
+                            )
+                            return False
 
-        # Hybrid
-        if type in ('remux', 'encode'):
-            if 'hybrid' in meta.get('name', '').lower():
+                # 4
+                invalid_codecs = []
+                for track in audio_tracks:
+                    codec = track['codec']
+                    if not codec:
+                        continue
 
-                is_hybrid_confirm = ask_yes_no(
-                    "This release appears to be a 'Hybrid'. Is this correct?"
-                )
+                    is_forbidden = any(kw.lower() in codec.lower() for kw in forbidden_keywords)
+                    if is_forbidden:
+                        invalid_codecs.append(codec)
+                        continue
 
-                if is_hybrid_confirm == 'y':
-                    hybrid_rule_text = (
-                        'Hybrid Remuxes and Encodes are subject to the following condition:\n\n'
-                        'Hybrid user releases are permitted, but are treated similarly to regular '
-                        'user releases and must be approved by staff before you upload them '
-                        '(please see the torrent approvals forum for details).'
+                    is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
+                    if not is_allowed:
+                        invalid_codecs.append(codec)
+
+                if invalid_codecs:
+                    unique_invalid_codecs = sorted(list(set(invalid_codecs)))
+                    meta['phd_rule'] = (
+                        warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
+                        f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.\n'
+                        f'Dolby Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.'
+                    )
+                    return False
+
+            def ask_yes_no(prompt_text):
+                while True:
+                    answer = input(f'{prompt_text} (y/n): ').lower()
+                    if answer in ['y', 'n']:
+                        return answer
+                    else:
+                        print("Invalid input. Please enter 'y' or 'n'.")
+
+            # Quality check
+            '''
+            Minimum quality:
+                Only upload proper encodes. Any encodes where the size and/or the bitrate imply a bad quality of the encode will be deleted. Indication of a proper encode:
+                    Or a minimum x265 video bitrate  of:
+                        720p HDTV/WEB-DL/WEBRip/HDRip: 1500 Kbps
+                        720p BluRay encode: 2000 Kbps
+                        1080p HDTV/WEB-DL/WEBRip/HDRip: 2500 Kbps
+                        1080p BluRay encode: 3500 Kbps
+                    Depending on the content, for example an animation movie or series, a lower bitrate (x264) can be allowed.
+                Video must at least be 720p
+                The above bitrates are subject to staff discretion and uploads may be nuked even if they fulfill the above criteria.
+            '''
+            BITRATE_RULES = {
+                ('x265', 'web', 720): 1500000,
+                ('x265', 'web', 1080): 2500000,
+                ('x265', 'bluray', 720): 2000000,
+                ('x265', 'bluray', 1080): 3500000,
+
+                ('x264', 'web', 720): 2500000,
+                ('x264', 'web', 1080): 4500000,
+                ('x264', 'bluray', 720): 3500000,
+                ('x264', 'bluray', 1080): 6000000,
+            }
+
+            WEB_SOURCES = ('hdtv', 'web', 'hdrip')
+
+            if type == 'encode':
+                bitrate = 0
+                for track in media_tracks:
+                    if track.get('@type') == 'Video':
+                        bitrate = int(track.get('BitRate'))
+                        break
+
+                source_type = None
+                if source in WEB_SOURCES:
+                    source_type = 'web'
+                elif source == 'bluray':
+                    source_type = 'bluray'
+
+                if source_type:
+                    rule_key = (video_encode, source_type, resolution)
+
+                    if rule_key in BITRATE_RULES:
+                        min_bitrate = BITRATE_RULES[rule_key]
+
+                        if bitrate < min_bitrate:
+                            quality_rule_text = (
+                                'Only upload proper encodes.\n'
+                                'Any encodes where the size and/or the bitrate imply a bad quality will be deleted.'
+                            )
+                            rule = (
+                                f'Your upload was rejected due to low quality.\n'
+                                f'Minimum bitrate for {resolution}p {source.upper()} {video_encode.upper()} is {min_bitrate / 1000} Kbps.'
+                            )
+                            meta['phd_rule'] = (warning + quality_rule_text + rule)
+
+            if resolution < 720:
+                rule = 'Video must be at least 720p.'
+                meta['phd_rule'] = (warning + rule)
+
+            # Hybrid
+            if type in ('remux', 'encode'):
+                if 'hybrid' in meta.get('name', '').lower():
+
+                    is_hybrid_confirm = ask_yes_no(
+                        "This release appears to be a 'Hybrid'. Is this correct?"
                     )
 
-                    print('\n' + '-'*60)
-                    print('Important Rule for Hybrid Releases')
-                    print('-' * 60)
-                    print(warning + hybrid_rule_text)
-                    print('-' * 60 + '\n')
+                    if is_hybrid_confirm == 'y':
+                        hybrid_rule_text = (
+                            'Hybrid Remuxes and Encodes are subject to the following condition:\n\n'
+                            'Hybrid user releases are permitted, but are treated similarly to regular '
+                            'user releases and must be approved by staff before you upload them '
+                            '(please see the torrent approvals forum for details).'
+                        )
 
-                    continue_upload = ask_yes_no(
-                        'Have you already received staff approval for this upload?'
-                        'Do you wish to continue?'
-                    )
+                        print('\n' + '-'*60)
+                        print('Important Rule for Hybrid Releases')
+                        print('-' * 60)
+                        print(warning + hybrid_rule_text)
+                        print('-' * 60 + '\n')
 
-                    if continue_upload == 'n':
-                        error_message = 'Upload aborted by user. Hybrid releases require prior staff approval.'
+                        continue_upload = ask_yes_no(
+                            'Have you already received staff approval for this upload?'
+                            'Do you wish to continue?'
+                        )
+
+                        if continue_upload == 'n':
+                            error_message = 'Upload aborted by user. Hybrid releases require prior staff approval.'
+                            print(f'{error_message}')
+                            meta['phd_rule'] = error_message
+
+                    else:
+                        error_message = "Upload aborted. The term 'Hybrid' in the release name is reserved for approved hybrid releases. Please correct the name if it is not a hybrid."
                         print(f'{error_message}')
                         meta['phd_rule'] = error_message
 
+            # Log
+            if type == 'remux':
+                remux_log = ask_yes_no(
+                    warning + 'Remuxes must have a demux/eac3to log under spoilers in description.\n'
+                    'Do you have these logs and will you add them to the description after upload?'
+                )
+                if remux_log == 'y':
+                    pass
                 else:
-                    error_message = "Upload aborted. The term 'Hybrid' in the release name is reserved for approved hybrid releases. Please correct the name if it is not a hybrid."
-                    print(f'{error_message}')
-                    meta['phd_rule'] = error_message
+                    meta['phd_rule'] = (warning + 'Remuxes must have a demux/eac3to log under spoilers in description.')
+                    return False
 
-        # Log
-        if type == 'remux':
-            remux_log = ask_yes_no(
-                warning + 'Remuxes must have a demux/eac3to log under spoilers in description.\n'
-                'Do you have these logs and will you add them to the description after upload?'
-            )
-            if remux_log == 'y':
-                pass
-            else:
-                meta['phd_rule'] = (warning + 'Remuxes must have a demux/eac3to log under spoilers in description.')
-                return False
+            # Bloated
+            if meta.get('bloated', False):
+                ask_bloated = ask_yes_no(
+                    warning + 'Audio dubs are never preferred and can always be trumped by original audio only rip (Exception for BD50/BD25).\n'
+                    'Do NOT upload a multi audio release when there is already a original audio only release on site.\n'
+                    'Do you want to upload anyway?'
+                )
+                if ask_bloated == 'y':
+                    pass
+                else:
+                    meta['phd_rule'] = 'Canceled by user. Reason: Bloated'
+                    return False
 
-        # Bloated
-        if meta.get('bloated', False):
-            ask_bloated = ask_yes_no(
-                warning + 'Audio dubs are never preferred and can always be trumped by original audio only rip (Exception for BD50/BD25).\n'
-                'Do NOT upload a multi audio release when there is already a original audio only release on site.\n'
-                'Do you want to upload anyway?'
-            )
-            if ask_bloated == 'y':
-                pass
-            else:
-                meta['phd_rule'] = 'Canceled by user. Reason: Bloated'
-                return False
-
-        return True
+            return True
 
     def edit_name(self, meta):
         upload_name = meta.get('name').replace(meta["aka"], '').replace('Dubbed', '').replace('Dual-Audio', '')

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import re
 from datetime import datetime
 from src.trackers.COMMON import COMMON
 from src.trackers.AVISTAZ_NETWORK import AZTrackerBase
@@ -428,34 +427,6 @@ class PHD(AZTrackerBase):
                     return False
 
             return True
-
-    def edit_name(self, meta):
-        upload_name = meta.get('name').replace(meta["aka"], '').replace('Dubbed', '').replace('Dual-Audio', '')
-        forbidden_terms = [
-            r'\bLIMITED\b',
-            r'\bCriterion Collection\b',
-            r'\b\d{1,3}(?:st|nd|rd|th)\s+Anniversary Edition\b'
-        ]
-        for term in forbidden_terms:
-            upload_name = re.sub(term, '', upload_name, flags=re.IGNORECASE).strip()
-
-        upload_name = re.sub(r'\bDirector[’\'`]s\s+Cut\b', 'DC', upload_name, flags=re.IGNORECASE)
-        upload_name = re.sub(r'\bExtended\s+Cut\b', 'Extended', upload_name, flags=re.IGNORECASE)
-        upload_name = re.sub(r'\bTheatrical\s+Cut\b', 'Theatrical', upload_name, flags=re.IGNORECASE)
-        upload_name = re.sub(r'\s{2,}', ' ', upload_name).strip()
-
-        tag_lower = meta['tag'].lower()
-        invalid_tags = ['nogrp', 'nogroup', 'unknown', '-unk-']
-
-        if meta['tag'] == '' or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
-            for invalid_tag in invalid_tags:
-                upload_name = re.sub(f'-{invalid_tag}', '', upload_name, flags=re.IGNORECASE)
-            upload_name = f'{upload_name}-NOGROUP'
-
-        if meta.get('has_encode_settings', False):
-            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
-
-        return upload_name
 
     def get_rip_type(self, meta):
         source_type = meta.get('type')

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -17,416 +17,320 @@ class PHD(AZTrackerBase):
         self.torrent_url = f'{self.base_url}/torrent/'
 
     async def rules(self, meta):
-        if self.config['TRACKERS'][self.tracker].get('check_for_rules', True) is False:
+        warnings = []
+
+        is_bd_disc = False
+        if meta.get('is_disc', '') == 'BDMV':
+            is_bd_disc = True
+
+        video_codec = meta.get('video_codec', '')
+        if video_codec:
+            video_codec = video_codec.strip().lower()
+
+        video_encode = meta.get('video_encode', '')
+        if video_encode:
+            video_encode = video_encode.strip().lower()
+
+        type = meta.get('type', '')
+        if type:
+            type = type.strip().lower()
+
+        source = meta.get('source', '')
+        if source:
+            source = source.strip().lower()
+
+        # This also checks the rule 'FANRES content is not allowed'
+        if meta['category'] not in ('MOVIE', 'TV'):
+            warnings.append(
+                'The only allowed content to be uploaded are Movies and TV Shows.\n'
+                'Anything else, like games, music, software and porn is not allowed!'
+            )
+
+        if meta.get('anime', False):
+            warnings.append("Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime.")
+
+        year = meta.get('year')
+        current_year = datetime.now().year
+        is_older_than_50_years = (current_year - year) >= 50
+        if is_older_than_50_years:
+            warnings.append('Upload movies/series 50+ years old to our sister site CinemaZ.to instead.')
+
+        # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+
+        africa = [
+            'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
+            'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
+            'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
+            'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
+        ]
+
+        america = [
+            'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
+            'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
+            'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
+            'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
+        ]
+
+        asia = [
+            'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
+            'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
+            'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
+            'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
+        ]
+
+        europe = [
+            'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+            'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
+            'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
+            'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
+        ]
+
+        oceania = [
+            'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
+            'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
+        ]
+
+        phd_allowed_countries = [
+            'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
+            'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
+        ]
+
+        all_countries = africa + america + europe + oceania
+        cinemaz_countries = list(set(all_countries) - set(phd_allowed_countries))
+
+        origin_countries_codes = meta.get('origin_country', [])
+
+        if any(code in phd_allowed_countries for code in origin_countries_codes):
             return True
+
+        # CinemaZ
+        elif any(code in cinemaz_countries for code in origin_countries_codes):
+            warnings.append('Upload European (EXCLUDING United Kingdom and Ireland), South American and African content to our sister site CinemaZ.to instead.')
+
+        # AvistaZ
+        elif any(code in asia for code in origin_countries_codes):
+            origin_country_str = ', '.join(origin_countries_codes)
+            warnings.append(
+                'DO NOT upload content originating from countries shown in this map (https://imgur.com/nIB9PM1).\n'
+                'In case of doubt, message the staff first. Upload Asian content to our sister site Avistaz.to instead.\n'
+                f'Origin country for your upload: {origin_country_str}'
+            )
+
+        elif not any(code in phd_allowed_countries for code in origin_countries_codes):
+            warnings.append(
+                'Only upload content to PrivateHD from all major English speaking countries.\n'
+                'Including United States, Canada, UK, Ireland, Australia, and New Zealand.'
+            )
+
+        # Tags
+        tag = meta.get('tag', '')
+        if tag:
+            tag = tag.strip().lower()
+            if tag in ('rarbg', 'fgt', 'grym', 'tbs'):
+                warnings.append('Do not upload RARBG, FGT, Grym or TBS. Existing uploads by these groups can be trumped at any time.')
+
+            if tag == 'evo' and source != 'web':
+                warnings.append('Do not upload non-web EVO releases. Existing uploads by this group can be trumped at any time.')
+
+        if meta.get('sd', '') == 1:
+            warnings.append('SD (Standard Definition) content is forbidden.')
+
+        if not is_bd_disc:
+            ext = os.path.splitext(meta['filelist'][0])[1].lower()
+            allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4'}
+            container = allowed_extensions.get(ext)
+            if container is None:
+                warnings.append('Allowed containers: MKV, MP4.')
+
+        # Video codec
+        # 1
+        if type == 'remux':
+            if video_codec not in ('mpeg-2', 'vc-1', 'h.264', 'h.265', 'avc'):
+                warnings.append('Allowed Video Codecs for BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265')
+
+        # 2
+        if type == 'encode' and source == 'bluray':
+            if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
+                warnings.append('Allowed Video Codecs for BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)')
+
+        # 3
+        if type in ('webdl', 'web-dl') and source == 'web':
+            if video_encode not in ('h.264', 'h.265', 'vp9'):
+                warnings.append('Allowed Video Codecs for WEB (Untouched): H.264, H.265, VP9')
+
+        # 4
+        if type == 'encode' and source == 'web':
+            if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
+                warnings.append('Allowed Video Codecs for WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)')
+
+        # 5
+        if type == 'encode':
+            if video_encode == 'x265':
+                if meta.get('bit_depth', '') != '10':
+                    warnings.append('Allowed Video Codecs for x265 encodes must be 10-bit')
+
+        # 6
+        resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
+        if resolution > 1080:
+            if video_encode in ('h.264', 'x264'):
+                warnings.append('H.264/x264 only allowed for 1080p and below.')
+
+        # 7
+        if video_codec not in ('avc', 'mpeg-2', 'vc-1', 'avc', 'h.264', 'vp9', 'h.265', 'x264', 'x265', 'hevc'):
+            warnings.append(f'Video codec not allowed in your upload: {video_codec}.')
+
+        # Audio codec
+        if is_bd_disc:
+            pass
         else:
-            meta['phd_rule'] = ''
-            warning = f'{self.tracker} RULE WARNING: '
-            rule = ''
-
-            is_bd_disc = False
-            if meta.get('is_disc', '') == 'BDMV':
-                is_bd_disc = True
-
-            video_codec = meta.get('video_codec', '')
-            if video_codec:
-                video_codec = video_codec.strip().lower()
-
-            video_encode = meta.get('video_encode', '')
-            if video_encode:
-                video_encode = video_encode.strip().lower()
-
-            type = meta.get('type', '')
-            if type:
-                type = type.strip().lower()
-
-            source = meta.get('source', '')
-            if source:
-                source = source.strip().lower()
-
-            # This also checks the rule 'FANRES content is not allowed'
-            if meta['category'] not in ('MOVIE', 'TV'):
-                meta['phd_rule'] = (
-                    warning + 'The only allowed content to be uploaded are Movies and TV Shows.\n'
-                    'Anything else, like games, music, software and porn is not allowed!'
-                )
-                return False
-
-            if meta.get('anime', False):
-                meta['phd_rule'] = warning + "Upload Anime content to our sister site AnimeTorrents.me instead. If it's on AniDB, it's an anime."
-                return False
-
-            year = meta.get('year')
-            current_year = datetime.now().year
-            is_older_than_50_years = (current_year - year) >= 50
-            if is_older_than_50_years:
-                meta['phd_rule'] = warning + 'Upload movies/series 50+ years old to our sister site CinemaZ.to instead.'
-                return False
-
-            # https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
-            africa = [
-                'AO', 'BF', 'BI', 'BJ', 'BW', 'CD', 'CF', 'CG', 'CI', 'CM', 'CV', 'DJ', 'DZ', 'EG', 'EH',
-                'ER', 'ET', 'GA', 'GH', 'GM', 'GN', 'GQ', 'GW', 'IO', 'KE', 'KM', 'LR', 'LS', 'LY', 'MA',
-                'MG', 'ML', 'MR', 'MU', 'MW', 'MZ', 'NA', 'NE', 'NG', 'RE', 'RW', 'SC', 'SD', 'SH', 'SL',
-                'SN', 'SO', 'SS', 'ST', 'SZ', 'TD', 'TF', 'TG', 'TN', 'TZ', 'UG', 'YT', 'ZA', 'ZM', 'ZW'
-            ]
-
-            america = [
-                'AG', 'AI', 'AR', 'AW', 'BB', 'BL', 'BM', 'BO', 'BQ', 'BR', 'BS', 'BV', 'BZ', 'CA', 'CL',
-                'CO', 'CR', 'CU', 'CW', 'DM', 'DO', 'EC', 'FK', 'GD', 'GF', 'GL', 'GP', 'GS', 'GT', 'GY',
-                'HN', 'HT', 'JM', 'KN', 'KY', 'LC', 'MF', 'MQ', 'MS', 'MX', 'NI', 'PA', 'PE', 'PM', 'PR',
-                'PY', 'SR', 'SV', 'SX', 'TC', 'TT', 'US', 'UY', 'VC', 'VE', 'VG', 'VI'
-            ]
-
-            asia = [
-                'AE', 'AF', 'AM', 'AZ', 'BD', 'BH', 'BN', 'BT', 'CN', 'CY', 'GE', 'HK', 'ID', 'IL', 'IN',
-                'IQ', 'IR', 'JO', 'JP', 'KG', 'KH', 'KP', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LK', 'MM', 'MN',
-                'MO', 'MV', 'MY', 'NP', 'OM', 'PH', 'PK', 'PS', 'QA', 'SA', 'SG', 'SY', 'TH', 'TJ', 'TL',
-                'TM', 'TR', 'TW', 'UZ', 'VN', 'YE'
-            ]
-
-            europe = [
-                'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-                'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM', 'IS', 'IT', 'JE', 'LI', 'LT',
-                'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE',
-                'SI', 'SJ', 'SK', 'SM', 'SU', 'UA', 'VA', 'XC'
-            ]
-
-            oceania = [
-                'AS', 'AU', 'CC', 'CK', 'CX', 'FJ', 'FM', 'GU', 'HM', 'KI', 'MH', 'MP', 'NC', 'NF', 'NR',
-                'NU', 'NZ', 'PF', 'PG', 'PN', 'PW', 'SB', 'TK', 'TO', 'TV', 'UM', 'VU', 'WF', 'WS'
-            ]
-
-            phd_allowed_countries = [
-                'AG', 'AI', 'AU', 'BB', 'BM', 'BS', 'BZ', 'CA', 'CW', 'DM', 'GB', 'GD', 'IE',
-                'JM', 'KN', 'KY', 'LC', 'MS', 'NZ', 'PR', 'TC', 'TT', 'US', 'VC', 'VG', 'VI',
-            ]
-
-            all_countries = africa + america + europe + oceania
-            cinemaz_countries = list(set(all_countries) - set(phd_allowed_countries))
-
-            origin_countries_codes = meta.get('origin_country', [])
-
-            if any(code in phd_allowed_countries for code in origin_countries_codes):
-                return True
-
-            # CinemaZ
-            elif any(code in cinemaz_countries for code in origin_countries_codes):
-                meta['phd_rule'] = warning + 'Upload European (EXCLUDING United Kingdom and Ireland), South American and African content to our sister site CinemaZ.to instead.'
-                return False
-
-            # AvistaZ
-            elif any(code in asia for code in origin_countries_codes):
-                origin_country_str = ', '.join(origin_countries_codes)
-                meta['phd_rule'] = (
-                    warning + 'DO NOT upload content originating from countries shown in this map (https://imgur.com/nIB9PM1).\n'
-                    'In case of doubt, message the staff first. Upload Asian content to our sister site Avistaz.to instead.\n'
-                    f'Origin country for your upload: {origin_country_str}'
-                )
-                return False
-
-            elif not any(code in phd_allowed_countries for code in origin_countries_codes):
-                meta['phd_rule'] = (
-                    warning + 'Only upload content to PrivateHD from all major English speaking countries.\n'
-                    'Including United States, Canada, UK, Ireland, Australia, and New Zealand.'
-                )
-                return False
-
-            # Tags
-            tag = meta.get('tag', '')
-            if tag:
-                tag = tag.strip().lower()
-                if tag in ('rarbg', 'fgt', 'grym', 'tbs'):
-                    meta['phd_rule'] = warning + 'Do not upload RARBG, FGT, Grym or TBS. Existing uploads by these groups can be trumped at any time.'
-                    return False
-
-                if tag == 'evo' and source != 'web':
-                    meta['phd_rule'] = warning + 'Do not upload non-web EVO releases. Existing uploads by this group can be trumped at any time.'
-                    return False
-
-            if meta.get('sd', '') == 1:
-                meta['phd_rule'] = warning + 'SD (Standard Definition) content is forbidden.'
-                return False
-
-            if not is_bd_disc:
-                ext = os.path.splitext(meta['filelist'][0])[1].lower()
-                allowed_extensions = {'.mkv': 'MKV', '.mp4': 'MP4'}
-                container = allowed_extensions.get(ext)
-                if container is None:
-                    meta['phd_rule'] = warning + 'Allowed containers: MKV, MP4.'
-                    return False
-
-            # Video codec
-            '''
-            Video Codecs:
-                Allowed:
-                    1 - BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265
-                    2 - BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
-                    3 - WEB (Untouched): H.264, H.265, VP9
-                    4 - WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)
-                    5 - x265 encodes must be 10-bit
-                    6 - H.264/x264 only allowed for 1080p and below.
-                    7 - Not Allowed: Any codec not mentioned above is not allowed.
-            '''
             # 1
-            if type == 'remux':
-                if video_codec not in ('mpeg-2', 'vc-1', 'h.264', 'h.265', 'avc'):
-                    meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Untouched + REMUX): MPEG-2, VC-1, H.264, H.265'
-                    return False
+            allowed_keywords = ['AC3', 'Dolby Digital', 'Dolby TrueHD', 'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby']
 
             # 2
-            if type == 'encode' and source == 'bluray':
-                if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
-                    meta['phd_rule'] = warning + 'Allowed Video Codecs for BluRay (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
-                    return False
+            forbidden_keywords = ['LPCM', 'PCM', 'Linear PCM']
+
+            audio_tracks = []
+            media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
+            for track in media_tracks:
+                if track.get('@type') == 'Audio':
+                    codec_info = track.get('Format_Commercial_IfAny')
+                    codec = codec_info if isinstance(codec_info, str) else ''
+                    audio_tracks.append({
+                        'codec': codec,
+                        'language': track.get('Language', '')
+                    })
 
             # 3
-            if type in ('webdl', 'web-dl') and source == 'web':
-                if video_encode not in ('h.264', 'h.265', 'vp9'):
-                    meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Untouched): H.264, H.265, VP9'
-                    return False
+            original_language = meta.get('original_language', '')
+
+            if original_language:
+                # Filter to only have audio tracks that are in the original language
+                original_language_tracks = [
+                    track for track in audio_tracks if track.get('language', '').lower() == original_language.lower()
+                ]
+
+                # Now checks are only done on the original language track list
+                if original_language_tracks:
+                    has_truehd_atmos = any(
+                        'truehd' in track['codec'].lower() and 'atmos' in track['codec'].lower()
+                        for track in original_language_tracks
+                    )
+
+                    # Check if there is an AC-3 compatibility track in the same language
+                    has_ac3_compat_track = any(
+                        'ac-3' in track['codec'].lower() or 'dolby digital' in track['codec'].lower()
+                        for track in original_language_tracks
+                    )
+
+                    if has_truehd_atmos and not has_ac3_compat_track:
+                        warnings.append(
+                            f'A TrueHD Atmos track was detected in the original language ({original_language}), '
+                            f'but no AC-3 (Dolby Digital) compatibility track was found for that same language.\n'
+                            'Rule: TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.'
+                        )
 
             # 4
-            if type == 'encode' and source == 'web':
-                if video_encode not in ('h.264', 'h.265', 'x264', 'x265'):
-                    meta['phd_rule'] = warning + 'Allowed Video Codecs for WEB (Encoded): H.264, H.265 (x264 and x265 respectively are the only permitted encoders)'
-                    return False
+            invalid_codecs = []
+            for track in audio_tracks:
+                codec = track['codec']
+                if not codec:
+                    continue
 
-            # 5
-            if type == 'encode':
-                if video_encode == 'x265':
-                    if meta.get('bit_depth', '') != '10':
-                        meta['phd_rule'] = warning + 'Allowed Video Codecs for x265 encodes must be 10-bit'
-                        return False
+                is_forbidden = any(kw.lower() in codec.lower() for kw in forbidden_keywords)
+                if is_forbidden:
+                    invalid_codecs.append(codec)
+                    continue
 
-            # 6
-            resolution = int(meta.get('resolution').lower().replace('p', '').replace('i', ''))
-            if resolution > 1080:
-                if video_encode in ('h.264', 'x264'):
-                    meta['phd_rule'] = warning + 'H.264/x264 only allowed for 1080p and below.'
-                    return False
+                is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
+                if not is_allowed:
+                    invalid_codecs.append(codec)
 
-            # 7
-            if video_codec not in ('avc', 'mpeg-2', 'vc-1', 'avc', 'h.264', 'vp9', 'h.265', 'x264', 'x265', 'hevc'):
-                meta['phd_rule'] = warning + f'Video codec not allowed in your upload: {video_codec}.'
-                return False
-
-            # Audio codec
-            '''
-            Audio Codecs:
-                1 - Allowed: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.
-                2 - Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.
-                3 - TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.
-                4 - Not Allowed: Any codec not mentioned above is not allowed.
-            '''
-            if is_bd_disc:
-                pass
-            else:
-                # 1
-                allowed_keywords = ['AC3', 'Dolby Digital', 'Dolby TrueHD', 'DTS', 'DTS-HD', 'FLAC', 'AAC', 'Dolby']
-
-                # 2
-                forbidden_keywords = ['LPCM', 'PCM', 'Linear PCM']
-
-                audio_tracks = []
-                media_tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])
-                for track in media_tracks:
-                    if track.get('@type') == 'Audio':
-                        codec_info = track.get('Format_Commercial_IfAny')
-                        codec = codec_info if isinstance(codec_info, str) else ''
-                        audio_tracks.append({
-                            'codec': codec,
-                            'language': track.get('Language', '')
-                        })
-
-                # 3
-                original_language = meta.get('original_language', '')
-
-                if original_language:
-                    # Filter to only have audio tracks that are in the original language
-                    original_language_tracks = [
-                        track for track in audio_tracks if track.get('language', '').lower() == original_language.lower()
-                    ]
-
-                    # Now checks are only done on the original language track list
-                    if original_language_tracks:
-                        has_truehd_atmos = any(
-                            'truehd' in track['codec'].lower() and 'atmos' in track['codec'].lower()
-                            for track in original_language_tracks
-                        )
-
-                        # Check if there is an AC-3 compatibility track in the same language
-                        has_ac3_compat_track = any(
-                            'ac-3' in track['codec'].lower() or 'dolby digital' in track['codec'].lower()
-                            for track in original_language_tracks
-                        )
-
-                        if has_truehd_atmos and not has_ac3_compat_track:
-                            meta['phd_rule'] = (
-                                warning + f'A TrueHD Atmos track was detected in the original language ({original_language}), '
-                                f'but no AC-3 (Dolby Digital) compatibility track was found for that same language.\n'
-                                'Rule: TrueHD/Atmos audio must have a compatibility track due to poor compatibility with most players.'
-                            )
-                            return False
-
-                # 4
-                invalid_codecs = []
-                for track in audio_tracks:
-                    codec = track['codec']
-                    if not codec:
-                        continue
-
-                    is_forbidden = any(kw.lower() in codec.lower() for kw in forbidden_keywords)
-                    if is_forbidden:
-                        invalid_codecs.append(codec)
-                        continue
-
-                    is_allowed = any(kw.lower() in codec.lower() for kw in allowed_keywords)
-                    if not is_allowed:
-                        invalid_codecs.append(codec)
-
-                if invalid_codecs:
-                    unique_invalid_codecs = sorted(list(set(invalid_codecs)))
-                    meta['phd_rule'] = (
-                        warning + f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
-                        f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.\n'
-                        f'Dolby Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.'
-                    )
-                    return False
-
-            def ask_yes_no(prompt_text):
-                while True:
-                    answer = input(f'{prompt_text} (y/n): ').lower()
-                    if answer in ['y', 'n']:
-                        return answer
-                    else:
-                        print("Invalid input. Please enter 'y' or 'n'.")
-
-            # Quality check
-            '''
-            Minimum quality:
-                Only upload proper encodes. Any encodes where the size and/or the bitrate imply a bad quality of the encode will be deleted. Indication of a proper encode:
-                    Or a minimum x265 video bitrate  of:
-                        720p HDTV/WEB-DL/WEBRip/HDRip: 1500 Kbps
-                        720p BluRay encode: 2000 Kbps
-                        1080p HDTV/WEB-DL/WEBRip/HDRip: 2500 Kbps
-                        1080p BluRay encode: 3500 Kbps
-                    Depending on the content, for example an animation movie or series, a lower bitrate (x264) can be allowed.
-                Video must at least be 720p
-                The above bitrates are subject to staff discretion and uploads may be nuked even if they fulfill the above criteria.
-            '''
-            BITRATE_RULES = {
-                ('x265', 'web', 720): 1500000,
-                ('x265', 'web', 1080): 2500000,
-                ('x265', 'bluray', 720): 2000000,
-                ('x265', 'bluray', 1080): 3500000,
-
-                ('x264', 'web', 720): 2500000,
-                ('x264', 'web', 1080): 4500000,
-                ('x264', 'bluray', 720): 3500000,
-                ('x264', 'bluray', 1080): 6000000,
-            }
-
-            WEB_SOURCES = ('hdtv', 'web', 'hdrip')
-
-            if type == 'encode':
-                bitrate = 0
-                for track in media_tracks:
-                    if track.get('@type') == 'Video':
-                        bitrate = int(track.get('BitRate'))
-                        break
-
-                source_type = None
-                if source in WEB_SOURCES:
-                    source_type = 'web'
-                elif source == 'bluray':
-                    source_type = 'bluray'
-
-                if source_type:
-                    rule_key = (video_encode, source_type, resolution)
-
-                    if rule_key in BITRATE_RULES:
-                        min_bitrate = BITRATE_RULES[rule_key]
-
-                        if bitrate < min_bitrate:
-                            quality_rule_text = (
-                                'Only upload proper encodes.\n'
-                                'Any encodes where the size and/or the bitrate imply a bad quality will be deleted.'
-                            )
-                            rule = (
-                                f'Your upload was rejected due to low quality.\n'
-                                f'Minimum bitrate for {resolution}p {source.upper()} {video_encode.upper()} is {min_bitrate / 1000} Kbps.'
-                            )
-                            meta['phd_rule'] = (warning + quality_rule_text + rule)
-
-            if resolution < 720:
-                rule = 'Video must be at least 720p.'
-                meta['phd_rule'] = (warning + rule)
-
-            # Hybrid
-            if type in ('remux', 'encode'):
-                if 'hybrid' in meta.get('name', '').lower():
-
-                    is_hybrid_confirm = ask_yes_no(
-                        "This release appears to be a 'Hybrid'. Is this correct?"
-                    )
-
-                    if is_hybrid_confirm == 'y':
-                        hybrid_rule_text = (
-                            'Hybrid Remuxes and Encodes are subject to the following condition:\n\n'
-                            'Hybrid user releases are permitted, but are treated similarly to regular '
-                            'user releases and must be approved by staff before you upload them '
-                            '(please see the torrent approvals forum for details).'
-                        )
-
-                        print('\n' + '-'*60)
-                        print('Important Rule for Hybrid Releases')
-                        print('-' * 60)
-                        print(warning + hybrid_rule_text)
-                        print('-' * 60 + '\n')
-
-                        continue_upload = ask_yes_no(
-                            'Have you already received staff approval for this upload?'
-                            'Do you wish to continue?'
-                        )
-
-                        if continue_upload == 'n':
-                            error_message = 'Upload aborted by user. Hybrid releases require prior staff approval.'
-                            print(f'{error_message}')
-                            meta['phd_rule'] = error_message
-
-                    else:
-                        error_message = "Upload aborted. The term 'Hybrid' in the release name is reserved for approved hybrid releases. Please correct the name if it is not a hybrid."
-                        print(f'{error_message}')
-                        meta['phd_rule'] = error_message
-
-            # Log
-            if type == 'remux':
-                remux_log = ask_yes_no(
-                    warning + 'Remuxes must have a demux/eac3to log under spoilers in description.\n'
-                    'Do you have these logs and will you add them to the description after upload?'
+            if invalid_codecs:
+                unique_invalid_codecs = sorted(list(set(invalid_codecs)))
+                warnings.append(
+                    f"Unallowed audio codec(s) detected: {', '.join(unique_invalid_codecs)}\n"
+                    f'Allowed codecs: AC3 (Dolby Digital), Dolby TrueHD, DTS, DTS-HD (MA), FLAC, AAC, all other Dolby codecs.\n'
+                    f'Dolby Exceptions: Any uncompressed audio codec that comes on a BluRay disc like; PCM, LPCM, etc.'
                 )
-                if remux_log == 'y':
-                    pass
-                else:
-                    meta['phd_rule'] = (warning + 'Remuxes must have a demux/eac3to log under spoilers in description.')
-                    return False
 
-            # Bloated
-            if meta.get('bloated', False):
-                ask_bloated = ask_yes_no(
-                    warning + 'Audio dubs are never preferred and can always be trumped by original audio only rip (Exception for BD50/BD25).\n'
-                    'Do NOT upload a multi audio release when there is already a original audio only release on site.\n'
-                    'Do you want to upload anyway?'
+        # Quality check
+        BITRATE_RULES = {
+            ('x265', 'web', 720): 1500000,
+            ('x265', 'web', 1080): 2500000,
+            ('x265', 'bluray', 720): 2000000,
+            ('x265', 'bluray', 1080): 3500000,
+
+            ('x264', 'web', 720): 2500000,
+            ('x264', 'web', 1080): 4500000,
+            ('x264', 'bluray', 720): 3500000,
+            ('x264', 'bluray', 1080): 6000000,
+        }
+
+        WEB_SOURCES = ('hdtv', 'web', 'hdrip')
+
+        if type == 'encode':
+            bitrate = 0
+            for track in media_tracks:
+                if track.get('@type') == 'Video':
+                    bitrate = int(track.get('BitRate'))
+                    break
+
+            source_type = None
+            if source in WEB_SOURCES:
+                source_type = 'web'
+            elif source == 'bluray':
+                source_type = 'bluray'
+
+            if source_type:
+                rule_key = (video_encode, source_type, resolution)
+
+                if rule_key in BITRATE_RULES:
+                    min_bitrate = BITRATE_RULES[rule_key]
+
+                    if bitrate < min_bitrate:
+                        quality_rule_text = (
+                            'Only upload proper encodes.\n'
+                            'Any encodes where the size and/or the bitrate imply a bad quality will be deleted.'
+                        )
+                        rule = (
+                            f'Your upload was rejected due to low quality.\n'
+                            f'Minimum bitrate for {resolution}p {source.upper()} {video_encode.upper()} is {min_bitrate / 1000} Kbps.'
+                        )
+                        warnings.append(quality_rule_text + rule)
+
+        if resolution < 720:
+            rule = 'Video must be at least 720p.'
+            warnings.append(rule)
+
+        # Hybrid
+        if type in ('remux', 'encode'):
+            if 'hybrid' in meta.get('name', '').lower():
+                warnings.append(
+                    'Hybrid Remuxes and Encodes are subject to the following condition:\n\n'
+                    'Hybrid user releases are permitted, but are treated similarly to regular '
+                    'user releases and must be approved by staff before you upload them '
+                    '(please see the torrent approvals forum for details).'
                 )
-                if ask_bloated == 'y':
-                    pass
-                else:
-                    meta['phd_rule'] = 'Canceled by user. Reason: Bloated'
-                    return False
 
-            return True
+        # Log
+        if type == 'remux':
+            warnings.append(
+                'Remuxes must have a demux/eac3to log under spoilers in description.\n'
+                'Do you have these logs and will you add them to the description after upload?'
+            )
+
+        # Bloated
+        if meta.get('bloated', False):
+            warnings.append(
+                'Audio dubs are never preferred and can always be trumped by original audio only rip (Exception for BD50/BD25).\n'
+                'Do NOT upload a multi audio release when there is already a original audio only release on site.\n'
+            )
+
+        if warnings:
+            all_warnings = '\n\n'.join(filter(None, warnings))
+            meta['az_rule'] = all_warnings
+
+        return warnings
 
     def get_rip_type(self, meta):
         source_type = meta.get('type')

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -101,7 +101,7 @@ class PHD(AZTrackerBase):
         origin_countries_codes = meta.get('origin_country', [])
 
         if any(code in phd_allowed_countries for code in origin_countries_codes):
-            return True
+            pass
 
         # CinemaZ
         elif any(code in cinemaz_countries for code in origin_countries_codes):
@@ -328,9 +328,9 @@ class PHD(AZTrackerBase):
 
         if warnings:
             all_warnings = '\n\n'.join(filter(None, warnings))
-            meta['az_rule'] = all_warnings
+            return all_warnings
 
-        return warnings
+        return
 
     def get_rip_type(self, meta):
         source_type = meta.get('type')

--- a/src/trackers/PHD.py
+++ b/src/trackers/PHD.py
@@ -452,6 +452,9 @@ class PHD(AZTrackerBase):
                 upload_name = re.sub(f'-{invalid_tag}', '', upload_name, flags=re.IGNORECASE)
             upload_name = f'{upload_name}-NOGROUP'
 
+        if meta.get('has_encode_settings', False):
+            upload_name = upload_name.replace('H.264', 'x264').replace('H.265', 'x265')
+
         return upload_name
 
     def get_rip_type(self, meta):

--- a/upload.py
+++ b/upload.py
@@ -267,7 +267,7 @@ async def process_meta(meta, base_dir, bot=None):
         console.print(f"[green]Processing {meta['name']} for upload...[/green]")
 
         audio_prompted = False
-        for tracker in ["AITHER", "ASC", "AZ", "BJS", "BT", "CBR", "CZ", "DP", "FF", "GPW", "HUNO", "LDU", "OE", "PTS", "SPD", "ULCX"]:
+        for tracker in ["AITHER", "ASC", "BJS", "BT", "CBR", "DP", "FF", "GPW", "HUNO", "LDU", "OE", "PTS", "SPD", "ULCX"]:
             if tracker in trackers:
                 if not audio_prompted:
                     await process_desc_language(meta, desc=None, tracker=tracker)


### PR DESCRIPTION
- Use `MediaInfo.json` for language detection and processing  
- Fix handling of SD content for AZ/CZ  
- Adjust codec naming when release includes encoding settings (e.g., H. → x.)  
- Fix positional argument handling when adding media to the site database  
- Add missing countries
- Make basic rule checking optional  
- fix Chinese language mapping
- Update the cookie file after a successful request, as they change with time. This persists the latest session state and handles cookie renewals from the server.
- Add Internal tag
- Remove the option to skip image rehosting. Screenshots should always be hosted on AZ sites.