### PR TITLE
Fix HUNO bit rate detection

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -367,7 +367,7 @@ class HUNO():
                         if bit_rate and "Animation" not in meta.get('genre', ""):
                             bit_rate_num = None
                             # Match number and unit (e.g., 42.4 Mb/s, 42400 kb/s, etc.)
-                            match = re.search(r'([\d.]+)\s*([kM]?b/s)', bit_rate.replace(',', ''), re.IGNORECASE)
+                            match = re.search(r'([\d.]+)\s*([kM]?b/s)', bit_rate.replace(',', '').replace(' ', ''), re.IGNORECASE)
                             if match:
                                 value = float(match.group(1))
                                 unit = match.group(2).lower()


### PR DESCRIPTION
Bit rate can look like this: `5 999 kb/s`

In this example, the regex matches only `999` so the check fails.