### PR TITLE
feat(UNIT3D) - refactor UNIT3D websites to reuse common code base

### DIFF
--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -1,144 +1,35 @@
 # -*- coding: utf-8 -*-
 # import discord
-import asyncio
 import glob
-import httpx
 import os
-import platform
-import requests
 from src.console import console
 from src.trackers.COMMON import COMMON
+from src.trackers.UNIT3D import UNIT3D
 
 
-class BLU():
-    """
-    Edit for Tracker:
-        Edit BASE.torrent with announce and source
-        Check for duplicates
-        Set type/category IDs
-        Upload
-    """
+class BLU(UNIT3D):
     def __init__(self, config):
+        super().__init__(config, tracker_name='BLU')
         self.config = config
+        self.common = COMMON(config)
         self.tracker = 'BLU'
         self.source_flag = 'BLU'
-        self.search_url = 'https://blutopia.cc/api/torrents/filter'
-        self.torrent_url = 'https://blutopia.cc/torrents/'
-        self.id_url = 'https://blutopia.cc/api/torrents/'
-        self.upload_url = 'https://blutopia.cc/api/torrents/upload'
-        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionuts Upload Assistant[/url][/center]"
+        self.base_url = 'https://blutopia.cc'
         self.banned_groups = [
-            '[Oj]', '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AROMA', 'aXXo', 'Brrip', 'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc', 'FaNGDiNG0', 'FGT', 'Flights',
-            'FRDS', 'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LEGi0N', 'LOAD', 'MeGusta', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'OFT',
-            'nSD', 'PiRaTeS', 'playBD', 'PlaySD', 'playXD', 'PRODJi', 'RAPiDCOWS', 'RARBG', 'RetroPeeps', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi', 'SicFoI', 'SPASM', 'SPDVD', 'STUTTERSHIT', 'Telly', 'TM',
-            'TRiToN', 'UPiNSMOKE', 'URANiME', 'WAF', 'x0r', 'xRed', 'XS', 'YIFY', 'ZKBL', 'ZmN', 'ZMNT', 'AOC',
-            ['EVO', 'Raw Content Only'], ['TERMiNAL', 'Raw Content Only'], ['ViSION', 'Note the capitalization and characters used'], ['CMRG', 'Raw Content Only']
+            '[Oj]', '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AOC', 'AROMA',
+            'aXXo', 'Brrip', 'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc',
+            'FaNGDiNG0', 'FGT', 'Flights', 'FRDS', 'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime',
+            'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LEGi0N', 'LOAD', 'MeGusta',
+            'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'nSD', 'OFT', 'PiRaTeS', 'playBD',
+            'PlaySD', 'playXD', 'PRODJi', 'RAPiDCOWS', 'RARBG', 'RDN', 'REsuRRecTioN', 'RetroPeeps',
+            'RMTeam', 'SANTi', 'SicFoI', 'SPASM', 'SPDVD', 'STUTTERSHIT', 'Telly', 'TM', 'TRiToN',
+            'UPiNSMOKE', 'URANiME', 'WAF', 'x0r', 'xRed', 'XS', 'YIFY', 'ZKBL', 'ZmN', 'ZMNT',
+            ['CMRG', 'Raw Content Only'], ['EVO', 'Raw Content Only'], ['TERMiNAL', 'Raw Content Only'],
+            ['ViSION', 'Note the capitalization and characters used'],
         ]
         pass
 
-    async def upload(self, meta, disctype):
-        common = COMMON(config=self.config)
-        blu_name = await self.edit_name(meta)
-        desc_header = ""
-        if meta.get('webdv', False):
-            blu_name, desc_header = await self.derived_dv_layer(meta)
-        await common.edit_torrent(meta, self.tracker, self.source_flag)
-        await common.unit3d_edit_desc(meta, self.tracker, self.signature, comparison=True, desc_header=desc_header)
-        cat_id = await self.get_cat_id(meta['category'], meta.get('edition', ''))
-        type_id = await self.get_type_id(meta['type'])
-        resolution_id = await self.get_res_id(meta['resolution'])
-        modq = await self.get_flag(meta, 'modq')
-        region_id = await common.unit3d_region_ids(meta.get('region'))
-        distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
-            anon = 0
-        else:
-            anon = 1
-
-        if meta['bdinfo'] is not None:
-            mi_dump = None
-            bd_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8').read()
-        else:
-            mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8').read()
-            bd_dump = None
-        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[BLU]DESCRIPTION.txt", 'r', encoding='utf-8').read()
-
-        base_dir = meta['base_dir']
-        uuid = meta['uuid']
-        specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
-        nfo_files = glob.glob(specified_dir_path)
-        nfo_file = None
-        if nfo_files:
-            nfo_file = open(nfo_files[0], 'rb')
-
-        open_torrent = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[BLU].torrent", 'rb')
-        files = {'torrent': ("placeholder.torrent", open_torrent, "application/x-bittorrent")}
-
-        if nfo_file:
-            files['nfo'] = ("nfo_file.nfo", nfo_file, "text/plain")
-
-        data = {
-            'name': blu_name,
-            'description': desc,
-            'mediainfo': mi_dump,
-            'bdinfo': bd_dump,
-            'category_id': cat_id,
-            'type_id': type_id,
-            'resolution_id': resolution_id,
-            'tmdb': meta['tmdb'],
-            'imdb': meta['imdb'],
-            'tvdb': meta['tvdb_id'],
-            'mal': meta['mal_id'],
-            'igdb': 0,
-            'anonymous': anon,
-            'stream': meta['stream'],
-            'sd': meta['sd'],
-            'keywords': meta['keywords'],
-            'personal_release': int(meta.get('personalrelease', False)),
-            'internal': 0,
-            'featured': 0,
-            'free': 0,
-            'doubleup': 0,
-            'sticky': 0,
-            'mod_queue_opt_in': modq,
-        }
-        # Internal
-        if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
-            if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
-                data['internal'] = 1
-
-        if region_id != 0:
-            data['region_id'] = region_id
-        if distributor_id != 0:
-            data['distributor_id'] = distributor_id
-        if meta.get('category') == "TV":
-            data['season_number'] = meta.get('season_int', '0')
-            data['episode_number'] = meta.get('episode_int', '0')
-        headers = {
-            'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
-        }
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        }
-
-        if meta['debug'] is False:
-            response = requests.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
-            try:
-                meta['tracker_status'][self.tracker]['status_message'] = response.json()
-                # adding torrent link to comment of torrent file
-                t_id = response.json()['data'].split(".")[1].split("/")[3]
-                meta['tracker_status'][self.tracker]['torrent_id'] = t_id
-                await common.add_tracker_torrent(meta, self.tracker, self.source_flag, self.config['TRACKERS'][self.tracker].get('announce_url'), "https://blutopia.cc/torrents/" + t_id, headers=headers, params=params, downurl=response.json()['data'])
-            except Exception:
-                console.print("It may have uploaded, go check")
-                return
-        else:
-            console.print("[cyan]Request Data:")
-            console.print(data)
-            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
-        open_torrent.close()
-
-    async def edit_name(self, meta):
+    async def get_name(self, meta):
         blu_name = meta['name']
         if meta['category'] == 'TV' and meta.get('episode_title', "") != "":
             blu_name = blu_name.replace(f"{meta['episode_title']} {meta['resolution']}", f"{meta['resolution']}", 1)
@@ -148,14 +39,65 @@ class BLU():
         blu_name = blu_name.replace(f"{meta['title']}", imdb_name, 1)
         if not meta.get('category') == "TV":
             blu_name = blu_name.replace(f"{year}", imdb_year, 1)
+
+        if all([x in meta['hdr'] for x in ['HDR', 'DV']]):
+            if "hybrid" not in blu_name.lower():
+                if "REPACK" in blu_name:
+                    blu_name = blu_name.replace('REPACK', 'Hybrid REPACK')
+                else:
+                    blu_name = blu_name.replace(meta['resolution'], f"Hybrid {meta['resolution']}")
+
         return blu_name
 
-    async def get_flag(self, meta, flag_name):
-        config_flag = self.config['TRACKERS'][self.tracker].get(flag_name)
-        if config_flag is not None:
-            return 1 if config_flag else 0
+    async def get_description(self, meta):
+        desc_header = ''
+        if meta.get('webdv', False):
+            desc_header = await self.derived_dv_layer(meta)
+        await self.common.unit3d_edit_desc(meta, self.tracker, self.signature, comparison=True, desc_header=desc_header)
+        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8').read()
+        return desc
 
-        return 1 if meta.get(flag_name, False) else 0
+    async def derived_dv_layer(self, meta):
+        desc_header = ''
+        # Exit if not DV + HDR
+        if not all([x in meta['hdr'] for x in ['HDR', 'DV']]):
+            return desc_header
+        import cli_ui
+        console.print("[bold yellow]Generating the required description addition for Derived DV Layers. Please respond appropriately.")
+        ask_comp = True
+        if meta['type'] == 'WEBDL':
+            if cli_ui.ask_yes_no("Is the DV Layer sourced from the same service as the video?"):
+                ask_comp = False
+                desc_header = "[code]This release contains a derived Dolby Vision profile 8 layer. Comparisons not required as DV and HDR are from same provider.[/code]"
+
+        if ask_comp:
+            while desc_header == "":
+                desc_input = cli_ui.ask_string("Please provide comparisons between HDR masters. (link or bbcode)", default="")
+                desc_header = f"[code]This release contains a derived Dolby Vision profile 8 layer. Comparisons between HDR masters: {desc_input}[/code]"
+
+        return desc_header
+
+    async def get_additional_data(self, meta):
+        data = {
+            'modq': await self.get_flag(meta, 'modq'),
+        }
+
+        return data
+
+    async def get_additional_files(self, meta):
+        files = {}
+        base_dir = meta['base_dir']
+        uuid = meta['uuid']
+        specified_dir_path = os.path.join(base_dir, 'tmp', uuid, '*.nfo')
+        nfo_files = glob.glob(specified_dir_path)
+
+        if nfo_files:
+            nfo_path = nfo_files[0]
+            with open(nfo_path, 'rb') as f:
+                content = f.read()
+            files['nfo'] = (os.path.basename(nfo_path), content, 'text/plain')
+
+        return files
 
     async def get_cat_id(self, category_name, edition):
         category_id = {
@@ -193,63 +135,3 @@ class BLU():
             '480i': '9'
         }.get(resolution, '10')
         return resolution_id
-
-    async def derived_dv_layer(self, meta):
-        name = meta['name']
-        desc_header = ""
-        # Exit if not DV + HDR
-        if not all([x in meta['hdr'] for x in ['HDR', 'DV']]):
-            return name, desc_header
-        import cli_ui
-        console.print("[bold yellow]Generating the required description addition for Derived DV Layers. Please respond appropriately.")
-        ask_comp = True
-        if meta['type'] == "WEBDL":
-            if cli_ui.ask_yes_no("Is the DV Layer sourced from the same service as the video?"):
-                ask_comp = False
-                desc_header = "[code]This release contains a derived Dolby Vision profile 8 layer. Comparisons not required as DV and HDR are from same provider.[/code]"
-
-        if ask_comp:
-            while desc_header == "":
-                desc_input = cli_ui.ask_string("Please provide comparisons between HDR masters. (link or bbcode)", default="")
-                desc_header = f"[code]This release contains a derived Dolby Vision profile 8 layer. Comparisons between HDR masters: {desc_input}[/code]"
-
-        if "hybrid" not in name.lower():
-            if "REPACK" in name:
-                name = name.replace('REPACK', 'Hybrid REPACK')
-            else:
-                name = name.replace(meta['resolution'], f"Hybrid {meta['resolution']}")
-        return name, desc_header
-
-    async def search_existing(self, meta, disctype):
-        dupes = []
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
-            'tmdbId': meta['tmdb'],
-            'categories[]': await self.get_cat_id(meta['category'], meta.get('edition', '')),
-            'types[]': await self.get_type_id(meta['type']),
-            'resolutions[]': await self.get_res_id(meta['resolution']),
-            'name': ""
-        }
-        if meta['category'] == 'TV':
-            params['name'] = params['name'] + f" {meta.get('season', '')}"
-        if meta.get('edition', "") != "":
-            params['name'] = params['name'] + f" {meta['edition']}"
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.get(url=self.search_url, params=params)
-                if response.status_code == 200:
-                    data = response.json()
-                    for each in data['data']:
-                        result = [each][0]['attributes']['name']
-                        dupes.append(result)
-                else:
-                    console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
-        except httpx.TimeoutException:
-            console.print("[bold red]Request timed out after 5 seconds")
-        except httpx.RequestError as e:
-            console.print(f"[bold red]Unable to search for existing torrents: {e}")
-        except Exception as e:
-            console.print(f"[bold red]Unexpected error: {e}")
-            await asyncio.sleep(5)
-
-        return dupes

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -15,6 +15,10 @@ class BLU(UNIT3D):
         self.tracker = 'BLU'
         self.source_flag = 'BLU'
         self.base_url = 'https://blutopia.cc'
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
         self.banned_groups = [
             '[Oj]', '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AOC', 'AROMA',
             'aXXo', 'Brrip', 'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc',

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -1380,15 +1380,15 @@ class COMMON():
         project_root = os.path.dirname(os.path.dirname(current_dir))
         version_file_path = os.path.join(project_root, 'data', 'version.py')
         if not os.path.isfile(version_file_path):
-            return None
+            return ''
         try:
             with open(version_file_path, "r", encoding="utf-8") as f:
                 content = f.read()
             match = re.search(r'__version__\s*=\s*"([^"]+)"', content)
             if match:
-                return match.group(1)
+                return f' {match.group(1)}'
         except OSError as e:
             print(f"Error reading version file: {e}")
-            return None
+            return ''
 
-        return None
+        return ''

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -1374,3 +1374,21 @@ class COMMON():
 
             bbcode_output += "\n"
             return bbcode_output
+
+    def get_version(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(os.path.dirname(current_dir))
+        version_file_path = os.path.join(project_root, 'data', 'version.py')
+        if not os.path.isfile(version_file_path):
+            return None
+        try:
+            with open(version_file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            match = re.search(r'__version__\s*=\s*"([^"]+)"', content)
+            if match:
+                return match.group(1)
+        except OSError as e:
+            print(f"Error reading version file: {e}")
+            return None
+
+        return None

--- a/src/trackers/FNP.py
+++ b/src/trackers/FNP.py
@@ -1,54 +1,28 @@
 # -*- coding: utf-8 -*-
 # import discord
-import asyncio
-import requests
-import platform
 import os
 import glob
-import httpx
-
 from src.trackers.COMMON import COMMON
-from src.console import console
+from src.trackers.UNIT3D import UNIT3D
 
 
-class FNP():
-    """
-    Edit for Tracker:
-        Edit BASE.torrent with announce and source
-        Check for duplicates
-        Set type/category IDs
-        Upload
-    """
-
+class FNP(UNIT3D):
     def __init__(self, config):
+        super().__init__(config, tracker_name='FNP')
         self.config = config
+        self.common = COMMON(config)
         self.tracker = 'FNP'
         self.source_flag = 'FnP'
-        self.upload_url = 'https://fearnopeer.com/api/torrents/upload'
-        self.search_url = 'https://fearnopeer.com/api/torrents/filter'
-        self.torrent_url = 'https://fearnopeer.com/torrents/'
-        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
-        self.banned_groups = ["4K4U", "BiTOR", "d3g", "FGT", "FRDS", "FTUApps", "GalaxyRG", "LAMA", "MeGusta", "NeoNoir", "PSA", "RARBG", "YAWNiX", "YTS", "YIFY", "x0r"]
+        self.base_url = 'https://fearnopeer.com'
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
+        self.banned_groups = [
+            "4K4U", "BiTOR", "d3g", "FGT", "FRDS", "FTUApps", "GalaxyRG", "LAMA",
+            "MeGusta", "NeoNoir", "PSA", "RARBG", "YAWNiX", "YTS", "YIFY", "x0r"
+        ]
         pass
-
-    async def get_cat_id(self, category_name):
-        category_id = {
-            'MOVIE': '1',
-            'TV': '2',
-        }.get(category_name, '0')
-        return category_id
-
-    async def get_type_id(self, type):
-        type_id = {
-            'DISC': '1',
-            'REMUX': '2',
-            'ENCODE': '3',
-            'WEBDL': '4',
-            'WEBRIP': '5',
-            'HDTV': '6',
-            'SDTV': '7'
-        }.get(type, '0')
-        return type_id
 
     async def get_res_id(self, resolution):
         resolution_id = {
@@ -64,128 +38,24 @@ class FNP():
         }.get(resolution, '10')
         return resolution_id
 
-    async def upload(self, meta, disctype):
-        common = COMMON(config=self.config)
-        await common.edit_torrent(meta, self.tracker, self.source_flag)
-        cat_id = await self.get_cat_id(meta['category'])
-        type_id = await self.get_type_id(meta['type'])
-        resolution_id = await self.get_res_id(meta['resolution'])
-        await common.unit3d_edit_desc(meta, self.tracker, self.signature)
-        region_id = await common.unit3d_region_ids(meta.get('region'))
-        distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
-            anon = 0
-        else:
-            anon = 1
+    async def get_additional_data(self, meta):
+        data = {
+            'modq': await self.get_flag(meta, 'modq'),
+        }
 
-        if meta['bdinfo'] is not None:
-            mi_dump = None
-            bd_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8').read()
-        else:
-            mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8').read()
-            bd_dump = None
-        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8').read()
-        open_torrent = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent", 'rb')
-        files = {'torrent': open_torrent}
+        return data
+
+    async def get_additional_files(self, meta):
+        files = {}
         base_dir = meta['base_dir']
         uuid = meta['uuid']
-        specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
+        specified_dir_path = os.path.join(base_dir, 'tmp', uuid, '*.nfo')
         nfo_files = glob.glob(specified_dir_path)
-        nfo_file = None
+
         if nfo_files:
-            nfo_file = open(nfo_files[0], 'rb')
-        if nfo_file:
-            files['nfo'] = ("nfo_file.nfo", nfo_file, "text/plain")
-        data = {
-            'name': meta['name'],
-            'description': desc,
-            'mediainfo': mi_dump,
-            'bdinfo': bd_dump,
-            'category_id': cat_id,
-            'type_id': type_id,
-            'resolution_id': resolution_id,
-            'tmdb': meta['tmdb'],
-            'imdb': meta['imdb'],
-            'tvdb': meta['tvdb_id'],
-            'mal': meta['mal_id'],
-            'igdb': 0,
-            'anonymous': anon,
-            'stream': meta['stream'],
-            'sd': meta['sd'],
-            'keywords': meta['keywords'],
-            'personal_release': int(meta.get('personalrelease', False)),
-            'internal': 0,
-            'featured': 0,
-            'free': 0,
-            'doubleup': 0,
-            'sticky': 0,
-        }
-        # Internal
-        if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
-            if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
-                data['internal'] = 1
+            nfo_path = nfo_files[0]
+            with open(nfo_path, 'rb') as f:
+                content = f.read()
+            files['nfo'] = (os.path.basename(nfo_path), content, 'text/plain')
 
-        if region_id != 0:
-            data['region_id'] = region_id
-        if distributor_id != 0:
-            data['distributor_id'] = distributor_id
-        if meta.get('category') == "TV":
-            data['season_number'] = meta.get('season_int', '0')
-            data['episode_number'] = meta.get('episode_int', '0')
-        headers = {
-            'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
-        }
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        }
-
-        if meta['debug'] is False:
-            response = requests.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
-            try:
-                meta['tracker_status'][self.tracker]['status_message'] = response.json()
-                # adding torrent link to comment of torrent file
-                t_id = response.json()['data'].split(".")[1].split("/")[3]
-                meta['tracker_status'][self.tracker]['torrent_id'] = t_id
-                await common.add_tracker_torrent(meta, self.tracker, self.source_flag, self.config['TRACKERS'][self.tracker].get('announce_url'), "https://fearnopeer.com/torrents/" + t_id, headers=headers, params=params, downurl=response.json()['data'])
-            except Exception:
-                console.print("It may have uploaded, go check")
-                return
-        else:
-            console.print("[cyan]Request Data:")
-            console.print(data)
-            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
-        open_torrent.close()
-
-    async def search_existing(self, meta, disctype):
-        dupes = []
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
-            'tmdbId': meta['tmdb'],
-            'categories[]': await self.get_cat_id(meta['category']),
-            'types[]': await self.get_type_id(meta['type']),
-            'resolutions[]': await self.get_res_id(meta['resolution']),
-            'name': ""
-        }
-        if meta['category'] == 'TV':
-            params['name'] = params['name'] + f" {meta.get('season', '')}"
-        if meta.get('edition', "") != "":
-            params['name'] = params['name'] + f" {meta['edition']}"
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.get(url=self.search_url, params=params)
-                if response.status_code == 200:
-                    data = response.json()
-                    for each in data['data']:
-                        result = [each][0]['attributes']['name']
-                        dupes.append(result)
-                else:
-                    console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
-        except httpx.TimeoutException:
-            console.print("[bold red]Request timed out after 5 seconds")
-        except httpx.RequestError as e:
-            console.print(f"[bold red]Unable to search for existing torrents: {e}")
-        except Exception as e:
-            console.print(f"[bold red]Unexpected error: {e}")
-            await asyncio.sleep(5)
-
-        return dupes
+        return files

--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -1,42 +1,25 @@
 # -*- coding: utf-8 -*-
 # import discord
-import asyncio
-import requests
-import platform
 import os
 import glob
-import httpx
 from src.trackers.COMMON import COMMON
-from src.console import console
+from src.trackers.UNIT3D import UNIT3D
 
 
-class LST():
-    """
-    Edit for Tracker:
-        Edit BASE.torrent with announce and source
-        Check for duplicates
-        Set type/category IDs
-        Upload
-    """
-
+class LST(UNIT3D):
     def __init__(self, config):
+        super().__init__(config, tracker_name='LST')
         self.config = config
+        self.common = COMMON(config)
         self.tracker = 'LST'
         self.source_flag = 'LST.GG'
-        self.upload_url = 'https://lst.gg/api/torrents/upload'
-        self.search_url = 'https://lst.gg/api/torrents/filter'
-        self.torrent_url = 'https://lst.gg/torrents/'
-        self.id_url = 'https://lst.gg/api/torrents/'
-        self.signature = "\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by Audionut's Upload Assistant[/url][/center]"
+        self.base_url = 'https://lst.gg'
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
         self.banned_groups = []
         pass
-
-    async def get_cat_id(self, category_name):
-        category_id = {
-            'MOVIE': '1',
-            'TV': '2',
-        }.get(category_name, '0')
-        return category_id
 
     async def get_type_id(self, type):
         type_id = {
@@ -50,125 +33,28 @@ class LST():
         }.get(type, '0')
         return type_id
 
-    async def get_res_id(self, resolution):
-        resolution_id = {
-            '8640p': '10',
-            '4320p': '1',
-            '2160p': '2',
-            '1440p': '3',
-            '1080p': '3',
-            '1080i': '4',
-            '720p': '5',
-            '576p': '6',
-            '576i': '7',
-            '480p': '8',
-            '480i': '9'
-        }.get(resolution, '10')
-        return resolution_id
+    async def get_additional_data(self, meta):
+        data = {
+            'modq': await self.get_flag(meta, 'modq'),
+            'draft': await self.get_flag(meta, 'draft'),
+        }
 
-    async def upload(self, meta, disctype):
-        common = COMMON(config=self.config)
-        await common.edit_torrent(meta, self.tracker, self.source_flag)
-        cat_id = await self.get_cat_id(meta['category'])
-        type_id = await self.get_type_id(meta['type'])
-        resolution_id = await self.get_res_id(meta['resolution'])
-        modq = await self.get_flag(meta, 'modq')
-        draft = await self.get_flag(meta, 'draft')
-        name = await self.edit_name(meta)
-        await common.unit3d_edit_desc(meta, self.tracker, self.signature, comparison=True)
-        region_id = await common.unit3d_region_ids(meta.get('region'))
-        distributor_id = await common.unit3d_distributor_ids(meta.get('distributor'))
-        if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
-            anon = 0
-        else:
-            anon = 1
+        return data
 
-        if meta['bdinfo'] is not None:
-            mi_dump = None
-            bd_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8').read()
-        else:
-            mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8').read()
-            bd_dump = None
-
-        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8').read()
-        if meta.get('service') == "hentai":
-            desc = "[center]" + "[img]" + str(meta['poster']) + "[/img][/center]" + "\n[center]" + "https://www.themoviedb.org/tv/" + str(meta['tmdb']) + "\nhttps://myanimelist.net/anime/" + str(meta['mal']) + "[/center]" + desc
-
-        torrent_file_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent"
-        open_torrent = open(torrent_file_path, 'rb')
-        files = {'torrent': open_torrent}
+    async def get_additional_files(self, meta):
+        files = {}
         base_dir = meta['base_dir']
         uuid = meta['uuid']
-        specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
+        specified_dir_path = os.path.join(base_dir, 'tmp', uuid, '*.nfo')
         nfo_files = glob.glob(specified_dir_path)
-        nfo_file = None
+
         if nfo_files:
-            nfo_file = open(nfo_files[0], 'rb')
-        if nfo_file:
-            files['nfo'] = ("nfo_file.nfo", nfo_file, "text/plain")
-        data = {
-            'name': name,
-            'description': desc,
-            'mediainfo': mi_dump,
-            'bdinfo': bd_dump,
-            'category_id': cat_id,
-            'type_id': type_id,
-            'resolution_id': resolution_id,
-            'tmdb': meta['tmdb'],
-            'imdb': meta['imdb'],
-            'tvdb': meta['tvdb_id'],
-            'mal': meta['mal_id'],
-            'igdb': 0,
-            'anonymous': anon,
-            'stream': meta['stream'],
-            'sd': meta['sd'],
-            'keywords': meta['keywords'],
-            'personal_release': int(meta.get('personalrelease', False)),
-            'internal': 0,
-            'featured': 0,
-            'free': 0,
-            'doubleup': 0,
-            'sticky': 0,
-            'mod_queue_opt_in': modq,
-            'draft_queue_opt_in': draft,
-        }
+            nfo_path = nfo_files[0]
+            with open(nfo_path, 'rb') as f:
+                content = f.read()
+            files['nfo'] = (os.path.basename(nfo_path), content, 'text/plain')
 
-        # Internal
-        if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
-            if meta['tag'] != "" and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
-                data['internal'] = 1
-        if meta.get('freeleech', 0) != 0:
-            data['free'] = meta.get('freeleech', 0)
-        if region_id != 0:
-            data['region_id'] = region_id
-        if distributor_id != 0:
-            data['distributor_id'] = distributor_id
-        if meta.get('category') == "TV":
-            data['season_number'] = meta.get('season_int', '0')
-            data['episode_number'] = meta.get('episode_int', '0')
-        headers = {
-            'User-Agent': f'Upload Assistant/2.2 ({platform.system()} {platform.release()})'
-        }
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        }
-
-        if meta['debug'] is False:
-            response = requests.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
-            try:
-                meta['tracker_status'][self.tracker]['status_message'] = response.json()
-                # adding torrent link to comment of torrent file
-                t_id = response.json()['data'].split(".")[1].split("/")[3]
-                meta['tracker_status'][self.tracker]['torrent_id'] = t_id
-                await common.add_tracker_torrent(meta, self.tracker, self.source_flag, self.config['TRACKERS'][self.tracker].get('announce_url'), "https://lst.gg/torrents/" + t_id, headers=headers, params=params, downurl=response.json()['data'])
-            except Exception:
-                console.print("It may have uploaded, go check")
-                return
-        else:
-            console.print("[cyan]Request Data:")
-            console.print(data)
-            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
-        open_torrent.close()
+        return files
 
     async def edit_name(self, meta):
         lst_name = meta['name']
@@ -185,44 +71,3 @@ class LST():
                 lst_name = lst_name.replace(f"{meta['video_codec']}", f"{meta['audio']} {meta['video_codec']}", 1)
 
         return lst_name
-
-    async def get_flag(self, meta, flag_name):
-        config_flag = self.config['TRACKERS'][self.tracker].get(flag_name)
-        if config_flag is not None:
-            return 1 if config_flag else 0
-
-        return 1 if meta.get(flag_name, False) else 0
-
-    async def search_existing(self, meta, disctype):
-        dupes = []
-        params = {
-            'api_token': self.config['TRACKERS'][self.tracker]['api_key'].strip(),
-            'tmdbId': meta['tmdb'],
-            'categories[]': await self.get_cat_id(meta['category']),
-            'types[]': await self.get_type_id(meta['type']),
-            'resolutions[]': await self.get_res_id(meta['resolution']),
-            'name': ""
-        }
-        if meta['category'] == 'TV':
-            params['name'] = params['name'] + f" {meta.get('season', '')}"
-        if meta.get('edition', "") != "":
-            params['name'] = params['name'] + f" {meta['edition']}"
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.get(url=self.search_url, params=params)
-                if response.status_code == 200:
-                    data = response.json()
-                    for each in data['data']:
-                        result = [each][0]['attributes']['name']
-                        dupes.append(result)
-                else:
-                    console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
-        except httpx.TimeoutException:
-            console.print("[bold red]Request timed out after 5 seconds")
-        except httpx.RequestError as e:
-            console.print(f"[bold red]Unable to search for existing torrents: {e}")
-        except Exception as e:
-            console.print(f"[bold red]Unexpected error: {e}")
-            await asyncio.sleep(5)
-
-        return dupes

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -3,8 +3,6 @@
 import asyncio
 import httpx
 import platform
-import re
-from pathlib import Path
 from src.trackers.COMMON import COMMON
 from src.console import console
 
@@ -14,18 +12,10 @@ class UNIT3D():
         self.config = config
         self.tracker = tracker_name
         self.common = COMMON(config)
-
         tracker_config = self.config['TRACKERS'][self.tracker]
-        self.base_url = tracker_config.get('base_url')
         self.announce_url = tracker_config.get('announce_url')
-        self.source_flag = tracker_config.get('source_flag')
-
-        self.id_url = f'{self.base_url}/api/torrents/'
-        self.upload_url = f'{self.base_url}/api/torrents/upload'
-        self.search_url = f'{self.base_url}/api/torrents/filter'
-        self.torrent_url = f'{self.base_url}/torrents/'
         self.api_key = self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        version = get_local_version()
+        version = self.common.get_version()
         self.ua_name = f"Audionut's Upload Assistant{f' {version}' if version else ''}"
         self.signature = f'\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by {self.ua_name}[/url][/center]'
         pass
@@ -247,21 +237,3 @@ class UNIT3D():
                 console.print('[cyan]Request Data:')
                 console.print(data)
                 meta['tracker_status'][self.tracker]['status_message'] = 'Debug mode enabled, not uploading.'
-
-
-def get_local_version():
-    project_root = Path(__file__).resolve().parent.parent.parent
-    version_file_path = project_root / 'data' / 'version.py'
-
-    if not version_file_path.is_file():
-        return None
-    try:
-        with open(version_file_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-            match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", content)
-            if match:
-                return match.group(1)
-    except OSError:
-        return None
-
-    return None

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -3,7 +3,8 @@
 import asyncio
 import httpx
 import platform
-from data.version import __version__
+import re
+from pathlib import Path
 from src.trackers.COMMON import COMMON
 from src.console import console
 
@@ -24,7 +25,8 @@ class UNIT3D():
         self.search_url = f'{self.base_url}/api/torrents/filter'
         self.torrent_url = f'{self.base_url}/torrents/'
         self.api_key = self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        self.ua_name = f"Audionut's Upload Assistant {__version__}"
+        version = get_local_version()
+        self.ua_name = f"Audionut's Upload Assistant{f' {version}' if version else ''}"
         self.signature = f'\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by {self.ua_name}[/url][/center]'
         pass
 
@@ -245,3 +247,21 @@ class UNIT3D():
                 console.print('[cyan]Request Data:')
                 console.print(data)
                 meta['tracker_status'][self.tracker]['status_message'] = 'Debug mode enabled, not uploading.'
+
+
+def get_local_version():
+    project_root = Path(__file__).resolve().parent.parent.parent
+    version_file_path = project_root / 'data' / 'version.py'
+
+    if not version_file_path.is_file():
+        return None
+    try:
+        with open(version_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+            match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", content)
+            if match:
+                return match.group(1)
+    except OSError:
+        return None
+
+    return None

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# import discord
+import asyncio
+import httpx
+import platform
+from src.trackers.COMMON import COMMON
+from src.console import console
+
+
+class UNIT3D():
+    def __init__(self, config, tracker_name):
+        self.config = config
+        self.tracker = tracker_name
+        self.common = COMMON(config)
+
+        tracker_config = self.config['TRACKERS'][self.tracker]
+        self.base_url = tracker_config.get('base_url')
+        self.announce_url = tracker_config.get('announce_url')
+        self.source_flag = tracker_config.get('source_flag')
+
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
+        self.api_key = self.config['TRACKERS'][self.tracker]['api_key'].strip()
+        # self.requests_url = f'{self.base_url}/api/requests/filter'
+        self.ua_name = "Audionut's Upload Assistant v5"
+        self.signature = f'\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by {self.ua_name}[/url][/center]'
+        pass
+
+    async def search_existing(self, meta, disctype):
+        dupes = []
+        params = {
+            'api_token': self.api_key,
+            'tmdbId': meta['tmdb'],
+            'categories[]': await self.get_cat_id(meta['category']),
+            'types[]': await self.get_type_id(meta['type']),
+            'resolutions[]': await self.get_res_id(meta['resolution']),
+            'name': ''
+        }
+        if meta['category'] == 'TV':
+            params['name'] = params['name'] + f" {meta.get('season', '')}"
+        if meta.get('edition', '') != '':
+            params['name'] = params['name'] + f" {meta['edition']}"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url=self.search_url, params=params)
+                if response.status_code == 200:
+                    data = response.json()
+                    for each in data['data']:
+                        result = [each][0]['attributes']['name']
+                        dupes.append(result)
+                else:
+                    console.print(f'[bold red]Failed to search torrents. HTTP Status: {response.status_code}')
+        except httpx.TimeoutException:
+            console.print('[bold red]Request timed out after 10 seconds')
+        except httpx.RequestError as e:
+            console.print(f'[bold red]Unable to search for existing torrents: {e}')
+        except Exception as e:
+            console.print(f'[bold red]Unexpected error: {e}')
+            await asyncio.sleep(5)
+
+        return dupes
+
+    async def get_cat_id(self, category_name):
+        category_id = {
+            'MOVIE': '1',
+            'TV': '2',
+        }.get(category_name, '0')
+        return category_id
+
+    async def get_type_id(self, type):
+        type_id = {
+            'DISC': '1',
+            'REMUX': '2',
+            'WEBDL': '4',
+            'WEBRIP': '5',
+            'HDTV': '6',
+            'ENCODE': '3'
+        }.get(type, '0')
+        return type_id
+
+    async def get_res_id(self, resolution):
+        resolution_id = {
+            '8640p': '10',
+            '4320p': '1',
+            '2160p': '2',
+            '1440p': '3',
+            '1080p': '3',
+            '1080i': '4',
+            '720p': '5',
+            '576p': '6',
+            '576i': '7',
+            '480p': '8',
+            '480i': '9'
+        }.get(resolution, '10')
+        return resolution_id
+
+    async def get_distributor_ids(self, meta):
+        distributor = await self.common.unit3d_distributor_ids(meta.get('distributor'))
+        return distributor
+
+    async def get_region_id(self, meta):
+        region = await self.common.unit3d_region_ids(meta.get('region'))
+        return region
+
+    async def get_anon(self, meta):
+        if meta['anon'] == 0 and not self.config['TRACKERS'][self.tracker].get('anon', False):
+            anon = 0
+        else:
+            anon = 1
+        return anon
+
+    async def get_bdinfo(self, meta):
+        if meta['bdinfo'] is not None:
+            bdinfo = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", 'r', encoding='utf-8').read()
+        else:
+            bdinfo = None
+
+        return bdinfo
+
+    async def get_mediainfo(self, meta):
+        if meta['bdinfo'] is not None:
+            mediainfo = None
+        else:
+            mediainfo = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", 'r', encoding='utf-8').read()
+
+        return mediainfo
+
+    async def get_description(self, meta):
+        await self.common.unit3d_edit_desc(meta, self.tracker, self.signature)
+        desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', encoding='utf-8').read()
+        return desc
+
+    async def get_name(self, meta):
+        return meta['name']
+
+    async def get_data(self, meta):
+        region_id = await self.get_region_id(meta)
+        distributor_id = await self.get_distributor_ids(meta)
+
+        data = {
+            'name': await self.get_name(meta),
+            'description': await self.get_description(meta),
+            'mediainfo': await self.get_mediainfo(meta),
+            'bdinfo': await self.get_bdinfo(meta),
+            'category_id': await self.get_cat_id(meta['category']),
+            'type_id': await self.get_type_id(meta['type']),
+            'resolution_id': await self.get_res_id(meta['resolution']),
+            'tmdb': meta['tmdb'],
+            'imdb': meta['imdb'],
+            'tvdb': meta.get('tvdb_id', 0) if meta['category'] == 'TV' else 0,
+            'mal': meta['mal_id'],
+            'igdb': 0,
+            'anonymous': await self.get_anon(meta),
+            'stream': meta['stream'],
+            'sd': meta['sd'],
+            'keywords': meta['keywords'],
+            'personal_release': int(meta.get('personalrelease', False)),
+            'internal': 0,
+            'featured': 0,
+            'free': 0,
+            'doubleup': 0,
+            'sticky': 0,
+        }
+        # Internal
+        if self.config['TRACKERS'][self.tracker].get('internal', False) is True:
+            if meta['tag'] != '' and (meta['tag'][1:] in self.config['TRACKERS'][self.tracker].get('internal_groups', [])):
+                data['internal'] = 1
+        if meta.get('freeleech', 0) != 0:
+            data['free'] = meta.get('freeleech', 0)
+        if region_id != 0:
+            data['region_id'] = region_id
+        if distributor_id != 0:
+            data['distributor_id'] = distributor_id
+        if meta.get('category') == 'TV':
+            data['season_number'] = meta.get('season_int', '0')
+            data['episode_number'] = meta.get('episode_int', '0')
+
+        return data
+
+    async def upload(self, meta, disctype):
+        data = await self.get_data(meta)
+        await self.common.edit_torrent(meta, self.tracker, self.source_flag)
+
+        with open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent", 'rb') as torrent_file:
+            files = {'torrent': torrent_file}
+            headers = {'User-Agent': f'{self.ua_name} ({platform.system()} {platform.release()})'}
+            params = {'api_token': self.api_key}
+
+            if meta['debug'] is False:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    response = await client.post(url=self.upload_url, files=files, data=data, headers=headers, params=params)
+                    try:
+                        meta['tracker_status'][self.tracker]['status_message'] = response.json()
+                        # adding torrent link to comment of torrent file
+                        t_id = response.json()['data'].split('.')[1].split('/')[3]
+                        meta['tracker_status'][self.tracker]['torrent_id'] = t_id
+                        await self.common.add_tracker_torrent(
+                            meta,
+                            self.tracker,
+                            self.source_flag,
+                            self.announce_url,
+                            self.torrent_url + t_id,
+                            headers=headers,
+                            params=params,
+                            downurl=response.json()['data']
+                        )
+                    except httpx.TimeoutException:
+                        console.print('[bold red]Request timed out after 10 seconds')
+                    except httpx.RequestError as e:
+                        console.print(f'[bold red]Unable to upload to tracker: {e}')
+                    except Exception:
+                        console.print('It may have uploaded, go check')
+                        return
+            else:
+                console.print('[cyan]Request Data:')
+                console.print(data)
+                meta['tracker_status'][self.tracker]['status_message'] = 'Debug mode enabled, not uploading.'

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -15,8 +15,7 @@ class UNIT3D():
         tracker_config = self.config['TRACKERS'][self.tracker]
         self.announce_url = tracker_config.get('announce_url')
         self.api_key = self.config['TRACKERS'][self.tracker]['api_key'].strip()
-        version = self.common.get_version()
-        self.ua_name = f"Audionut's Upload Assistant{f' {version}' if version else ''}"
+        self.ua_name = f"Audionut's Upload Assistant{self.common.get_version()}"
         self.signature = f'\n[center][url=https://github.com/Audionut/Upload-Assistant]Created by {self.ua_name}[/url][/center]'
         pass
 
@@ -120,7 +119,6 @@ class UNIT3D():
         return anon
 
     async def get_additional_data(self, meta):
-        data = {}
         # Used to add additional data if needed
         '''
         data = {
@@ -128,6 +126,7 @@ class UNIT3D():
             'draft': await self.get_flag(meta, 'draft'),
         }
         '''
+        data = {}
 
         return data
 
@@ -194,6 +193,19 @@ class UNIT3D():
 
     async def get_additional_files(self, meta):
         # Used to add nfo or other files if needed
+        '''
+        files = {}
+        base_dir = meta['base_dir']
+        uuid = meta['uuid']
+        specified_dir_path = os.path.join(base_dir, 'tmp', uuid, '*.nfo')
+        nfo_files = glob.glob(specified_dir_path)
+
+        if nfo_files:
+            nfo_path = nfo_files[0]
+            with open(nfo_path, 'rb') as f:
+                content = f.read()
+            files['nfo'] = (os.path.basename(nfo_path), content, 'text/plain')
+        '''
         files = {}
 
         return files


### PR DESCRIPTION
Essentially, that's what I had done on the AZ websites. I tried to create a function for each piece of necessary data, so that if a website needed something modified (such as name or description), it could be easily implemented by simply copying and pasting the function from the base code and applying the modification. 
Let me know if that's okay, then I'll make the other trackers when I have time.