### PR TITLE
conform to GPW description image rules

### DIFF
--- a/src/trackers/GPW.py
+++ b/src/trackers/GPW.py
@@ -214,7 +214,7 @@ class GPW():
         if images:
             screenshots_block = '[center]\n'
             for i, image in enumerate(images, start=1):
-                screenshots_block += f"[img=350]{image['raw_url']}[/img] "
+                screenshots_block += f"[img]{image['raw_url']}[/img] "
                 if i % 2 == 0:
                     screenshots_block += '\n'
             screenshots_block += '\n[/center]'


### PR DESCRIPTION
Hi. First of all, thanks for the great work.
I received this message this morning from GPW torrent moderation

Hello,
According to the uploading rules, please modify your uploading script to make sure the uploaded images shown as their original resolution instade of 350px, just replacing [img]350[/img] with [img][/img]. 

So I modified GPW.py accordingly.