### PR TITLE
Improve NFO downloading robustness

### DIFF
--- a/src/is_scene.py
+++ b/src/is_scene.py
@@ -43,7 +43,7 @@ async def is_scene(video, meta, imdb=None, lower=False):
                         try:
                             release = first_result['release']
                             release_lower = release.lower()
-                            
+
                             release_details_url = f"https://api.srrdb.com/v1/details/{release}"
                             release_details_response = requests.get(release_details_url, timeout=30)
                             if release_details_response.status_code == 200:


### PR DESCRIPTION
Uses SRRDB API to obtain filename of NFO file, fallsback to using lowercase if unavailable via API. 
Allows grabbing NFO when filename is not lowercase of release name.