### PR TITLE
Fix YUS get_type_id

### DIFF
--- a/src/trackers/YUS.py
+++ b/src/trackers/YUS.py
@@ -30,7 +30,7 @@ class YUS(UNIT3D):
 
         return should_continue
 
-    async def get_type_id(self, meta):
+    async def get_type_id(self, meta, type=None, reverse=False, mapping_only=False):
         type_id = {
             'DISC': '17',
             'REMUX': '2',
@@ -38,5 +38,14 @@ class YUS(UNIT3D):
             'WEBRIP': '5',
             'HDTV': '6',
             'ENCODE': '3'
-        }.get(meta['type'], '0')
-        return {'type_id': type_id}
+        }
+        if mapping_only:
+            return type_id
+        elif reverse:
+            return {v: k for k, v in type_id.items()}
+        elif type is not None:
+            return {'type_id': type_id.get(type, '0')}
+        else:
+            meta_type = meta.get('type', '')
+            resolved_id = type_id.get(meta_type, '0')
+            return {'type_id': resolved_id}


### PR DESCRIPTION
Give it the same arguments in UNIT3D base otherwise there will be error:
```
An unexpected error occurred: YUS.get_type_id() got an unexpected keyword argument 'mapping_only'
Traceback (most recent call last):
  File "/Upload-Assistant/upload.py", line 917, in do_the_thing
    await tracker_setup.tracker_request(meta, meta['trackers'])
  File "/Upload-Assistant/src/trackersetup.py", line 780, in tracker_request
    results = await asyncio.gather(*)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Upload-Assistant/src/trackersetup.py", line 620, in process_single_tracker
    type_mapping = await tracker_instance.get_type_id(meta, mapping_only=True)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: YUS.get_type_id() got an unexpected keyword argument 'mapping_only'
```