### PR TITLE
Both [code] and [quote] should coexist in PTP descriptions

### DIFF
--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -713,8 +713,6 @@ class PTP():
         desc = desc.replace("[list]", "").replace("[/list]", "")
         desc = desc.replace("[ul]", "").replace("[/ul]", "")
         desc = desc.replace("[ol]", "").replace("[/ol]", "")
-        desc = desc.replace('[code', '[quote')
-        desc = desc.replace('[/code]', '[/quote]')
         desc = re.sub(r"\[img=[^\]]+\]", "[img]", desc)
         return desc
 


### PR DESCRIPTION
[code] and [quote] blocks have different use cases and are both useful in PTP descriptions.
They should coexist, imo.