### PR TITLE
feat(SAM): add name processing and add additional checks for Portuguese audio/subtitle tracks

### DIFF
--- a/src/trackers/SAM.py
+++ b/src/trackers/SAM.py
@@ -1,19 +1,106 @@
 # -*- coding: utf-8 -*-
+import re
+from src.console import console
+from src.languages import process_desc_language
 from src.trackers.COMMON import COMMON
 from src.trackers.UNIT3D import UNIT3D
 
 
 class SAM(UNIT3D):
     def __init__(self, config):
-        super().__init__(config, tracker_name='SAM')
+        super().__init__(config, tracker_name="SAM")
         self.config = config
         self.common = COMMON(config)
-        self.tracker = 'SAM'
-        self.source_flag = 'SAMARITANO'
-        self.base_url = 'https://samaritano.cc'
-        self.id_url = f'{self.base_url}/api/torrents/'
-        self.upload_url = f'{self.base_url}/api/torrents/upload'
-        self.search_url = f'{self.base_url}/api/torrents/filter'
-        self.torrent_url = f'{self.base_url}/torrents/'
+        self.tracker = "SAM"
+        self.source_flag = "SAMARITANO"
+        self.base_url = "https://samaritano.cc"
+        self.id_url = f"{self.base_url}/api/torrents/"
+        self.upload_url = f"{self.base_url}/api/torrents/upload"
+        self.search_url = f"{self.base_url}/api/torrents/filter"
+        self.torrent_url = f"{self.base_url}/torrents/"
+        self.requests_url = f"{self.base_url}/api/requests/filter"
         self.banned_groups = []
         pass
+
+    async def get_name(self, meta):
+        name = (
+            meta["name"]
+            .replace("DD+ ", "DDP")
+            .replace("DD ", "DD")
+            .replace("AAC ", "AAC")
+            .replace("FLAC ", "FLAC")
+            .replace("Dubbed", "")
+            .replace("Dual-Audio", "")
+        )
+
+        # If it is a Series or Anime, remove the year from the title.
+        if meta.get("category") in ["TV", "ANIMES"]:
+            year = str(meta.get("year", ""))
+            if year and year in name:
+                name = name.replace(year, "").replace(f"({year})", "").strip()
+
+        # Remove the AKA title, unless it is Brazilian
+        if meta.get("original_language") != "pt":
+            name = name.replace(meta["aka"], "")
+
+        # If it is Brazilian, use only the AKA title, deleting the foreign title
+        if meta.get("original_language") == "pt" and meta.get("aka"):
+            aka_clean = meta["aka"].replace("AKA", "").strip()
+            title = meta.get("title")
+            name = name.replace(meta["aka"], "").replace(title, aka_clean).strip()
+
+        sam_name = name
+        tag_lower = meta["tag"].lower()
+        invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
+
+        audio_tag = ""
+        if meta.get("audio_languages"):
+            audio_languages = set(meta["audio_languages"])
+
+            if "Portuguese" in audio_languages:
+                if len(audio_languages) >= 3:
+                    audio_tag = " MULTI"
+                elif len(audio_languages) == 2:
+                    audio_tag = " DUAL"
+                else:
+                    audio_tag = ""
+
+            if audio_tag:
+                if "-" in sam_name:
+                    parts = sam_name.rsplit("-", 1)
+                    sam_name = f"{parts[0]}{audio_tag}-{parts[1]}"
+                else:
+                    sam_name += audio_tag
+
+        if meta["tag"] == "" or any(
+            invalid_tag in tag_lower for invalid_tag in invalid_tags
+        ):
+            for invalid_tag in invalid_tags:
+                sam_name = re.sub(f"-{invalid_tag}", "", sam_name, flags=re.IGNORECASE)
+            sam_name = f"{sam_name}-NoGroup"
+
+        return {"name": re.sub(r"\s{2,}", " ", sam_name)}
+
+    async def get_additional_data(self, meta):
+        data = {
+            "mod_queue_opt_in": await self.get_flag(meta, "modq"),
+        }
+
+        return data
+
+    async def get_additional_checks(self, meta):
+        should_continue = True
+        if not meta.get("language_checked", False):
+            await process_desc_language(meta, desc=None, tracker=self.tracker)
+        portuguese_languages = ["Portuguese", "Português"]
+        if not any(
+            lang in meta.get("audio_languages", []) for lang in portuguese_languages
+        ) and not any(
+            lang in meta.get("subtitle_languages", []) for lang in portuguese_languages
+        ):
+            console.print(
+                "[bold red]SAM requires at least one Portuguese audio or subtitle track."
+            )
+            should_continue = False
+
+        return should_continue

--- a/upload.py
+++ b/upload.py
@@ -311,7 +311,7 @@ async def process_meta(meta, base_dir, bot=None):
         trackers = meta['trackers']
 
         audio_prompted = False
-        for tracker in ["AITHER", "ASC", "BJS", "BT", "CBR", "DP", "FF", "GPW", "HUNO", "LDU", "OE", "PTS", "SHRI", "SPD", "ULCX"]:
+        for tracker in ["AITHER", "ASC", "BJS", "BT", "CBR", "DP", "FF", "GPW", "HUNO", "LDU", "OE", "PTS", "SAM", "SHRI", "SPD", "ULCX"]:
             if tracker in trackers:
                 if not audio_prompted:
                     await process_desc_language(meta, desc=None, tracker=tracker)


### PR DESCRIPTION
- The staff said they want to use the same naming conventions as CBR to be more aligned with other Brazilian trackers.
- Also add `requests_url`, as they have updated to version 9.1.7.