### PR TITLE
fix: args key

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -220,7 +220,7 @@ class Args():
                         meta['manual_type'] = value2.upper().replace('-', '')
                     elif key == 'tag':
                         meta[key] = f"-{value2}"
-                    elif key == 'descfile':
+                    elif key == 'description_file':
                         meta[key] = os.path.abspath(value2)
                     elif key == 'comparison':
                         meta[key] = os.path.abspath(value2)


### PR DESCRIPTION
Commit ee1885b changed the name of the key for the description_file has changed 2 days ago.
This has broken the use of relative path for the description file.
This PR fixes that.