### PR TITLE
SHRI: fix type_id

### DIFF
--- a/src/trackers/SHRI.py
+++ b/src/trackers/SHRI.py
@@ -237,7 +237,7 @@ class SHRI(UNIT3D):
 
         return {"name": name}
 
-    async def get_type_id(self, meta):
+    async def get_type_id(self, meta, type=None, reverse=False, mapping_only=False):
         """Map release type to ShareIsland type IDs"""
         effective_type = self._get_effective_type(meta)
         type_id = {
@@ -250,8 +250,16 @@ class SHRI(UNIT3D):
             "ENCODE": "15",
             "DVDRIP": "15",
             "BRRIP": "15",
-        }.get(effective_type, "0")
-        return {"type_id": type_id}
+        }
+        if mapping_only:
+            return type_id
+        elif reverse:
+            return {v: k for k, v in type_id.items()}
+        elif type is not None:
+            return {'type_id': type_id.get(type, '0')}
+        else:
+            resolved_id = type_id.get(effective_type, '0')
+            return {'type_id': resolved_id}
 
     async def get_additional_checks(self, meta):
         """


### PR DESCRIPTION
@tdrkmn

I missed this earlier also, request searching needs to use the reverse mapping.

<img width="844" height="222" alt="image" src="https://github.com/user-attachments/assets/919ff343-7b19-41e8-823c-91dcf91b7638" />
