### PR TITLE
Run docker image workflow for every branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags-ignore:
+      - "**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This makes it much easier to do docker-driven development, since pushing will automatically build an image.

This also ignores all tags so it won't run twice on release (since releases also make a tag).