### PR TITLE
Center ordinary screens on HDB

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -533,7 +533,7 @@ class HDB():
                         descfile.write(f"{hdbimg_bbcode}")
                         descfile.write("[/center]")
                     else:
-                        descfile.write(f"{hdbimg_bbcode}")
+                        descfile.write(f"[center]{hdbimg_bbcode}[/center]")
             else:
                 images = meta['image_list']
                 if len(images) > 0:


### PR DESCRIPTION
Screens from comparisons on HDB are centered by UA, but ordinary screens were not.
This PR will fix that.