### PR TITLE
remove center from bbcode

### DIFF
--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -336,7 +336,6 @@ class ASC:
             return '[center]Erro: Não foi possível carregar o layout da descrição.[/center]'
 
         layout_image = {k: v for k, v in user_layout.items() if k.startswith('BARRINHA_')}
-        description_parts = ['[center]']
 
         async def append_section(key: str, content: str):
             if content and (img := layout_image.get(key)):
@@ -450,7 +449,6 @@ class ASC:
         # Custom Bar
         for i in range(1, 4):
             description_parts.append(await self.format_image(layout_image.get(f'BARRINHA_CUSTOM_B_{i}')))
-        description_parts.append('[/center]')
 
         # External description
         desc = ''


### PR DESCRIPTION
Whenever a release created using the Upload Assistant is edited, the "Informações do Arquivo" spoiler breaks and doesn't function as expected.

This happens because its content is inside a `[left]` which in turn is inside a `[center]`.

Since the page content already maintains a `[center]`, there's no need to add another one, maintaining the page indentation and preventing the spoiler from breaking.