### PR TITLE
Scan type detection for empty ScanType value

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -231,7 +231,7 @@ async def get_resolution(guess, folder_id, base_dir):
             scan = mi['media']['track'][1]['ScanType']
         except Exception:
             scan = "Progressive"
-        if scan == "Progressive":
+        if not scan or scan == "Progressive":
             scan = "p"
         elif scan == "Interlaced":
             scan = 'i'


### PR DESCRIPTION
Fix https://github.com/Audionut/Upload-Assistant/issues/979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video resolution format detection to robustly handle edge cases with missing or empty scan type information, in addition to progressive video formats. This enhancement ensures more reliable and consistent resolution output even when video metadata is incomplete, unavailable, or malformed, improving overall compatibility across various video sources and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->