### PR TITLE
BLU: Update banned release groups list

### DIFF
--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -21,8 +21,8 @@ class BLU(UNIT3D):
         self.torrent_url = f'{self.base_url}/torrents/'
         self.banned_groups = [
             '[Oj]', '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AOC', 'AROMA', 'aXXo', 'B3LLUM',
-            'BHDStudio', 'Brrip',  'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'DTLegacy', 'ELiTE',
-            'eSc', 'EZTV', 'EZTV.RE', 'F13', 'FaNGDiNG0', 'FGT', 'Flights', 'FRDS', 'FUM', 'HAiKU', 'hallowed',  
+            'BHDStudio', 'Brrip', 'CHD', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'DTLegacy', 'ELiTE',
+            'eSc', 'EZTV', 'EZTV.RE', 'F13', 'FaNGDiNG0', 'FGT', 'Flights', 'FRDS', 'FUM', 'HAiKU', 'hallowed',
             'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'LAMA', 'Leffe', 'LEGi0N',
             'LOAD', 'MeGusta', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'nSD', 'PiRaTeS', 'playBD',
             'PlaySD', 'playXD', 'PRODJi', 'RAPiDCOWS', 'RARBG', 'RetroPeeps', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi', 'SasukeducK',


### PR DESCRIPTION
Updated BLU's Banned Release Groups

The list has been revised as of October 4, 2025.

ADDITIONS:
- B3LLUM
- BHDStudio
- DTLegacy
- EZTV
- EZTV.RE
- F13
- hallowed
- LAMA
- SasukeducK
- TheFarm
- WKS

REMOVALS:
- OFT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering on the BLU tracker by updating the blocked group list, reducing low-quality or unwanted releases from appearing in results.
  * Delivers cleaner search and browse experiences with fewer false positives.

* **Chores**
  * Refreshed internal blocklist data to reflect current ecosystem changes and maintain results quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->