### PR TITLE
fix(SHRI): improve REMUX detection and codec identification

### DIFF
--- a/src/trackers/SHRI.py
+++ b/src/trackers/SHRI.py
@@ -425,7 +425,8 @@ class SHRI(UNIT3D):
 
             if "makemkv" in encoded_app or "makemkv" in encoded_lib:
                 video = next((t for t in mi if t.get("@type") == "Video"), {})
-                if not video.get("Encoded_Library_Settings"):
+                settings = video.get("Encoded_Library_Settings")
+                if not settings or isinstance(settings, dict):
                     return True
 
         return False


### PR DESCRIPTION
- Prioritize REMUX markers before base type check
- Detect MakeMKV in mediainfo as REMUX indicator
- Fix codec detection for MPEG-2, VC-1, and other formats
- Make get_effective_type public for test compatibility
- Remove debug logging statements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media-type detection by prioritizing REMUX markers from filenames and adding heuristics for certain remuxed files
  * Tightened release-group extraction to prevent false VU/UNTOUCHED matches
  * Expanded codec/format recognition and refined WEB-DL, WEBRip and REMUX classification

* **Refactor**
  * Removed noisy debug output from detection flows

* **Documentation**
  * Updated docstrings/comments to reflect detection and release-group behavior adjustments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->