### PR TITLE
fix(THR): replace unsupported bbcode tags and fix NFO content alignment

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -550,6 +550,11 @@ class BBCODE:
         desc = desc.replace('[/pre]', '[/code]')
         return desc
 
+    def convert_code_to_pre(self, desc):
+        desc = desc.replace('[code]', '[pre]')
+        desc = desc.replace('[/code]', '[/pre]')
+        return desc
+
     def convert_hide_to_spoiler(self, desc):
         desc = desc.replace('[hide', '[spoiler')
         desc = desc.replace('[/hide]', '[/spoiler]')


### PR DESCRIPTION
[spoiler] and [code] bbcode tags are not supported on THR (hide and pre are), so when including scene or framestor NFO in description it would not get displayed properly.
Also, NFO content inside the spoiler/hide would get aligned to center and look ugly because it inherits the alignment from here: https://github.com/Audionut/Upload-Assistant/blob/a5c6ecfe8f4c67573194e86d27706980214f9618/src/get_desc.py#L79 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tracker description handling with enhanced BBCode tag conversion and alignment fixes for more consistent content formatting
  * Added symmetric, bidirectional tag conversion utilities to support round-trip transformations between markup styles
  * Optimized description processing pipeline to improve display quality, consistency, and overall content presentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->