### PR TITLE
fix(FF): follow the site's naming conventions

### DIFF
--- a/src/trackers/FF.py
+++ b/src/trackers/FF.py
@@ -441,7 +441,7 @@ class FF:
                 ff_name = meta["uuid"]
                 base, ext = os.path.splitext(ff_name)
                 if ext.lower() in {".mkv", ".mp4", ".avi", ".ts"}:
-                    ff_name = base
+                    ff_name = base.replace(" ", ".")
         else:
             ff_name = meta.get("clean_name").replace(" ", ".")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined torrent naming and upload flow: scene names are preferred when available; otherwise the item identifier is used with common video extensions removed. Non-scene names now use dots instead of spaces. Simplified normalization to avoid prior Unicode/ASCII transformations and updated upload flow to use the new naming logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->