### PR TITLE
fix(SHRI): improve language handling for Italian and English

### DIFF
--- a/src/trackers/SHRI.py
+++ b/src/trackers/SHRI.py
@@ -934,7 +934,12 @@ class SHRI(UNIT3D):
                 ita_audio = audio_tracks[0]
 
             # General info
-            fn = os.path.basename(meta.get("filelist", ["file.mkv"])[0])
+            filelist = meta.get("filelist", [])
+            fn = (
+                os.path.basename(filelist[0])
+                if filelist
+                else general.get("FileName", "file.mkv")
+            )
             size = f"{safe_int(general.get('FileSize', 0)) / (1024**3):.1f} GiB"
 
             dur_sec = float(general.get("Duration", 0))
@@ -1051,6 +1056,11 @@ class SHRI(UNIT3D):
             traceback.print_exc()
             return None
 
+    def _strip_bbcode(self, text):
+        """Remove BBCode tags from text, keeping only plain content"""
+        pattern = re.compile(r"\[/?[^\]]+\]")
+        return pattern.sub("", text).strip()
+
     def _build_bbcode(
         self, title, info_line, logo_url, summary, screens, synthetic_mi, category, meta
     ):
@@ -1066,13 +1076,31 @@ class SHRI(UNIT3D):
             category_header = "--- FILM ---"
         release_group = meta.get("tag", "").lstrip("-").strip()
 
+        tonemapped_text = ""
+        if meta.get("tonemapped", False):
+            tonemapped_header = self.config.get("DEFAULT", {}).get(
+                "tonemapped_header", ""
+            )
+            if tonemapped_header:
+                tonemapped_text = self._strip_bbcode(tonemapped_header)
+
         if release_group.lower() == "island":
-            release_notes_section = """[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
-[size=11][color=#FFFFFF]Questa è una release interna pubblicata in esclusiva su Shareisland.[/color][/size]
-[size=11][color=#FFFFFF]Si prega di non ricaricare questa release su tracker pubblici o privati. Si prega di mantenerla in seed il più a lungo possibile. Grazie![/color][/size]"""
+            base_notes = "Questa è una release interna pubblicata in esclusiva su Shareisland.\nSi prega di non ricaricare questa release su tracker pubblici o privati. Si prega di mantenerla in seed il più a lungo possibile. Grazie!"
+            if tonemapped_text:
+                release_notes_section = f"""[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
+[size=11][color=#FFFFFF]{base_notes}
+{tonemapped_text}[/color][/size]"""
+            else:
+                release_notes_section = f"""[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
+[size=11][color=#FFFFFF]{base_notes}[/color][/size]"""
         else:
-            release_notes_section = """[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
-[size=11][color=#FFFFFF]Nulla da aggiungere.[/color][/size]"""
+            base_notes = "Nulla da aggiungere."
+            if tonemapped_text:
+                release_notes_section = f"""[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
+[size=11][color=#FFFFFF]{tonemapped_text}[/color][/size]"""
+            else:
+                release_notes_section = f"""[size=13][b][color=#e8024b]--- RELEASE NOTES ---[/color][/b][/size]
+[size=11][color=#FFFFFF]{base_notes}[/color][/size]"""
 
         pirate_shouts = [
             "The Scene never dies",
@@ -1102,12 +1130,6 @@ class SHRI(UNIT3D):
         imdb_id = meta.get("imdb", "")
         tmdb_id = meta.get("tmdb", "")
         media_type = "tv" if category == "TV" else "movie"
-
-        tonemapped_section = ""
-        if meta.get("tonemapped", False) and self.config.get("DEFAULT", {}).get(
-            "tonemapped_header"
-        ):
-            tonemapped_section = f"\n{self.config['DEFAULT']['tonemapped_header']}\n"
 
         links_section = ""
         if imdb_id or tmdb_id:
@@ -1161,7 +1183,7 @@ class SHRI(UNIT3D):
 {summary}
 
 [center][size=13][b][color=#e8024b]--- SCREENS ---[/color][/b][/size][/center]
-{screens}{tonemapped_section}
+{screens}
 {links_section}{mediainfo_section}{release_notes_section}
 
 [size=13][b][color=#e8024b]--- SHOUTOUTS ---[/color][/b][/size]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize language codes by removing country suffixes (e.g., en-US → en).
  * Tighten Italian audio/subtitle detection to avoid false matches and improve filtering.
  * Ensure Italian and English audio/language labels display correctly as Italiano and Inglese.
  * Correct content type mapping so certain HDTV items are classified consistently.

* **Enhancements**
  * Improve release note generation to better include tone-mapped text and correct file-name selection for media details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->