### PR TITLE
refactor(DC): remove logo and screenshot header from description

### DIFF
--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -38,19 +38,10 @@ class DC:
         # Custom Header
         desc_parts.append(await builder.get_custom_header(self.tracker))
 
-        # Logo
-        logo, logo_size = await builder.get_logo_section(meta, self.tracker)
-        if logo and logo_size:
-            desc_parts.append(f'[center][img={logo_size}]{logo}[/img][/center]')
-
         # TV
         title, episode_image, episode_overview = await builder.get_tv_info(meta, self.tracker)
         if episode_overview:
             desc_parts.append(f'[center]{title}[/center]')
-
-            if episode_image:
-                desc_parts.append(f"[center][img=300]{episode_image}[/img][/center]")
-
             desc_parts.append(f'[center]{episode_overview}[/center]')
 
         # File information
@@ -63,9 +54,6 @@ class DC:
         # User description
         desc_parts.append(await builder.get_user_description(meta))
 
-        # Screenshot Header
-        desc_parts.append(await builder.screenshot_header(self.tracker))
-
         # Screenshots
         if f'{self.tracker}_images_key' in meta:
             images = meta[f'{self.tracker}_images_key']
@@ -74,9 +62,9 @@ class DC:
         if images:
             screenshots_block = '[center]\n'
             for i, image in enumerate(images, start=1):
-                img_url = image['img_url']
-                web_url = image['web_url']
-                screenshots_block += f'[url={web_url}][img=350]{img_url}[/img][/url] '
+                screenshots_block += (
+                    f"[url={image['web_url']}][img=350]{image['raw_url']}[/img][/url] "
+                )
                 # limits to 2 screens per line, as the description box is small
                 if i % 2 == 0:
                     screenshots_block += '\n'


### PR DESCRIPTION
DigitalCore now extracts images from descriptions and places them in a dedicated section with an integrated image preview.

- Changes image URLs to use raw links, so that image previews display the image in full quality
- Removes the logo and headers from screenshots, as they now look out of place
- The same styling method for adding images to the description has been kept. This could be simplified, as now only direct links are needed, but if this update is reverted, the description will still look acceptable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined content rendering by removing logo display and episode image sections
  * Updated screenshot image sourcing and link handling for improved consistency
  * Removed screenshot header elements for cleaner layout presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->