### PR TITLE
Refine IMDb ID assignment logic

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -723,8 +723,8 @@ class Prep():
             meta['imdb_id'] = meta.get('mismatched_imdb_id', 0)
             meta['imdb_info'] = None
 
-        # Get IMDb ID if not set
-        if meta.get('imdb_id') == 0:
+        # Get IMDb ID if not set (unless user explicitly skipped with -imdb 0)
+        if meta.get('imdb_id') == 0 and meta.get('imdb_manual') is None:
             meta['imdb_id'] = await search_imdb(filename, meta['search_year'], quickie=False, category=meta.get('category', None), debug=debug, secondary_title=meta.get('secondary_title', None), path=meta.get('path', None), untouched_filename=untouched_filename, duration=duration, unattended=unattended)
 
         # user might have skipped tmdb earlier, lets double check


### PR DESCRIPTION
Skip IMDb ID lookup if the user explicitly set imdb_manual, preventing unnecessary searches when the user intends to skip IMDb assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMDb ID handling to respect explicit user settings. The system now correctly honors manual IMDb values and skip flags, preventing automatic IMDb ID retrieval when users have explicitly configured these settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->