### PR TITLE
Use listdir and filter to grab PNGs instead of glob

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from src.takescreens import disc_screenshots, dvd_screenshots, screenshots
 from src.uploadscreens import upload_screens
 from data.config import config
+from aiofiles import os as aio_os
 
 
 async def match_host(hostname, approved_hosts):
@@ -194,7 +195,7 @@ async def handle_image_upload(meta, tracker, url_host_mapping, approved_image_ho
     # First check if there are any saved screenshots matching those in the image_list
     if meta.get('image_list') and isinstance(meta['image_list'], list):
         # Get all PNG files in the screenshots directory
-        all_png_files = await asyncio.to_thread(glob.glob, os.path.join(screenshots_dir, "*.png"))
+        all_png_files = [file for file in await aio_os.listdir(screenshots_dir) if file.endswith('.png')]
         if all_png_files and meta.get('debug'):
             console.print(f"[cyan]Found {len(all_png_files)} PNG files in screenshots directory")
 


### PR DESCRIPTION
The glob varient cannot find PNGs that this one can.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized performance of screenshot file retrieval through improved asynchronous processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->