### PR TITLE
refactor(DC): streamline torrent naming convention and remove duplicate title check

### DIFF
--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -183,20 +183,13 @@ class DC:
         Scene uploads should also have "[UNRAR]" in the name, as the UA only uploads unzipped files, which are considered "altered".
         https://digitalcore.club/forum/17/topic/1051/uploading-for-beginners
         """
-        rename = meta.get("tracker_renames", {}).get(self.tracker)
-        if rename:
-            return rename
-
-        if meta.get("scene", False):
-            if meta.get("scene_name", ""):
-                dc_name = meta.get("scene_name")
-            else:
-                dc_name = meta["uuid"]
-                base, ext = os.path.splitext(dc_name)
-                if ext.lower() in {".mkv", ".mp4", ".avi", ".ts"}:
-                    dc_name = f"{base} [UNRAR]"
+        if meta.get("scene_name", ""):
+            dc_name = f"{meta.get('scene_name')} [UNRAR]"
         else:
-            dc_name = meta['uuid']
+            dc_name = meta["uuid"]
+            base, ext = os.path.splitext(dc_name)
+            if ext.lower() in {".mkv", ".mp4", ".avi", ".ts"}:
+                dc_name = base
 
         return dc_name
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved torrent naming: scene uploads now preserve scene names and append " [UNRAR]"; non-scene uploads use a UUID-based base name with common video extensions stripped for cleaner titles.

* **Refactor**
  * Consolidated naming flow so the final upload/display name is computed once and used consistently.

* **Bug Fixes**
  * Removed a redundant duplicate-check path to prevent premature naming/skip behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->