### PR TITLE
Update eMuwarez base url

### DIFF
--- a/src/trackers/EMUW.py
+++ b/src/trackers/EMUW.py
@@ -18,7 +18,7 @@ class EMUW(UNIT3D):
     def __init__(self, config):
         super().__init__(config, tracker_name='EMUW')
         self.source_flag = 'Emuwarez'
-        self.base_url = 'https://emuwarez.it'
+        self.base_url = 'https://emuwarez.com'
         self.id_url = f'{self.base_url}/api/torrents/'
         self.upload_url = f'{self.base_url}/api/torrents/upload'
         self.search_url = f'{self.base_url}/api/torrents/filter'


### PR DESCRIPTION
The tracker eMuwarez (EMUW) has updated its domain from emuwarez.it to emuwarez.com.

It solves #1039.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated an integrated tracker service endpoint to the current URL, ensuring continued functionality and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->