### PR TITLE
fix: prevent leading space in AKA titles from breaking title parsing

### DIFF
--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1145,7 +1145,7 @@ async def get_anime(response, meta):
             animation = True
     if response['original_language'] == 'ja' and animation is True:
         romaji, mal_id, eng_title, season_year, episodes, demographic = await get_romaji(tmdb_name, meta.get('mal_id', None), meta)
-        alt_name = f" AKA {romaji}"
+        alt_name = f"AKA {romaji}"
 
         anime = True
         # mal = AnimeSearch(romaji)


### PR DESCRIPTION
AKA titles were incorrectly stored, resulting in a format like this:
```json
"aka": " AKA Alt Title"
```
The leading space before " AKA Alt Title" caused subsequent title building steps to fail when attempting to replace the AKA section, as the spacing was inconsistent after global cleanup operations.

This leads to the incorrect transformation of the final output string:

The title is built and extra spaces are removed in get_name.py:
https://github.com/Audionut/Upload-Assistant/blob/d6757ccd689ac1823e7d3dced98236c74ce3804c/src/get_name.py#L165

The AKA replacement is then attempted:
https://github.com/Audionut/Upload-Assistant/blob/d6757ccd689ac1823e7d3dced98236c74ce3804c/src/trackers/ULCX.py#L108

Resulting Output Corruption:

From:
```Title AKA Alt Title 2025 1080p MA WEB-DL Dual-Audio DTS-HD MA 5.1 H.264-Group```
To:
```Title2025 1080p MA WEB-DL Dual-Audio DTS-HD MA 5.1 H.264-Group```

Reproducing the issue: movie/1218925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing formatting in alternative anime names, removing extra whitespace before the "AKA" prefix for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->