### PR TITLE
fix: fix meta["video_encode"] detection for VP9 and VC-1

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -112,13 +112,13 @@ async def get_video_encode(mi, type, bdinfo):
     except Exception:
         format = bdinfo['video'][0]['codec']
         format_profile = bdinfo['video'][0]['profile']
-    if type in ("ENCODE", "WEBRIP", "DVDRIP"):  # ENCODE or WEBRIP or DVDRIP
+    if format in ('AV1', 'VP9', 'VC-1'):
+        codec = format
+    elif type in ("ENCODE", "WEBRIP", "DVDRIP"):  # ENCODE or WEBRIP or DVDRIP
         if format == 'AVC':
             codec = 'x264'
         elif format == 'HEVC':
             codec = 'x265'
-        elif format == 'AV1':
-            codec = 'AV1'
         elif format == 'MPEG-4 Visual':
             if encoded_library_name:
                 if 'xvid' in encoded_library_name.lower():
@@ -130,15 +130,9 @@ async def get_video_encode(mi, type, bdinfo):
             codec = 'H.264'
         elif format == 'HEVC':
             codec = 'H.265'
-        elif format == 'AV1':
-            codec = 'AV1'
 
         if type == 'HDTV' and has_encode_settings is True:
             codec = codec.replace('H.', 'x')
-    elif format == "VP9":
-        codec = "VP9"
-    elif format == "VC-1":
-        codec = "VC-1"
     if format_profile == 'High 10':
         profile = "Hi10P"
     else:


### PR DESCRIPTION
The codec for  e.g. `VP9 WEB-DL` would not get detected, which would in turn leave `meta["video_encode"]` empty and the torrent name incomplete.

Moved up, in the if-else tree, the branch with formats that have the same codec regardless if it's an encode or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized video codec handling by streamlining format detection and encoding logic. Modern video formats now process more efficiently with reduced redundant operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->