### PR TITLE
update(LT.py): release naming for spanish variants

### DIFF
--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -95,12 +95,12 @@ class LT(UNIT3D):
                 is_castilian_title = any(kw in title for kw in castilian_keywords)
 
                 # 1. Check strict Latino language codes or Edge Case: Language is 'es' but Title contains Latino keywords
-                if lang in audio_latino_check or lang == 'es' and is_latino_title:
+                if lang in audio_latino_check or (lang == 'es' and is_latino_title):
                     has_latino = True
                     audios.append(audio)
 
                 # 2. Edge Case: Language is 'es' and Title contains Castilian keywords or Fallback: Check strict Castilian codes (includes 'es' as default)
-                elif lang == 'es' and is_castilian_title or lang in audio_castilian_check:
+                elif (lang == 'es' and is_castilian_title) or lang in audio_castilian_check:
                     has_castilian = True
                     audios.append(audio)
 


### PR DESCRIPTION
Updated the audio title and language parsing to properly add the `[CAST]` tag to the release name when uploading with Spanish (Castilian) dub or original audio only, since this is used in the tracker  to differentiate between Spanish (Castilian) and Spanish (Latin America) dub/original audio..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Spanish audio detection using language codes plus title-keyword matching to distinguish Latino vs. Castilian tracks
  * Per-track evaluation with explicit Latino/Castilian presence tracking (skips commentary)
  * Inserts a CAST tag when Castilian audio exists but no Latino audio is found
  * Preserves [SUBS] fallback and tag placement logic for other scenarios
  * Streamlines language checks by replacing a large hard-coded list with a smaller code set plus keywords

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->