### PR TITLE
fix: use cleaned summary for BDInfo parsing and meta

### DIFF
--- a/src/discparse.py
+++ b/src/discparse.py
@@ -305,7 +305,7 @@ class DiscParse():
 
                             # Save to discs array
                             if idx == 0:
-                                discs[i]['summary'] = bd_summary_cleaned.strip()
+                                discs[i]['summary'] = bd_summary_cleaned
                                 discs[i]['bdinfo'] = bdinfo
                                 discs[i]['playlists'] = selected_playlists
                                 if valid_playlists and meta['unattended'] and not meta.get('unattended_confirm', False):
@@ -330,7 +330,7 @@ class DiscParse():
                                     if meta['debug']:
                                         console.print(f"[cyan]Stored {len(simplified_playlists)} unique playlists by duration (from {len(valid_playlists)} total)")
                             else:
-                                discs[i][f'summary_{idx}'] = bd_summary_cleaned.strip()
+                                discs[i][f'summary_{idx}'] = bd_summary_cleaned
                                 discs[i][f'bdinfo_{idx}'] = bdinfo
 
                         except Exception:


### PR DESCRIPTION
Some websites are using bdinfo directly from meta:
https://github.com/Audionut/Upload-Assistant/blob/98ca55e09bd2f646789e86ee589c7f7adeb107fd/src/get_desc.py#L322-L336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency by using cleaned BDInfo summaries, removing extraneous spacing and formatting inconsistencies in disc summary fields.

* **Chores**
  * No changes to public interfaces or exported signatures; integrations remain compatible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->