### PR TITLE
feat(THR): add documentary category detection

### DIFF
--- a/src/trackers/THR.py
+++ b/src/trackers/THR.py
@@ -144,7 +144,12 @@ class THR():
             return False
 
     async def get_cat_id(self, meta):
-        if meta['category'] == "MOVIE":
+        genres = meta.get('genres', '').lower()
+        keywords = meta.get('keywords', '').lower()
+
+        if 'documentary' in genres or 'documentary' in keywords:
+            cat = '12'
+        elif meta['category'] == "MOVIE":
             if meta.get('is_disc') == "BMDV":
                 cat = '40'
             elif meta.get('is_disc') == "DVD" or meta.get('is_disc') == "HDDVD":


### PR DESCRIPTION
Add detection of documentary category in the same way some other trackers do (e.g. HDB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content categorization logic with enhanced detection and prioritization of documentary content.

* **Refactor**
  * Streamlined category assignment decision flow for more consistent content classification across movie and TV formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->