### PR TITLE
Process screenshots in paths with special characters for HDB

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -621,7 +621,7 @@ class HDB():
             unwanted_patterns = ["FILE*", "PLAYLIST*", "POSTER*"]
             unwanted_files = set()
             for pattern in unwanted_patterns:
-                glob_results = await asyncio.to_thread(glob.glob, pattern)
+                glob_results = await asyncio.to_thread(glob.glob, full_pattern)
                 unwanted_files.update(glob_results)
                 hidden_pattern = "." + pattern
                 hidden_glob_results = await asyncio.to_thread(glob.glob, hidden_pattern)


### PR DESCRIPTION
Currently, we're using `glob.glob(filepath)` to check for PNG screenshots, which can't handle space or special characters without escape correctly. If the path is non-standard (contains special characters like `[` `]` and ` ` (space)), then the script won't find any image to rehost for HDB.

The method in `uploadscreens.py` (starting at L546) seems to work well so far, I just brought that over for HDB.

Fixes https://github.com/Audionut/Upload-Assistant/issues/1068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads now use asynchronous-safe filesystem scanning for more reliable processing.
  * Broader pattern matching captures additional image files, including hidden variants.
  * Improved detection and filtering of unwanted/hidden files.
  * Stronger de-duplication to prevent duplicate images during upload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->