### PR TITLE
fix(ptscreens): status code error

### DIFF
--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -192,13 +192,9 @@ async def upload_image_task(args):
                         response = await client.post(url, headers=headers, files=files, timeout=timeout)
                         response_data = response.json()
 
-                        if response.status_code == 400:
-                            console.print("[yellow]ptscreens upload failed: Duplicate upload (400)")
-                            return {'status': 'failed', 'reason': 'ptscreens duplicate'}
-
-                        if response_data.get('status_code') != 200:
-                            console.print("[yellow]ptscreens failed")
-                            return {'status': 'failed', 'reason': 'ptscreens upload failed'}
+                        if response.status_code != 200:
+                            console.print(f'[yellow]ptscreens upload failed: {response_data.get("error", {}).get("message", "Unknown error")} {(response.status_code)}')
+                            return {'status': 'failed', 'reason': f'ptscreens upload failed: {response_data.get("error", {}).get("message", "Unknown error")}'}
 
                         img_url = response_data['image']['medium']['url']
                         raw_url = response_data['image']['url']


### PR DESCRIPTION
Failed upload with status code 400 in the response when uploading to ptscreens was hardcoded to `Duplicate upload` error and 400 not always means duplicate upload, sometimes it could be related to other type of errors like "Invalid API key prefix"

Resolves #1072 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for file uploads to provide consistent failure messages across different error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->