### PR TITLE
DC: set upload torrent file

### DIFF
--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -243,7 +243,8 @@ class DC:
         if not meta.get('debug', False):
             try:
                 upload_url = f'{self.api_base_url}/upload'
-                torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/BASE.torrent"
+                await self.common.create_torrent_for_upload(meta, self.tracker, 'DigitalCore.club')
+                torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent"
 
                 with open(torrent_path, 'rb') as torrent_file:
                     files = {'file': (torrent_title + '.torrent', torrent_file, 'application/x-bittorrent')}


### PR DESCRIPTION
I can't for the life of me, understand why it works when a single tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced torrent upload process with improved file handling and organization. Torrent files are now created and prepared more efficiently before upload, with better system organization using tracker-specific naming conventions. All error handling and upload sequencing remains intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->