### PR TITLE
Fix TypeError issue in dupe_checking.py

### DIFF
--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -317,7 +317,7 @@ async def filter_dupes(dupes, meta, tracker_name):
             if "hdtv" in normalized and not any(web_term in normalized for web_term in ["web-dl", "web -dl", "webdl", "web dl"]):
                 await log_exclusion("source mismatch: WEB-DL vs HDTV", each)
                 return True
-            if ['blu-ray', 'blu ray', 'bluray', 'blu -ray'] in normalized and not any(web_term in normalized for web_term in ["web-dl", "web -dl", "webdl", "web dl"]):
+            if any(term in normalized for term in ['blu-ray', 'blu ray', 'bluray', 'blu -ray']) and not any(web_term in normalized for web_term in ["web-dl", "web -dl", "webdl", "web dl"]):
                 await log_exclusion("source mismatch: WEB-DL vs BluRay", each)
                 return True
         if not web_dl:


### PR DESCRIPTION
### Issue

Line 320 `if ['blu-ray', 'blu ray', 'bluray', 'blu -ray'] in normalized and not any(web_term in normalized for web_term in ["web-dl", "web -dl", "webdl", "web dl"]):` resulted in the following error when attempting a dupe search of WEB-DL content, in my case a season pack.

```
Name: Heated Rivalry S01 1080p AMZN WEB-DL DD+ 5.1 H.264-RAWR
Is this correct? y/N: y
Processing Heated Rivalry S01 1080p AMZN WEB-DL DD+ 5.1 H.264-RAWR for upload...
Searching for existing torrents on ULCX...
An unexpected error occurred: 'in <string>' requires string as left operand, not list
Traceback (most recent call last):
  File "E:\Portable\AudionutsUA\upload.py", line 988, in do_the_thing
    await process_meta(meta, base_dir, bot=bot)
  File "E:\Portable\AudionutsUA\upload.py", line 376, in process_meta
    successful_trackers = await process_all_trackers(meta)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Portable\AudionutsUA\src\trackerstatus.py", line 229, in process_all_trackers
    tracker_name, status = await process_single_tracker(tracker_name, meta)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Portable\AudionutsUA\src\trackerstatus.py", line 113, in process_single_tracker
    dupes = await filter_dupes(dupes, local_meta, tracker_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Portable\AudionutsUA\src\dupe_checking.py", line 405, in filter_dupes
    if not await process_exclusion(each):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Portable\AudionutsUA\src\dupe_checking.py", line 320, in process_exclusion
    if ['blu-ray', 'blu ray', 'bluray', 'blu -ray'] in normalized and not any(web_term in normalized for web_term in
["web-dl", "web -dl", "webdl", "web dl"]):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'in <string>' requires string as left operand, not list
```
### Potential Fix

Replacing that specific line with the following code seems to fix it for me but not sure if it's correct so you may want to double check it in case it breaks something else.

`if any(term in normalized for term in ['blu-ray', 'blu ray', 'bluray', 'blu -ray']) and not any(web_term in normalized for web_term in ["web-dl", "web -dl", "webdl", "web dl"]):`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BluRay variant detection to correctly identify all BluRay format variations when checking for duplicates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->