### PR TITLE
Refactor is_scene to use httpx for async requests and implement caching for srrDB searches

### DIFF
--- a/src/is_scene.py
+++ b/src/is_scene.py
@@ -154,7 +154,7 @@ async def is_scene(video, meta, imdb=None, lower=False):
 
                     if int(response_json.get('resultsCount', 0)) > 0:
                         first_result = response_json['results'][0]
-                        imdb_str = first_result['imdbId']
+                        imdb_str = first_result.get('imdbId')
                         if imdb_str and imdb_str == str(meta.get('imdb_id')).zfill(7) and meta.get('imdb_id') != 0:
                             meta['scene'] = True
                             release_name = first_result['release']
@@ -184,10 +184,18 @@ async def is_scene(video, meta, imdb=None, lower=False):
                                         console.print("[yellow]Failed to download NFO file:", e)
 
                         return release_name
+                    else:
+                        if meta['debug']:
+                            console.print("[yellow]SRRDB: No match found with lower/tag search")
+                        return None
 
                 except Exception as e:
                     console.print(f"[yellow]SRRDB search failed: {e}")
                     return None
+            else:
+                if meta['debug']:
+                    console.print("[yellow]SRRDB: Missing name or tag for lower/tag search")
+                return None
 
     check_predb = config['DEFAULT'].get('check_predb', False)
     if not scene and check_predb and not meta.get('emby_debug', False):


### PR DESCRIPTION
In my experience, making requests to srrDB can take from ~1 second to ~15 seconds, and I often get timeouts. I think saving the results in a local cache helps a lot with speed, reducing it to a few milliseconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Search results, release details, and local NFO files are now cached to reduce repeated network requests and speed up lookups.

* **Improvements**
  * Network calls moved to asynchronous, non-blocking requests for faster processing.
  * Debug mode reports total scene processing time and clearer progress messages.
  * Search expanded to include additional name/tag lookup paths and validates identifiers to improve match accuracy.

* **Bug Fixes**
  * Unified network error handling to reduce unexpected failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->