### PR TITLE
CBR, SAM: do not add DUAL/MULTI to the title when it is a full disc

### DIFF
--- a/src/trackers/CBR.py
+++ b/src/trackers/CBR.py
@@ -94,34 +94,35 @@ class CBR(UNIT3D):
         tag_lower = meta["tag"].lower()
         invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
 
-        audio_tag = ""
-        if meta.get("audio_languages"):
-            audio_languages = set(meta["audio_languages"])
+        if not meta.get('is_disc'):
+            audio_tag = ""
+            if meta.get("audio_languages"):
+                audio_languages = set(meta["audio_languages"])
 
-            if any(lang.lower() == "portuguese" or lang == "português" for lang in audio_languages):
-                if len(audio_languages) >= 3:
-                    audio_tag = " MULTI"
-                elif len(audio_languages) == 2:
-                    audio_tag = " DUAL"
-                else:
-                    audio_tag = ""
+                if any(lang.lower() == "portuguese" or lang == "português" for lang in audio_languages):
+                    if len(audio_languages) >= 3:
+                        audio_tag = " MULTI"
+                    elif len(audio_languages) == 2:
+                        audio_tag = " DUAL"
+                    else:
+                        audio_tag = ""
 
-            if audio_tag:
-                if "-" in cbr_name:
-                    parts = cbr_name.rsplit("-", 1)
+                if audio_tag:
+                    if "-" in cbr_name:
+                        parts = cbr_name.rsplit("-", 1)
 
-                    custom_tag = self.config.get("TRACKERS", {}).get(self.tracker, {}).get("tag_for_custom_release", "")
-                    if custom_tag and custom_tag in name:
-                        match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)", meta["uuid"])
-                        if match and match.group(1) != meta["tag"]:
-                            original_group_tag = match.group(1)
-                            cbr_name = f"{parts[0]}-{original_group_tag}{audio_tag}-{parts[1]}"
+                        custom_tag = self.config.get("TRACKERS", {}).get(self.tracker, {}).get("tag_for_custom_release", "")
+                        if custom_tag and custom_tag in name:
+                            match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)", meta["uuid"])
+                            if match and match.group(1) != meta["tag"]:
+                                original_group_tag = match.group(1)
+                                cbr_name = f"{parts[0]}-{original_group_tag}{audio_tag}-{parts[1]}"
+                            else:
+                                cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
                         else:
                             cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
                     else:
-                        cbr_name = f"{parts[0]}{audio_tag}-{parts[1]}"
-                else:
-                    cbr_name += audio_tag
+                        cbr_name += audio_tag
 
         if meta["tag"] == "" or any(
             invalid_tag in tag_lower for invalid_tag in invalid_tags

--- a/src/trackers/SAM.py
+++ b/src/trackers/SAM.py
@@ -51,34 +51,35 @@ class SAM(UNIT3D):
         tag_lower = meta["tag"].lower()
         invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
 
-        audio_tag = ""
-        if meta.get("audio_languages"):
-            audio_languages = set(meta["audio_languages"])
+        if not meta.get('is_disc'):
+            audio_tag = ""
+            if meta.get("audio_languages"):
+                audio_languages = set(meta["audio_languages"])
 
-            if "Portuguese" in audio_languages:
-                if len(audio_languages) >= 3:
-                    audio_tag = " MULTI"
-                elif len(audio_languages) == 2:
-                    audio_tag = " DUAL"
-                else:
-                    audio_tag = ""
+                if "Portuguese" in audio_languages:
+                    if len(audio_languages) >= 3:
+                        audio_tag = " MULTI"
+                    elif len(audio_languages) == 2:
+                        audio_tag = " DUAL"
+                    else:
+                        audio_tag = ""
 
-            if audio_tag:
-                if "-" in sam_name:
-                    parts = sam_name.rsplit("-", 1)
+                if audio_tag:
+                    if "-" in sam_name:
+                        parts = sam_name.rsplit("-", 1)
 
-                    custom_tag = self.config.get("TRACKERS", {}).get(self.tracker, {}).get("tag_for_custom_release", "")
-                    if custom_tag and custom_tag in name:
-                        match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)", meta["uuid"])
-                        if match and match.group(1) != meta["tag"]:
-                            original_group_tag = match.group(1)
-                            sam_name = f"{parts[0]}-{original_group_tag}{audio_tag}-{parts[1]}"
+                        custom_tag = self.config.get("TRACKERS", {}).get(self.tracker, {}).get("tag_for_custom_release", "")
+                        if custom_tag and custom_tag in name:
+                            match = re.search(r"-([^.-]+)\.(?:DUAL|MULTI)", meta["uuid"])
+                            if match and match.group(1) != meta["tag"]:
+                                original_group_tag = match.group(1)
+                                sam_name = f"{parts[0]}-{original_group_tag}{audio_tag}-{parts[1]}"
+                            else:
+                                sam_name = f"{parts[0]}{audio_tag}-{parts[1]}"
                         else:
                             sam_name = f"{parts[0]}{audio_tag}-{parts[1]}"
                     else:
-                        sam_name = f"{parts[0]}{audio_tag}-{parts[1]}"
-                else:
-                    sam_name += audio_tag
+                        sam_name += audio_tag
 
         if meta["tag"] == "" or any(
             invalid_tag in tag_lower for invalid_tag in invalid_tags


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio language tagging to correctly exclude disc-level items from tagging logic.
  * Enhanced custom release tag handling to better preserve group information when tags are modified.
  * Fixed audio tag insertion behavior when names lack separators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->