### PR TITLE
BJS: Handle image URL validation and error reporting

### DIFF
--- a/src/trackers/BJS.py
+++ b/src/trackers/BJS.py
@@ -783,7 +783,14 @@ class BJS:
             )
             response.raise_for_status()
             data = response.json()
-            return data.get('url', '').replace('\\/', '/')
+
+            img_url = None
+            if data.get('url') and data.get('url').startswith('http'):
+                img_url = data.get('url').replace('\\/', '/')
+            else:
+                console.print(f'{self.tracker}: [bold red]The image host appears to be down.[/bold red]')
+
+            return img_url
         except Exception as e:
             print(f'Exceção no upload de {filename}: {e}')
             return None


### PR DESCRIPTION
When the BJS image hosting service is down, it responds with `{"url":null}`, which the current code is not prepared to handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of image uploads to ensure returned URLs are valid HTTP addresses
  * Invalid or missing image URLs are now properly rejected with clear warning messages
  * Enhanced error handling for image hosting services to prevent broken image links

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->