### PR TITLE
Update HDB.py to fix DTS-HD HRA codec in title

### DIFF
--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -200,6 +200,7 @@ class HDB():
         hdb_name = hdb_name.replace('REMUX', 'Remux')
         hdb_name = hdb_name.replace('BluRay Remux', 'Remux')
         hdb_name = hdb_name.replace('UHD Remux', 'Remux')
+        hdb_name = hdb_name.replace('DTS-HD HRA', 'DTS-HD HR')
         hdb_name = ' '.join(hdb_name.split())
         hdb_name = re.sub(r"[^0-9a-zA-ZÀ-ÿ. :&+'\-\[\]]+", "", hdb_name)
         hdb_name = hdb_name.replace(' .', '.').replace('..', '.')


### PR DESCRIPTION
HDB uses `DTS-HD HR` instead of `DTS-HD HRA` in torrent titles for torrents with DTS-HD Hi-Res audio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio codec naming to display DTS-HD variants in standardized form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->