### PR TITLE
HUNO: Add missing return statement in check_image_hosts

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -96,6 +96,7 @@ class HUNO(UNIT3D):
             "imagebam.com": "bam",
         }
         await check_hosts(meta, self.tracker, url_host_mapping=url_host_mapping, img_host_index=1, approved_image_hosts=self.approved_image_hosts)
+        return
 
     async def get_description(self, meta):
         if 'HUNO_images_key' in meta:


### PR DESCRIPTION
Fixes an issue where UA would still upload screenshots even when no torrent was being uploaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected image host verification execution flow to properly complete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->