### PR TITLE
Fix manual description handling

### DIFF
--- a/src/trackerhandle.py
+++ b/src/trackerhandle.py
@@ -145,7 +145,7 @@ async def process_trackers(meta, config, client, console, api_trackers, tracker_
                         manual_tracker = manual_tracker.replace(" ", "").upper().strip()
                         tracker_class = tracker_class_map[manual_tracker](config=config)
                         if manual_tracker in api_trackers:
-                            await DescriptionBuilder(config).unit3d_edit_desc(meta, tracker_class.tracker, tracker_class.signature)
+                            await DescriptionBuilder(config).unit3d_edit_desc(meta, "MANUAL")
                         else:
                             await tracker_class.edit_desc(meta)
                 url = await package(meta)

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -21,7 +21,6 @@ class UNIT3D:
         tracker_config = self.config['TRACKERS'].get(self.tracker, {})
         self.announce_url = tracker_config.get('announce_url', '')
         self.api_key = tracker_config.get('api_key', '')
-        self.signature = ""
         pass
 
     async def get_additional_checks(self, meta):


### PR DESCRIPTION
I have added a default empty signature in case a tracker does not have their own signature, like DP.
if a tracker does not have this signature, the script errors and fails to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized manual tracker description generation for improved consistency and reduced complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->