### PR TITLE
feat(helm): initialize upload-assistant deployment infrastructure

### DIFF
--- a/charts/upload-assistant/.helmignore
+++ b/charts/upload-assistant/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/upload-assistant/Chart.yaml
+++ b/charts/upload-assistant/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: upload-assistant
+description: Upload-Assistant (Docker GUI / Web UI)
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v6.3.1-webui"

--- a/charts/upload-assistant/README.md
+++ b/charts/upload-assistant/README.md
@@ -1,0 +1,195 @@
+# upload-assistant (Web UI)
+
+Helm chart for running Upload-Assistant's Web UI (Docker GUI) on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3
+- A valid Upload-Assistant `config.py` (see https://github.com/Audionut/Upload-Assistant/wiki/Configuration)
+
+## TL;DR
+
+1. Pick a namespace (example: `upload-assistant`):
+
+   ```bash
+   kubectl create namespace upload-assistant --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+2. Create a Secret containing your `config.py` (recommended):
+
+   ```bash
+   kubectl -n upload-assistant create secret generic upload-assistant-config \
+     --from-file=config.py=/path/to/config.py
+   ```
+
+3. Install/upgrade the chart:
+
+   ```bash
+   helm upgrade --install upload-assistant ./charts/upload-assistant \
+     --namespace upload-assistant --create-namespace \
+     -f my-values.yaml
+   ```
+
+## Installing the chart
+
+From the repo root:
+
+```bash
+helm upgrade --install upload-assistant ./charts/upload-assistant \
+  --namespace upload-assistant --create-namespace \
+  -f my-values.yaml
+```
+
+## Accessing the Web UI
+
+- `ClusterIP` (default): `kubectl -n upload-assistant port-forward deploy/upload-assistant 5000:5000`
+- `LoadBalancer`: `kubectl -n upload-assistant get svc upload-assistant -w`
+- `Ingress`: set `ingress.enabled=true` and configure `ingress.hosts`
+
+## Uninstalling the chart
+
+```bash
+helm uninstall upload-assistant --namespace upload-assistant
+```
+
+## Configuration
+
+All values (and defaults) are documented in `values.yaml`. A fuller working example is also available at the repo root: `upload-assistant-values.yaml`.
+
+### Providing `config.py`
+
+Upload-Assistant reads configuration from `/Upload-Assistant/data/config.py`.
+
+Recommended approach (default):
+
+- Create a Secret named `upload-assistant-config` containing a `config.py` key.
+- Keep `config.enabled=true` and `config.existingSecret=upload-assistant-config`.
+  - The Secret/ConfigMap must exist in the same namespace as the Helm release.
+
+Alternatives:
+
+- Provide an existing ConfigMap via `config.existingConfigMap`
+- Inline config (chart-managed Secret/ConfigMap) via `config.kind` + `config.configPy` (convenient for quick testing; avoid committing real credentials)
+
+#### Inline config details
+
+To have the chart create the Secret/ConfigMap for you:
+
+- Set `config.existingSecret=""` and `config.existingConfigMap=""`
+- Set `config.kind` to `secret` or `configMap`
+- Put the contents of your `config.py` file into `config.configPy` (use a YAML block scalar like `|-` and keep indentation)
+- If you don’t need `config.py` to be writable, set `config.copyToVolume=false` to mount it read-only at `config.mountPath`
+
+The chart creates a resource named `<release fullname>-config` containing the key `config.key` (defaults to `config.py`).
+
+Example:
+
+```yaml
+config:
+  enabled: true
+  existingSecret: ""
+  existingConfigMap: ""
+  kind: secret # secret | configMap
+  key: config.py
+  copyToVolume: true
+  overwrite: true
+  configPy: |-
+    config = {
+        "DEFAULT": {
+            "tmdb_api": "<your-tmdb-api-key>",
+        }
+    }
+```
+
+If `config.copyToVolume=true`, the chart copies the Secret/ConfigMap file into the writable `persistence.uaData` volume on startup so it can be persisted/edited. Use `config.overwrite` to control whether it is replaced on every start.
+
+### Persistence
+
+- `persistence.uaData`: backs `/Upload-Assistant/data` (must be writable; this is where `config.py` lives)
+- `persistence.tmp`: backs `/Upload-Assistant/tmp` (recommended)
+- `persistence.files`: optional mount (often NFS) so the UI can browse your downloads/media (typical mountPath: `/data`)
+- `persistence.torrentStorage`: optional mount for torrent client state (e.g. qBittorrent `BT_backup`) used for torrent re-use
+
+If you use the Web UI file browser, set `persistence.files.mountPath` to match the `local_path` you configure in `config.py`.
+
+### Common values example
+
+```yaml
+# Run as the same user/group as your torrent client so UA can read/write the same files.
+podSecurityContext:
+  fsGroup: 1000
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+
+extraEnv:
+  - name: TZ
+    value: America/Denver
+
+config:
+  enabled: true
+  existingSecret: upload-assistant-config
+  copyToVolume: true
+  overwrite: true
+
+persistence:
+  files:
+    enabled: true
+    type: nfs
+    mountPath: /data
+    nfs:
+      server: <nfs-server-ip>
+      path: /path/to/share
+
+  uaData:
+    enabled: true
+    type: pvc
+    storageClassName: <your-storage-class>
+    size: 1Gi
+
+  tmp:
+    enabled: true
+    type: emptyDir
+
+service:
+  type: ClusterIP # or LoadBalancer
+
+# Optional ingress
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: upload.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+```
+
+## Parameters
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `image.repository` | Image repository | `ghcr.io/audionut/upload-assistant` |
+| `image.tag` | Image tag (defaults to chart `appVersion`) | `""` |
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service port | `5000` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `config.enabled` | Enable config management | `true` |
+| `config.existingSecret` | Existing Secret name containing `config.key` | `upload-assistant-config` |
+| `config.existingConfigMap` | Existing ConfigMap name containing `config.key` | `""` |
+| `config.kind` | Create a `secret` or `configMap` when not using `existingSecret`/`existingConfigMap` | `secret` |
+| `config.key` | Key name in the Secret/ConfigMap | `config.py` |
+| `config.mountPath` | Mount/copy destination path | `/Upload-Assistant/data/config.py` |
+| `config.copyToVolume` | Copy config into `persistence.uaData` (writable) | `true` |
+| `config.overwrite` | Overwrite destination on every start | `true` |
+| `config.configPy` | Inline `config.py` contents (used when creating Secret/ConfigMap) | `""` |
+| `persistence.uaData.enabled` | Enable `/Upload-Assistant/data` volume | `true` |
+| `persistence.uaData.type` | Storage type for `/Upload-Assistant/data` | `pvc` |
+| `persistence.tmp.enabled` | Enable `/Upload-Assistant/tmp` volume | `true` |
+| `persistence.tmp.type` | Storage type for `/Upload-Assistant/tmp` | `emptyDir` |
+| `persistence.files.enabled` | Enable optional files volume (UI browser) | `false` |
+| `persistence.files.type` | Storage type for files volume | `nfs` |
+| `extraEnv` | Extra environment variables | `[{name: ENABLE_WEB_UI, value: "true"}]` |

--- a/charts/upload-assistant/templates/NOTES.txt
+++ b/charts/upload-assistant/templates/NOTES.txt
@@ -1,0 +1,26 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "upload-assistant.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "upload-assistant.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "upload-assistant.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "upload-assistant.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use Upload-Assistant"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:$CONTAINER_PORT
+{{- end }}
+
+2. Provide a `config.py`:
+  - Upload-Assistant reads it from `/Upload-Assistant/data/config.py`.
+  - Recommended: set `config.enabled=true` and `config.existingSecret=<secret name>`.

--- a/charts/upload-assistant/templates/_helpers.tpl
+++ b/charts/upload-assistant/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "upload-assistant.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "upload-assistant.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "upload-assistant.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "upload-assistant.labels" -}}
+helm.sh/chart: {{ include "upload-assistant.chart" . }}
+{{ include "upload-assistant.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "upload-assistant.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "upload-assistant.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "upload-assistant.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "upload-assistant.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/upload-assistant/templates/config.yaml
+++ b/charts/upload-assistant/templates/config.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.config.enabled (not .Values.config.existingSecret) (not .Values.config.existingConfigMap) }}
+{{- if eq .Values.config.kind "configMap" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-config
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.key }}: |-
+{{ .Values.config.configPy | indent 4 }}
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-config
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.config.key }}: |-
+{{ .Values.config.configPy | indent 4 }}
+{{- end }}
+{{- end }}
+

--- a/charts/upload-assistant/templates/deployment.yaml
+++ b/charts/upload-assistant/templates/deployment.yaml
@@ -1,0 +1,265 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "upload-assistant.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "upload-assistant.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "upload-assistant.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.config.enabled .Values.config.copyToVolume }}
+      initContainers:
+        - name: config-init
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              src="/config-template/{{ .Values.config.key }}"
+              dst="{{ .Values.config.mountPath }}"
+              mkdir -p "$(dirname "$dst")"
+              overwrite="{{ .Values.config.overwrite }}"
+              if [ "$overwrite" = "true" ]; then
+                cp -f "$src" "$dst"
+              else
+                if [ ! -f "$dst" ]; then
+                  cp "$src" "$dst"
+                fi
+              fi
+              chown {{ .Values.securityContext.runAsUser | default 0 }}:{{ .Values.securityContext.runAsGroup | default 0 }} "$dst" || true
+          volumeMounts:
+            - name: ua-data
+              mountPath: {{ .Values.persistence.uaData.mountPath }}
+            - name: config-template
+              mountPath: /config-template
+              readOnly: true
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ua-data
+              mountPath: {{ .Values.persistence.uaData.mountPath }}
+              {{- with .Values.persistence.uaData.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.persistence.tmp.mountPath }}
+              {{- with .Values.persistence.tmp.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+            {{- if .Values.persistence.files.enabled }}
+            - name: files
+              mountPath: {{ .Values.persistence.files.mountPath }}
+              {{- with .Values.persistence.files.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+              {{- if .Values.persistence.files.readOnly }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
+            {{- if .Values.persistence.torrentStorage.enabled }}
+            - name: torrent-storage
+              mountPath: {{ .Values.persistence.torrentStorage.mountPath }}
+              {{- with .Values.persistence.torrentStorage.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+              {{- if .Values.persistence.torrentStorage.readOnly }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
+            {{- if and .Values.config.enabled (not .Values.config.copyToVolume) }}
+            - name: config-template
+              mountPath: {{ .Values.config.mountPath }}
+              subPath: {{ .Values.config.key }}
+              readOnly: true
+            {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: ua-data
+          {{- if .Values.persistence.uaData.enabled }}
+          {{- if eq .Values.persistence.uaData.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.uaData.existingClaim | default (printf "%s-ua-data" (include "upload-assistant.fullname" .)) }}
+          {{- else if eq .Values.persistence.uaData.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.persistence.uaData.hostPath.path | quote }}
+            {{- with .Values.persistence.uaData.hostPath.type }}
+            type: {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          {{- if .Values.persistence.tmp.enabled }}
+          {{- if eq .Values.persistence.tmp.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.tmp.existingClaim | default (printf "%s-tmp" (include "upload-assistant.fullname" .)) }}
+          {{- else if eq .Values.persistence.tmp.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.persistence.tmp.hostPath.path | quote }}
+            {{- with .Values.persistence.tmp.hostPath.type }}
+            type: {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.persistence.files.enabled }}
+        - name: files
+          {{- if eq .Values.persistence.files.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.files.existingClaim | default (printf "%s-files" (include "upload-assistant.fullname" .)) }}
+          {{- else if eq .Values.persistence.files.type "nfs" }}
+          nfs:
+            server: {{ .Values.persistence.files.nfs.server | quote }}
+            path: {{ .Values.persistence.files.nfs.path | quote }}
+          {{- else if eq .Values.persistence.files.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.persistence.files.hostPath.path | quote }}
+            {{- with .Values.persistence.files.hostPath.type }}
+            type: {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.persistence.torrentStorage.enabled }}
+        - name: torrent-storage
+          {{- if eq .Values.persistence.torrentStorage.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.torrentStorage.existingClaim | default (printf "%s-torrent-storage" (include "upload-assistant.fullname" .)) }}
+          {{- else if eq .Values.persistence.torrentStorage.type "nfs" }}
+          nfs:
+            server: {{ .Values.persistence.torrentStorage.nfs.server | quote }}
+            path: {{ .Values.persistence.torrentStorage.nfs.path | quote }}
+          {{- else if eq .Values.persistence.torrentStorage.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.persistence.torrentStorage.hostPath.path | quote }}
+            {{- with .Values.persistence.torrentStorage.hostPath.type }}
+            type: {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+      {{- if .Values.config.enabled }}
+        - name: config-template
+          {{- if .Values.config.existingSecret }}
+          secret:
+            secretName: {{ .Values.config.existingSecret }}
+            items:
+              - key: {{ .Values.config.key }}
+                path: {{ .Values.config.key }}
+          {{- else if .Values.config.existingConfigMap }}
+          configMap:
+            name: {{ .Values.config.existingConfigMap }}
+            items:
+              - key: {{ .Values.config.key }}
+                path: {{ .Values.config.key }}
+          {{- else if eq .Values.config.kind "configMap" }}
+          configMap:
+            name: {{ printf "%s-config" (include "upload-assistant.fullname" .) }}
+            items:
+              - key: {{ .Values.config.key }}
+                path: {{ .Values.config.key }}
+          {{- else }}
+          secret:
+            secretName: {{ printf "%s-config" (include "upload-assistant.fullname" .) }}
+            items:
+              - key: {{ .Values.config.key }}
+                path: {{ .Values.config.key }}
+          {{- end }}
+        {{- end }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/upload-assistant/templates/hpa.yaml
+++ b/charts/upload-assistant/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "upload-assistant.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/upload-assistant/templates/ingress.yaml
+++ b/charts/upload-assistant/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "upload-assistant.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/upload-assistant/templates/pvc.yaml
+++ b/charts/upload-assistant/templates/pvc.yaml
@@ -1,0 +1,91 @@
+{{- if and .Values.persistence.uaData.enabled (eq .Values.persistence.uaData.type "pvc") (not .Values.persistence.uaData.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-ua-data
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.persistence.uaData.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.uaData.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.uaData.size | quote }}
+  {{- with .Values.persistence.uaData.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.persistence.tmp.enabled (eq .Values.persistence.tmp.type "pvc") (not .Values.persistence.tmp.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-tmp
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.persistence.tmp.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.tmp.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.tmp.size | quote }}
+  {{- with .Values.persistence.tmp.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.persistence.files.enabled (eq .Values.persistence.files.type "pvc") (not .Values.persistence.files.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-files
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.persistence.files.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.files.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.files.size | quote }}
+  {{- with .Values.persistence.files.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.persistence.torrentStorage.enabled (eq .Values.persistence.torrentStorage.type "pvc") (not .Values.persistence.torrentStorage.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}-torrent-storage
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.persistence.torrentStorage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.torrentStorage.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.torrentStorage.size | quote }}
+  {{- with .Values.persistence.torrentStorage.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+

--- a/charts/upload-assistant/templates/service.yaml
+++ b/charts/upload-assistant/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "upload-assistant.fullname" . }}
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "upload-assistant.selectorLabels" . | nindent 4 }}

--- a/charts/upload-assistant/templates/serviceaccount.yaml
+++ b/charts/upload-assistant/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "upload-assistant.serviceAccountName" . }}
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/upload-assistant/templates/tests/test-connection.yaml
+++ b/charts/upload-assistant/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "upload-assistant.fullname" . }}-test-connection"
+  labels:
+    {{- include "upload-assistant.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "upload-assistant.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/upload-assistant/values.yaml
+++ b/charts/upload-assistant/values.yaml
@@ -1,0 +1,237 @@
+# Default values for upload-assistant.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/audionut/upload-assistant
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Default to running the Web UI like the upstream docker-compose.yml.
+command: ["/bin/bash", "-lc"]
+args:
+  - source /venv/bin/activate && python /Upload-Assistant/web_ui/server.py
+
+# Extra environment variables/envFrom added to the container.
+extraEnv:
+  - name: ENABLE_WEB_UI
+    value: "true"
+extraEnvFrom: []
+
+# Provide `/Upload-Assistant/data/config.py` via Secret/ConfigMap and (optionally) copy it into the writable `uaData` volume.
+config:
+  enabled: true
+  # Use an existing Secret/ConfigMap instead of creating one.
+  existingSecret: "upload-assistant-config"
+  existingConfigMap: ""
+  # When creating a config source, prefer `secret` since config.py commonly contains API keys.
+  kind: secret # secret | configMap
+  key: config.py
+  mountPath: /Upload-Assistant/data/config.py
+  # Copy Secret/ConfigMap -> `mountPath` on startup so the file is writable/persistent.
+  copyToVolume: true
+  # If true, overwrite `mountPath` on every start (recommended for Helm-managed config).
+  overwrite: true
+  # Only used when `enabled=true` and no `existingSecret`/`existingConfigMap` is set.
+  # Avoid committing real credentials; prefer `existingSecret`.
+  # configPy: |-
+  #   # Edit your Upload-Assistant config.py here (or set `config.existingSecret`).
+  #   # See: https://github.com/Audionut/Upload-Assistant/wiki/Configuration
+  #   config = {}
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 5000
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# Persistent and shared storage (all optional):
+# - `files`: mount your downloads/media for the Web UI browser (recommended mountPath: `/data`).
+# - `uaData`: stores `/Upload-Assistant/data` (must contain `config.py`).
+# - `tmp`: stores `/Upload-Assistant/tmp`.
+# - `torrentStorage`: optional mount for qBittorrent `BT_backup` (or other client session dir) used for torrent re-use.
+persistence:
+  files:
+    enabled: false
+    type: nfs # nfs | pvc | emptyDir | hostPath
+    mountPath: /data
+    subPath: ""
+    readOnly: false
+    nfs:
+      server: ""
+      path: ""
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+    annotations: {}
+    hostPath:
+      path: ""
+      type: ""
+
+  uaData:
+    enabled: true
+    type: pvc # pvc | emptyDir | hostPath
+    mountPath: /Upload-Assistant/data
+    subPath: ""
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+    annotations: {}
+    hostPath:
+      path: ""
+      type: ""
+
+  tmp:
+    enabled: true
+    type: emptyDir # pvc | emptyDir | hostPath
+    mountPath: /Upload-Assistant/tmp
+    subPath: ""
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+    annotations: {}
+    hostPath:
+      path: ""
+      type: ""
+
+  torrentStorage:
+    enabled: false
+    type: nfs # nfs | pvc | emptyDir | hostPath
+    mountPath: /torrent_storage_dir
+    subPath: ""
+    readOnly: false
+    nfs:
+      server: ""
+      path: ""
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+    annotations: {}
+    hostPath:
+      path: ""
+      type: ""
+
+# Consistent aliases for `volumes`/`volumeMounts` (matches other charts in this repo).
+extraVolumes: []
+extraVolumeMounts: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Summary
Adds an initial Helm chart for deploying Upload-Assistant’s Web UI (Docker GUI) on Kubernetes, with configurable storage and configuration injection.

## What’s included
- New chart at `charts/upload-assistant` (Chart + templates + defaults + README)
- Config management for `/Upload-Assistant/data/config.py`:
  - Default: reference an existing Secret (`config.existingSecret=upload-assistant-config`)
  - Optional: chart-created Secret/ConfigMap via `config.kind` + `config.configPy`
  - Optional initContainer flow to copy config into a writable/persistent volume (`config.copyToVolume=true`, `config.overwrite=true`)
- Persistence options for:
  - `/Upload-Assistant/data` (`persistence.uaData`, default PVC)
  - `/Upload-Assistant/tmp` (`persistence.tmp`, default `emptyDir`)
  - Optional `/data` files mount (`persistence.files`, e.g. NFS/PVC/hostPath)
  - Optional `/torrent_storage_dir` mount (`persistence.torrentStorage`, e.g. NFS/PVC/hostPath)
- Service + optional Ingress, liveness/readiness probes (`/api/health`), optional HPA
- `helm test` hook to validate service connectivity

## How to test
```bash
helm lint charts/upload-assistant
helm template upload-assistant charts/upload-assistant -f my-values.yaml
```

Cluster install example:
```bash
kubectl -n upload-assistant create secret generic upload-assistant-config \
  --from-file=config.py=/path/to/config.py

helm upgrade --install upload-assistant ./charts/upload-assistant \
  --namespace upload-assistant --create-namespace \
  -f my-values.yaml
```

## Notes / gotchas
- Defaults assume you provide `config.py` via Secret named `upload-assistant-config`.
- `persistence.uaData` defaults to a PVC; clusters without a default StorageClass will need `persistence.uaData.storageClassName` (or `persistence.uaData.existingClaim`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart support for streamlined deployment to Kubernetes clusters
  * Enabled configuration management via secrets, ConfigMaps, or inline settings
  * Added support for multiple service types (ClusterIP, LoadBalancer, Ingress)
  * Included horizontal pod autoscaling capabilities
  * Configured persistent storage for data, temporary files, and torrents

* **Documentation**
  * Added comprehensive Helm chart documentation with installation and configuration guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->