### PR TITLE
LT: Fix [CAST] tag

### DIFF
--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -105,7 +105,10 @@ class LT(UNIT3D):
 
             if len(audios) > 0:  # If there is at least 1 audio spanish
                 if not has_latino and has_castilian:
-                    lt_name = lt_name.replace(meta['tag'], f" [CAST]{meta['tag']}")
+                    if meta.get('tag'):
+                        lt_name = lt_name.replace(meta['tag'], f" [CAST]{meta['tag']}")
+                    else:
+                        lt_name = f"{lt_name} [CAST]"
                 # else: no special tag needed for Latino-only or mixed audio
             # if not audio Spanish exists, add "[SUBS]"
             elif not meta.get('tag'):


### PR DESCRIPTION
Fixes and issue when the name for LT had ` [CAST]` on each character if the `meta('tag')` was empty.

**Before**:
`Example` was named ` [CAST]E [CAST]x [CAST]a [CAST]m [CAST]p [CAST]l [CAST]e`

*After*:
`Example` is named `Example [CAST]` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Spanish audio labeling could fail when certain metadata is unavailable, improving stability when processing audio content with Castilian audio options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->