### PR TITLE
ANT: Fix media type for discs

### DIFF
--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -18,13 +18,16 @@ from src.get_desc import DescriptionBuilder
 from src.torrentcreate import TorrentCreator
 from src.trackers.COMMON import COMMON
 
+Meta = dict[str, Any]
+Config = dict[str, Any]
+
 
 class ANT:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Config):
         self.tracker = 'ANT'
         self.config = config
         self.common = COMMON(config)
-        self.tracker_config: dict[str, Any] = self.config['TRACKERS'].get(self.tracker, {})
+        self.tracker_config = self.config["TRACKERS"].get(self.tracker, {})
         self.source_flag = 'ANT'
         self.search_url = 'https://anthelion.me/api.php'
         self.upload_url = 'https://anthelion.me/api.php'
@@ -39,7 +42,7 @@ class ANT:
         ]
         pass
 
-    async def get_flags(self, meta: dict[str, Any]) -> list[str]:
+    async def get_flags(self, meta: Meta) -> list[str]:
         flags: list[str] = []
         flags.extend(
             [
@@ -69,7 +72,7 @@ class ANT:
             flags.append('Remux')
         return flags
 
-    async def get_release_group(self, meta: dict[str, Any]) -> str:
+    async def get_release_group(self, meta: Meta) -> str:
         if meta.get('tag', ''):
             tag = str(meta['tag'])
 
@@ -77,7 +80,7 @@ class ANT:
 
         return ""
 
-    async def get_tags(self, meta: dict[str, Any]) -> Union[list[str], str]:
+    async def get_tags(self, meta: Meta) -> Union[list[str], str]:
         no_tags = False
         tags: list[str] = []
         if meta.get('genres', []):
@@ -121,7 +124,7 @@ class ANT:
 
         return tags if not no_tags else ""
 
-    async def get_type(self, meta: dict[str, Any]) -> int:
+    async def get_type(self, meta: Meta) -> int:
         antType = None
         imdb_info = meta.get('imdb_info', {})
         if imdb_info.get('type') is not None:
@@ -165,7 +168,7 @@ class ANT:
 
         return antType
 
-    async def upload(self, meta: dict[str, Any], _) -> bool:
+    async def upload(self, meta: Meta, _) -> bool:
         torrent_filename = "BASE"
         torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/BASE.torrent"
         torrent_file_size_kib = os.path.getsize(torrent_path) / 1024
@@ -203,9 +206,7 @@ class ANT:
             'release_desc': await self.edit_desc(meta),
         }
         if meta['bdinfo'] is not None:
-            data.update({
-                'media': 'Blu-ray',
-            })
+            data.update({"media": "BluRay"})
         if meta['scene']:
             # ID of "Scene?" checkbox on upload form is actually "censored"
             data['censored'] = 1
@@ -355,7 +356,7 @@ class ANT:
             meta['tracker_status'][self.tracker]['status_message'] = "data error: double check if it uploaded"
             return False
 
-    async def get_audio(self, meta: dict[str, Any]) -> str:
+    async def get_audio(self, meta: Meta) -> str:
         '''
         Possible values:
         MP2, MP3, AAC, AC3, DTS, FLAC, PCM, True-HD, Opus
@@ -378,7 +379,7 @@ class ANT:
         console.print(f'{self.tracker}: Unexpected audio format: {audio}. The format must be one of the following: MP2, MP3, AAC, AC3, DTS, FLAC, PCM, True-HD, Opus')
         return ""
 
-    async def mediainfo(self, meta: dict[str, Any]) -> str:
+    async def mediainfo(self, meta: Meta) -> str:
         if meta.get('is_disc') == 'BDMV':
             mediainfo = str(await self.common.get_bdmv_mediainfo(meta, remove=['File size', 'Overall bit rate'], char_limit=100000))
         else:
@@ -388,7 +389,7 @@ class ANT:
 
         return mediainfo
 
-    async def edit_desc(self, meta: dict[str, Any]) -> str:
+    async def edit_desc(self, meta: Meta) -> str:
         builder = DescriptionBuilder(self.tracker, self.config)
         desc_parts: list[str] = []
 
@@ -445,7 +446,7 @@ class ANT:
 
         return description
 
-    async def search_existing(self, meta: dict[str, Any], _) -> list[dict[str, Any]]:
+    async def search_existing(self, meta: Meta, _) -> list[dict[str, Any]]:
         dupes: list[dict[str, Any]] = []
         if meta.get('category') == "TV":
             if not meta['unattended']:
@@ -532,7 +533,7 @@ class ANT:
 
         return dupes
 
-    async def get_data_from_files(self, meta: dict[str, Any]) -> list[dict[str, Any]]:
+    async def get_data_from_files(self, meta: Meta) -> list[dict[str, Any]]:
         imdb_tmdb_list: list[dict[str, Any]] = []
         if meta.get('is_disc', False):
             return imdb_tmdb_list


### PR DESCRIPTION
I started getting errors when uploading discs. I couldn't find the `Blu-ray` option on the website, maybe they removed it. All the discs I saw are marked as `BluRay`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code consistency and type safety through internal refactoring.
  * Minor standardization in media type representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->