### PR TITLE
Update HUNO.py Multiple Languages in torrent title

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -183,6 +183,9 @@ class HUNO(UNIT3D):
             else:
                 languages_result = str(next(iter(normalized_languages), "SKIPPED"))
 
+            if languages_result == "Multiple":
+                languages_result = "Multiple Languages"
+
             if not languages_result:
                 languages_result = "SKIPPED"
 


### PR DESCRIPTION
HUNO expects "Multiple Languages" as the language in the torrent title if the main audio track is tagged with the mul matroska iso language code rather than just "Multiple".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio language detection labeling to display "Multiple Languages" instead of "Multiple" when multiple audio languages are identified, improving clarity in the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->