### PR TITLE
Add --show-tracker-names CLI argument

### DIFF
--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -193,6 +193,7 @@ Thise will use the specified hash to get tracker ids from qBitTorrent or rTorren
 - `-debug`, `--debug`: Debug mode; runs through motions without uploading.
 - `-ffdebug`, `--ffdebug`: Show debugging info from ffmpeg while taking screenshots.
 - `-uptimer`, `--upload-timer`: Print time to upload to each site.
+- `-stn`, `--show-tracker-names`: Show tracker-specific release names before confirmation prompt. Useful to preview how your release name will appear on each target tracker.
 
 ## VapourSynth screenshots
 

--- a/src/args.py
+++ b/src/args.py
@@ -167,6 +167,7 @@ class Args:
         parser.add_argument('-debug', '--debug', action='store_true', required=False, help="Debug Mode, will run through all the motions providing extra info, but will not upload to trackers.")
         parser.add_argument('-ffdebug', '--ffdebug', action='store_true', required=False, help="Will show info from ffmpeg while taking screenshots.")
         parser.add_argument('-uptimer', '--upload-timer', action='store_true', required=False, help="Prints the time it takes to upload to each individual site.", dest="upload_timer")
+        parser.add_argument('-stn', '--show-tracker-names', action='store_true', required=False, help="Show tracker-specific release names before confirmation prompt", dest="show_tracker_names")
         parser.add_argument('-mps', '--max-piece-size', nargs=1, required=False, help="Set max piece size allowed in MiB for default torrent creation (default 128 MiB)", choices=['1', '2', '4', '8', '16', '32', '64', '128'])
         parser.add_argument('-nh', '--nohash', action='store_true', required=False, help="Don't hash .torrent")
         parser.add_argument('-rh', '--rehash', action='store_true', required=False, help="DO hash .torrent")


### PR DESCRIPTION
Adds a new command-line argument to preview tracker-specific release names before the confirmation prompt.

Usage
`python upload.py /path/to/media --show-tracker-names`
Example Output
```
Name: Ozma 2012 S01 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-maksii

Tracker-specific release names:  
AITHER: Ozma 2012 S01 JAPANESE 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-maksii
HUNO: Ozma (2012) S01 (1080p BluRay REMUX AVC SDR AAC 2.0 Dual - maksii)
BLU: Ozma 2012 S01 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-maksii
Is this correct? y/N:
```

Why
Useful for verifying tracker-specific naming conventions before uploading and during debug, helping catch naming issues early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `-stn` / `--show-tracker-names` command-line flag to the debugging output options. When enabled, displays tracker-specific release names during operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->