### PR TITLE
feat(dp): enhance dual and multi-audio track management for multilingual releases

### DIFF
--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -7,8 +7,8 @@ import cli_ui
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
-from src.tmdb import TmdbManager
 from src.languages import languages_manager
+from src.tmdb import TmdbManager
 from src.trackers.UNIT3D import UNIT3D
 
 
@@ -128,7 +128,7 @@ class DP(UNIT3D):
             for invalid_tag in invalid_tags:
                 dp_name = re.sub(f"-{invalid_tag}", "", dp_name, flags=re.IGNORECASE)
             dp_name = f"{dp_name}-NOGROUP"
-            
+
         audio = await self.get_audio(meta)
         if audio and audio != "SKIPPED" and "Dual-Audio" in dp_name:
             dp_name = dp_name.replace("Dual-Audio", audio)


### PR DESCRIPTION
### What
Improves dual and multi-audio handling for releases with multiple language audio tracks on the DarkPeers (DP) tracker.

### Why
The DarkPeers (DP) tracker requires that when more than two audio languages are present, the release must be marked as MULTi instead of Dual-Audio.  

### Changes
- Improved detection and handling of dual/multi-language audio tracks for DP
- Better support for multilingual audio tracks on DarkPeers releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release names now include audio-language tags: single-language code for one track, "Dual-Audio" for two, "MULTi" for three or more, and "SKIPPED" when none or unprocessable.
  * Audio-language detection is integrated into name construction, normalizes language lists, deduplicates entries, and replaces generic "Dual-Audio" tags with the derived label when applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->