### PR TITLE
Fix: TMDB metadata retrieval failed: 'NoneType' object has no attribute 'lower'

### DIFF
--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1544,7 +1544,7 @@ async def get_romaji(tmdb_name: str, mal: Optional[int], meta: dict[str, Any]) -
         except Exception:
             console.print('[red]Failed to get anime specific info from anilist. Continuing without it...')
             media = []
-    search_name = meta['filename'].lower() if "subsplease" in meta.get('filename', '').lower() else re.sub(r"[^0-9a-zA-Z\[\\]]+", "", tmdb_name.lower().replace(' ', ''))
+    search_name = (meta.get('filename') or '').lower() if "subsplease" in (meta.get('filename') or '').lower() else re.sub(r"[^0-9a-zA-Z\[\\]]+", "", tmdb_name.lower().replace(' ', ''))
 
     # Extract expected season number from various sources
     expected_season = None


### PR DESCRIPTION
Fix error TMDB metadata retrieval failed: 'NoneType' object has no attribute 'lower'

But this is more of a console error fix rather than a complete solution. The logic is too complex for me for some quick solution, and we need to figure out why an empty value is being passed there and why it is being called twice, where the second run already has a value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash when filename information is unavailable during content search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->