### PR TITLE
Fix: show "applies a naming change for this release" in dupe scenario

### DIFF
--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -61,6 +61,10 @@ class UploadHelper:
                 elif isinstance(tracker_rename, str):
                     display_name = tracker_rename
 
+            # Show naming change before dupe prompts so user knows what the final name will be
+            if display_name is not None and display_name != "" and display_name != meta.get('name', ''):
+                console.print(f"[bold yellow]{tracker_name} applies a naming change for this release: [green]{display_name}[/green][/bold yellow]")
+
             trumpable_text = None
             if meta.get('trumpable_id') or meta.get('matched_episode_ids', []):
                 trumpable_dupes = [


### PR DESCRIPTION
Adding logic to trigger "applies a naming change for this release" in case of a duplicate condition, as currently the logic would skip this block when the user decides to proceed, never showing the renaming message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notification banner that displays naming changes before duplicate detection prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->