### PR TITLE
qui reference updated

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -929,8 +929,9 @@ config = {
         # See https://github.com/Audionut/Upload-Assistant/wiki
         "qbittorrent": {
             "torrent_client": "qbit",
-            # qui reverse proxy url, see https://github.com/autobrr/qui#reverse-proxy-for-external-applications
-            # If using the qui reverse proxy, no other auth type needs to be set
+            # QUI reverse proxy: https://getqui.com/docs/features/reverse-proxy
+            # Create a Client Proxy API Key in QUI (Settings → Client Proxy Keys), pick the instance, paste the full proxy URL here.
+            # Example: "http://localhost:7476/proxy/<your-client-api-key>". No other qbit auth needed when set.
             "qui_proxy_url": "",
             # enable_search to True will automatically try and find a suitable hash to save having to rehash when creating torrents
             "enable_search": True,
@@ -978,8 +979,9 @@ config = {
         "qbittorrent_searching": {
             # an example of using a qBitTorrent client just for searching, when using another client for injection
             "torrent_client": "qbit",
-            # qui reverse proxy url, see https://github.com/autobrr/qui#reverse-proxy-for-external-applications
-            # If using the qui reverse proxy, no other auth type needs to be set
+            # QUI reverse proxy: https://getqui.com/docs/features/reverse-proxy
+            # Create a Client Proxy API Key in QUI (Settings → Client Proxy Keys), pick the instance, paste the full proxy URL here.
+            # Example: "http://localhost:7476/proxy/<your-client-api-key>". No other qbit auth needed when set.
             "qui_proxy_url": "",
             # enable_search to True will automatically try and find a suitable hash to save having to rehash when creating torrents
             "enable_search": True,

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -279,7 +279,7 @@ Security note: these settings can allow the app (and the Web UI) to interact wit
 
 ### qBittorrent (`torrent_client: "qbit"`)
 Typical keys:
-- `qui_proxy_url` (str): Optional qui reverse proxy URL. No other qbit credentials are required if using qui.
+- `qui_proxy_url` (str): Optional. [QUI reverse proxy](https://getqui.com/docs/features/reverse-proxy) URL for qBittorrent. Create a **Client Proxy API Key** in QUI (**Settings → Client Proxy Keys**): name the client (e.g. "Upload Assistant"), choose the qBittorrent instance, then copy the generated proxy URL. Use the **full** URL, e.g. `http://localhost:7476/proxy/<client-api-key>`. The instance is fixed by the key you create. When set, `qbit_url` / `qbit_port` / `qbit_user` / `qbit_pass` are not used.
 - `enable_search` (bool): Search client for existing torrents to reuse hashes. NOTE: independant of auto_torrent_searching
 - `qbit_url` / `qbit_port` (str): Web UI host/port.
 - `qbit_user` / `qbit_pass` (str): Credentials.


### PR DESCRIPTION
qui moved documentation to https://getqui.com/docs/features/reverse-proxy from https://github.com/autobrr/qui#reverse-proxy-for-external-applications
Example config and related wiki updated with new URL and basic instructions for setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced qBittorrent reverse proxy configuration documentation with step-by-step setup guidance and API key creation instructions
  * Documented multiple qBittorrent configuration options including proxy URL, tracker management, tagging, content layout, and storage path settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->