### PR TITLE
Reduce Docker image size using multi-stage builds

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,6 +2,8 @@ FROM python:3.12-alpine AS base
 
 ENV PIP_VERSION=25.3
 ENV REQUESTS_VERSION=2.32.5
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Install system dependencies including mono
 RUN apk add --no-cache \
@@ -64,6 +66,17 @@ RUN python3 -c "from bin.get_mkbrr import MkbrrBinaryManager; MkbrrBinaryManager
 # Download bdinfo binary for the container architecture using the docker helper
 RUN python3 bin/get_bdinfo_docker.py
 
+RUN chown -R 1000:1000 /Upload-Assistant/bin/mkbrr \
+    && chown -R 1000:1000 /Upload-Assistant/bin/MI \
+    && chown -R 1000:1000 /Upload-Assistant/bin/bdinfo \
+    && chmod -R +rx /Upload-Assistant/bin/mkbrr \
+    && chmod -R +rx /Upload-Assistant/bin/MI \
+    && chmod -R +rx /Upload-Assistant/bin/bdinfo
+
+# Create tmp directory with appropriate permissions
+RUN mkdir -p /Upload-Assistant/tmp && chmod 1777 /Upload-Assistant/tmp
+ENV TMPDIR=/Upload-Assistant/tmp
+
 # START BUILDING SLIM IMAGE
 FROM base
 
@@ -74,22 +87,17 @@ ENV PATH="/venv/bin:$PATH"
 # Copy application
 COPY --from=builder-app /Upload-Assistant /Upload-Assistant
 
-# Set workdir
 WORKDIR /Upload-Assistant
 
-# Ensure mkbrr is executable
-RUN find bin/mkbrr -name "mkbrr" -exec chmod +x {} \; && \
-    find bin/bdinfo -name "bdinfo" -exec chmod +x {} \;
+EXPOSE 5000
 
-# Enable non-root access while still letting Upload-Assistant tighten mkbrr permissions at runtime
-RUN chown -R 1000:1000 /Upload-Assistant/bin/mkbrr
+STOPSIGNAL SIGTERM
 
-# Enable non-root access for DVD MediaInfo binary
-RUN chown -R 1000:1000 /Upload-Assistant/bin/MI
+# Health check for WebUI mode — ignored when running CLI
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -sf http://localhost:5000/api/health || exit 1
 
-# Create tmp directory with appropriate permissions
-RUN mkdir -p /Upload-Assistant/tmp && chmod 777 /Upload-Assistant/tmp
-ENV TMPDIR=/Upload-Assistant/tmp
-
-# Set the entry point for the container
 ENTRYPOINT ["python", "/Upload-Assistant/upload.py"]
+
+# Default: show help when no arguments are provided
+CMD ["-h"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,95 @@
+FROM python:3.12-alpine AS base
+
+ENV PIP_VERSION=25.3
+ENV REQUESTS_VERSION=2.32.5
+
+# Install system dependencies including mono
+RUN apk add --no-cache \
+    ca-certificates \
+    curl \
+    ffmpeg \
+    gcompat \
+    icu-libs \
+    libgdiplus \
+    mediainfo \
+    mktorrent \
+    mono \
+    nano \
+    && update-ca-certificates
+
+# Setup venv
+FROM base AS builder-venv
+
+# Install build dependencies
+RUN apk add --no-cache \
+    cargo \
+    gcc \
+    git \
+    g++ \
+    linux-headers \
+    musl-dev \
+    python3-dev
+
+COPY requirements.txt /tmp/requirements.txt
+
+# Python venv setup
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Install requirements
+RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} && \
+    pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Finalize app directory in seperate build stage
+FROM base AS builder-app
+
+# Copy virtual environment
+COPY --from=builder-venv /venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Install requests (for DVD MediaInfo download)
+RUN pip install --upgrade requests==${REQUESTS_VERSION}
+
+WORKDIR /Upload-Assistant
+
+# Copy app into container
+COPY . .
+
+# Run DVD MediaInfo download script
+RUN python3 bin/get_dvd_mediainfo_docker.py
+
+# Download only the required mkbrr binary (requires full repo for src imports)
+RUN python3 -c "from bin.get_mkbrr import MkbrrBinaryManager; MkbrrBinaryManager.download_mkbrr_for_docker()"
+
+# Download bdinfo binary for the container architecture using the docker helper
+RUN python3 bin/get_bdinfo_docker.py
+
+# START BUILDING SLIM IMAGE
+FROM base
+
+# Copy venv
+COPY --from=builder-venv /venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Copy application
+COPY --from=builder-app /Upload-Assistant /Upload-Assistant
+
+# Set workdir
+WORKDIR /Upload-Assistant
+
+# Ensure mkbrr is executable
+RUN find bin/mkbrr -name "mkbrr" -exec chmod +x {} \; && \
+    find bin/bdinfo -name "bdinfo" -exec chmod +x {} \;
+
+# Enable non-root access while still letting Upload-Assistant tighten mkbrr permissions at runtime
+RUN chown -R 1000:1000 /Upload-Assistant/bin/mkbrr
+
+# Enable non-root access for DVD MediaInfo binary
+RUN chown -R 1000:1000 /Upload-Assistant/bin/MI
+
+# Create tmp directory with appropriate permissions
+RUN mkdir -p /Upload-Assistant/tmp && chmod 777 /Upload-Assistant/tmp
+ENV TMPDIR=/Upload-Assistant/tmp
+
+# Set the entry point for the container
+ENTRYPOINT ["python", "/Upload-Assistant/upload.py"]


### PR DESCRIPTION
This PR introduces multi-stage Docker builds to reduce the final image size by excluding build-time dependencies from the runtime image.

### Results
- **Before:** `2.86 GB`  
- **After:** ~~`1.63 GB`~~  _(-1.23 GB)_

_EDIT:_ New results:
- **slim:** `1.27 GB`
- **alpine:** `0.85 GB`

### Changes
- Added dedicated build stages for compiling/installing dependencies
- Final stage contains only runtime requirements
-  Added an alternative alpine image that is even smaller (~~`1.2GB`~~`0.85 GB`)

I tested each final image by processing a full disc and movie.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Alpine Linux-based Docker image for the application with multi-stage build optimization, resulting in a smaller and more efficient container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->