### PR TITLE
feat(ui): add search and collapse/expand functionality for argument categories

### DIFF
--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -1065,31 +1065,33 @@ function AudionutsUAGUI() {
                 
                 {/* Collapsible Section Content */}
                 {!collapsedSections.has(cat.title) && (
-                  <div className={`px-3 pb-3 space-y-2 ${isDarkMode ? 'border-t border-gray-700' : 'border-t border-gray-200'}`}>
-                    {cat.args.map((a) => (
-                      <div
-                        key={a.label}
-                        className={`w-full p-2 rounded-lg border ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-100'}`}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <button
-                            onClick={() => addArgument(a.label)}
-                            disabled={isExecuting}
-                            className={`px-3 py-1 text-sm font-mono rounded-md border ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white hover:bg-purple-600 hover:text-white' : 'bg-white border-gray-200 text-gray-800 hover:bg-purple-600 hover:text-white'} transition-colors`}
-                          >
-                            {a.label}
-                          </button>
-                          <div className="flex-1 text-right">
-                            {a.placeholder && (
-                              <div className={`text-xs ${isDarkMode ? 'text-gray-300' : 'text-gray-500'} font-mono`}>{a.placeholder}</div>
-                            )}
+                  <div className={`px-3 pb-3 pt-2 ${isDarkMode ? 'border-t border-gray-700' : 'border-t border-gray-200'}`}>
+                    <div className="grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-2">
+                      {cat.args.map((a) => (
+                        <div
+                          key={a.label}
+                          className={`w-full p-2 rounded-lg border ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-100'}`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <button
+                              onClick={() => addArgument(a.label)}
+                              disabled={isExecuting}
+                              className={`px-3 py-1 text-sm font-mono rounded-md border ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white hover:bg-purple-600 hover:text-white' : 'bg-white border-gray-200 text-gray-800 hover:bg-purple-600 hover:text-white'} transition-colors`}
+                            >
+                              {a.label}
+                            </button>
+                            <div className="flex-1 text-right">
+                              {a.placeholder && (
+                                <div className={`text-xs ${isDarkMode ? 'text-gray-300' : 'text-gray-500'} font-mono`}>{a.placeholder}</div>
+                              )}
+                            </div>
                           </div>
+                          {a.description && (
+                            <div className={`text-xs mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{a.description}</div>
+                          )}
                         </div>
-                        {a.description && (
-                          <div className={`text-xs mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{a.description}</div>
-                        )}
-                      </div>
-                    ))}
+                      ))}
+                    </div>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
<img width="551" height="451" alt="image" src="https://github.com/user-attachments/assets/4f553e1f-3a26-4175-9461-e9e3ad6a1b05" />
<img width="540" height="454" alt="image" src="https://github.com/user-attachments/assets/d9f9a3e4-b03b-46c2-8c37-1cdf9ffff83d" />
<img width="477" height="424" alt="image" src="https://github.com/user-attachments/assets/fd61a6cb-b32a-475f-b2e4-7511e272eeb9" />
<img width="655" height="644" alt="image" src="https://github.com/user-attachments/assets/e9d25ac7-075b-4e27-be5e-921816afc07c" />

Search argument, Collapse\Expand all functionality added to main page