### PR TITLE
TOS: Fix scene detection and WEBRIP type mapping

### DIFF
--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -65,7 +65,7 @@ class TOS(UNIT3D):
                 "REMUX": "2",
                 "ENCODE": "3",
                 "WEBDL": "4",
-                "WEBRIP": "5",
+                "WEBRIP": "4",
                 "HDTV": "6",
             }.get(meta["type"], "0")
         return {"type_id": type_id}


### PR DESCRIPTION
## Summary
- Fix `meta.get("scene_name")` to `meta.get("scene", False)` for proper scene detection
- Fix WEBRIP type ID mapping in TOS tracker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in release type identification for WEBRIP formats.
  * Enhanced scene release detection with refined identification logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->