### PR TITLE
feat(UTP): add hybrid tag to torrent naming for movies and TV shows

### DIFF
--- a/src/trackers/UTP.py
+++ b/src/trackers/UTP.py
@@ -144,6 +144,7 @@ class UTP(UNIT3D):
         three_d = str(meta.get('3D', ''))
         uhd = str(meta.get('uhd', ''))
         edition = str(meta.get('edition', ''))
+        hybrid = 'Hybrid' if meta.get('webdv', "") else ''
         repack = str(meta.get('repack', ''))
         resolution = str(meta.get('resolution', ''))
         hdr = str(meta.get('hdr', ''))
@@ -182,9 +183,9 @@ class UTP(UNIT3D):
 
         # Build name using single template per category
         if category == "MOVIE":
-            name = f"{title} {aka} {year} {repack} {edition} {region} {three_d} {uhd} {source_tag} {type_tag} {resolution} {hdr} {vcodec} {audio}"
+            name = f"{title} {aka} {year} {hybrid} {repack} {edition} {region} {three_d} {uhd} {source_tag} {type_tag} {resolution} {hdr} {vcodec} {audio}"
         elif category == "TV":
-            name = f"{title} {aka} {season}{episode} {year} {edition} {repack} {region} {three_d} {uhd} {source_tag} {type_tag} {resolution} {hdr} {vcodec} {audio}"
+            name = f"{title} {aka} {season}{episode} {year} {hybrid} {edition} {repack} {region} {three_d} {uhd} {source_tag} {type_tag} {resolution} {hdr} {vcodec} {audio}"
         else:
             name = str(meta.get('name', ''))
 


### PR DESCRIPTION
Add of missing Hybrid flag for utp tracker naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Hybrid" indicator to content naming. Movie and TV show titles will now include a "Hybrid" label in their names when applicable, appearing after the release year for better identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->