### PR TITLE
feat(upload): implement graceful shutdown handling for script and server

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1337,8 +1337,10 @@ async def do_the_thing(base_dir: str) -> None:
                 server_thread = threading.Thread(target=_webui_server.run, daemon=True)
                 server_thread.start()
 
-                # Wait for shutdown signal
+                # Wait for shutdown signal or unexpected thread death
                 while not _shutdown_event.is_set():
+                    if not server_thread.is_alive():
+                        raise RuntimeError("Web UI server thread exited unexpectedly")
                     _shutdown_event.wait(timeout=1.0)
 
                 # Close server gracefully


### PR DESCRIPTION
Add proper signal handling (SIGINT/SIGTERM) for a clean shutdown
Fix the WebUI server to respond to a single Ctrl+C
Should support Docker docker stop graceful shutdown
Improve startup/shutdown messages with a clickable URL

before
```
Starting Web UI server on 127.0.0.1:5000...
^C^C^C
asyncio.exceptions.CancelledError
KeyboardInterrupt
```

After
```
Web UI server started
Access at: http://localhost:5000
Press Ctrl+C to stop the server

^C
Received SIGINT, shutting down gracefully...
Web UI server stopped
Shutdown complete
```

webui "Kill and Clear" requires some rework on the UI side or server side to properly handle the kill event during execution, as it currently struggles to do so(when run in same proces without the use of UA_WEBUI_USE_SUBPROCESS).
As that's corner cases, even not sure if we should redo it or just adjust UI to block kill button, while process running(eg, wait till we get to some point, like confirmation ask)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web UI can run in background mode with coordinated lifecycle, startup/shutdown sequencing, and displays the access URL.

* **Bug Fixes**
  * Improved handling of interrupts and system signals for graceful, timeout-bounded cleanup.
  * Cleaner shutdown messaging and safer cross-thread shutdown synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->