### PR TITLE
Fix No module named 'web_ui'

### DIFF
--- a/web_ui/server.py
+++ b/web_ui/server.py
@@ -27,10 +27,11 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from werkzeug.security import safe_join
 
-import web_ui.auth as auth_mod
 from flask_session import Session
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import web_ui.auth as auth_mod
 
 # Helper to convert ANSI -> HTML using Rich (optional)
 try:


### PR DESCRIPTION
Import of webui was below sys.path so switched them back. This should fix error #1187.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization improvements to enhance maintainability.

**Note:** This release contains no user-facing changes or new features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->