### PR TITLE
Fix argument in screenshot_header method

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -409,7 +409,7 @@ class DescriptionBuilder:
         """Returns the screenshot header if applicable."""
         try:
             screenheader = self.tracker_config.get(
-                "custom_screenshot_header", self.config["DEFAULT"].get("screenshot_header", None)
+                "screenshot_header", self.config["DEFAULT"].get("screenshot_header", None)
             )
             if screenheader:
                 return str(screenheader)


### PR DESCRIPTION
Corrected the argument in the screenshot_header method to ensure proper retrieval of the custom screenshot header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated screenshot header configuration retrieval to use the correct configuration reference point, ensuring headers display based on the appropriate configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->