### PR TITLE
SHRI: Fixed the audio language tag building following rules

### DIFF
--- a/src/trackers/SHRI.py
+++ b/src/trackers/SHRI.py
@@ -146,7 +146,7 @@ class SHRI(UNIT3D):
             elif num_langs == 2:
                 # Two languages ("ITA - [lang]" if ITA is present, "[lang] - [lang]" if not)
                 if "ITA" in audio_langs:
-                    other = [l for l in audio_langs if l != "ITA"][0]
+                    other = [lang for lang in audio_langs if lang != "ITA"][0]
                     audio_lang_str = f"ITA - {other}"
                 else:
                     audio_lang_str = " - ".join(audio_langs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified audio language tag logic with explicit formatting for single, two, and multiple languages.
  * When Italian is present, tags are formatted to highlight Italian consistently for two or many languages.
  * Preserves original casing when resolving language names.
  * Removed legacy original-language deduction that previously influenced tag selection.
  * No changes to public interfaces or external output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->