### PR TITLE
Refactor comments and improve description formatting

### DIFF
--- a/src/trackers/TVC.py
+++ b/src/trackers/TVC.py
@@ -771,7 +771,7 @@ class TVC:
 
         # MINIMAL TVC FIX
         desc = desc.replace("[center]\n", "[center]")
-        
+
         # Collapse any run of 2+ newlines into a single newline
         desc = re.sub(r"\n{2,}", "\n", desc)
 
@@ -782,12 +782,16 @@ class TVC:
         if signature:
             desc += f"\n{signature}\n"
 
-        # Write description asynchronously
-        def _write():
-            with open(descfile_path, "w", encoding="utf-8") as f:
-                f.write(desc)
+        try:
+            # Write description asynchronously
+            def _write():
+                with open(descfile_path, "w", encoding="utf-8") as f:
+                    f.write(desc)
 
-        await asyncio.to_thread(_write)
+            await asyncio.to_thread(_write)
+        except Exception as e:
+            console.print(f"[yellow]Warning: Failed to write description file: {e}[/yellow]")
+
         return desc
 
 


### PR DESCRIPTION
TVC changed the site use of the bbc description box to something hybrid. if a` /n `appears after` [center]` it injects `<br>` breaking the centring` /n/n `becomes `<br><br>`

This is a quick fix, removing the errors the new site parser produces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaner, standardized description formatting with normalized headings (DISCS, MOVIE RELEASE INFO, TV PACK LAYOUT, EPISODE LAYOUT, MOVIE / FALLBACK, NOTES), reduced blank lines, and collapsed redundant newlines.
  * Improved BBCode rendering for TV packs, episodes, lists, screenshots, centering and logo placement.
  * More reliable description output: ensures temp description location exists, writes asynchronously, and emits a warning on write failure.
  * Added a minimal fallback message to avoid empty descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->