### PR TITLE
docker: add non root user info

### DIFF
--- a/docs/docker-wiki-full.md
+++ b/docs/docker-wiki-full.md
@@ -55,6 +55,19 @@ docker run --rm -it --network=host \
 ghcr.io/audionut/upload-assistant:latest /downloads/path/to/content --help
 ```
 
+## Run as non root
+mount `tmp` and `banned` directories to run as a non root user
+
+```
+docker run --rm -it --network=host \
+-u 1000:1000 \
+-v /full/path/to/config.py:/Upload-Assistant/data/config.py \
+-v /full/path/to/downloads:/downloads \
+-v /full/path/to/tmp:/Upload-Assistant/tmp \
+-v /full/path/to/banned:/Upload-Assistant/data/banned \
+ghcr.io/audionut/upload-assistant:latest /downloads/path/to/content --help
+```
+
 ## What is docker?
 Google is your friend
 


### PR DESCRIPTION
I had to add `tmp` and `banned` mounts in order to run it as non root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added instructions for running containers as a non-root user, including configuration for directory mounting and user ID mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->