### PR TITLE
Fix mkbrr: Resolve TypeError (int vs str) and support system binary path

### DIFF
--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -1,5 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
+import contextlib
 import fnmatch
 import glob
 import math
@@ -280,10 +281,8 @@ class TorrentCreator:
 
                         # Ensure executable permission for non-Windows systems
                         if not sys.platform.startswith("win"):
-                            try:
+                            with contextlib.suppress(Exception):
                                 os.chmod(mkbrr_binary, 0o700)
-                            except Exception:
-                                pass
 
                         cmd = [mkbrr_binary, "create", os.fspath(path)]
 


### PR DESCRIPTION
This PR fixes a critical crash when using `mkbrr` for torrent creation.

**The Issues Fixed:**
1. TypeError Crash: The script was passing integer values (like thread count) to `subprocess`, which caused a `TypeError: expected str, bytes or os.PathLike object, not int`. I wrapped these arguments in `str()` to fix this.
2. Binary Detection: The script previously only looked for `mkbrr` in the internal `bin/` folder. I added a check using `shutil.which("mkbrr")` to detect system-installed versions (e.g., `/usr/local/bin/mkbrr`), which allows the bot to work in environments like Termux, Proot, and Docker containers where the internal binary might be missing or incompatible.

Testing:
Tested on Linux (Debian/Proot) where the crash was reproducible. After the fix, torrent creation and hashing work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents failures when adjusting executable permissions on non‑Windows systems by safely handling permission changes.
  * Ensures the background process receives the correct worker/thread count by explicitly formatting the value passed.
  * Prefers a system-installed executable when available, falling back to the bundled binary if not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->