### PR TITLE
Aither: fix language requirements

### DIFF
--- a/src/trackers/AITHER.py
+++ b/src/trackers/AITHER.py
@@ -30,7 +30,7 @@ class AITHER(UNIT3D):
         should_continue = True
 
         if meta['is_disc'] not in ["BDMV", "DVD"] and not await self.common.check_language_requirements(
-            meta, self.tracker, languages_to_check=["english"], check_audio=True, check_subtitle=True, original_language=True
+            meta, self.tracker, languages_to_check=["english"], check_audio=True, check_subtitle=True, original_language=True, original_required=True
         ):
             return False
 

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -1071,6 +1071,7 @@ class COMMON:
         check_subtitle: bool = False,
         require_both: bool = False,
         original_language: bool = False,
+        original_required: bool = False,
     ) -> bool:
         """
         Check if the media metadata meets specific language requirements for audio and/or subtitles.
@@ -1095,7 +1096,9 @@ class COMMON:
         :param original_language: If True, checks if the media's original language matches the audio
                                   track, allowing a fallback to subtitle-only validation.
         :type original_language: bool
-        :return: True if language requirements are met, False otherwise.
+        :param original_required: If True, the original language must be present in the audio tracks.
+        :type original_required: bool
+        :return: True if the media meets the specified language requirements, False otherwise.
         :rtype: bool
         """
         try:
@@ -1133,6 +1136,14 @@ class COMMON:
 
             if language_display:
                 original_ok = language_display in audio_languages
+
+            if original_required and not original_ok:
+                console.print(
+                    f"[red]Original language requirement not met for [bold]{tracker}[/bold].[/red]\n"
+                    f"[yellow]Required original audio language:[/yellow] {language_display}\n"
+                    f"[cyan]Found Audio Languages:[/cyan] {', '.join(audio_languages) or 'None'}"
+                )
+                return False
 
             audio_ok = (
                 not check_audio


### PR DESCRIPTION
https://aither.cc/pages/1

> Foreign content must contain an English dub track, English subtitles, or both 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language requirement validation for non-BDMV/DVD media to verify English support in audio and subtitles.
  * Introduced an optional enforcement toggle to require the original-language track be present in audio; if missing, the item is rejected earlier with a clear failure path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->