### PR TITLE
Update BLU encode min resolution

### DIFF
--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -57,6 +57,11 @@ class BLU(UNIT3D):
             else:
                 return False
 
+        if meta['type'] in ["ENCODE"] and meta['resolution'] in ['576p', '576i', '480p', '480i']:
+            if not meta['unattended']:
+                console.print(f'[bold red]Encodes must be at least 720p resolution for {self.tracker}.[/bold red]')
+            return False
+        
         if not meta['valid_mi_settings']:
             console.print(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False


### PR DESCRIPTION
https://blutopia.cc/pages/18#resolution-requirements
> 4.2 Encodes must be at least 720p.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Added validation to prevent uploading ENCODE releases with resolutions below 720p. Uploads with 480p, 480i, 576p, or 576i resolutions will now be rejected to maintain quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->