### PR TITLE
Fix "continue anyway" on banned group detection

### DIFF
--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -371,7 +371,7 @@ class TRACKER_SETUP:
         if result:
             if not meta['unattended'] or meta.get('unattended_confirm', False):
                 try:
-                    if not cli_ui.ask_yes_no(cli_ui.red, "Do you want to continue anyway?", default=False):
+                    if cli_ui.ask_yes_no(cli_ui.red, "Do you want to continue anyway?", default=False):
                         return False
                 except EOFError:
                     console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")


### PR DESCRIPTION
Previously this did the opposite, aka. if a user typed "y", the check for the tracker failed, if they type "n", the upload would continue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confirmation prompt behavior when encountering banned group warnings, allowing users to correctly proceed or abort as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->