### PR TITLE
webui: handle SSE error events and avoid false completion

### DIFF
--- a/web_ui/static/js/app.js
+++ b/web_ui/static/js/app.js
@@ -1054,6 +1054,9 @@ function AudionutsUAGUI() {
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
+      let sawTerminalEvent = false;
+      let sawErrorEvent = false;
+      let sawOutputEvent = false;
 
       const processSSELine = (line) => {
         if (localController && localController.signal.aborted) return;
@@ -1061,6 +1064,7 @@ function AudionutsUAGUI() {
         try {
           const data = JSON.parse(line.substring(6));
           if (data.type === 'html' || data.type === 'html_full') {
+            sawOutputEvent = true;
             try {
               const rawHtml = data.data || '';
               const clean = sanitizeHtml(rawHtml);
@@ -1085,10 +1089,23 @@ function AudionutsUAGUI() {
             } catch (e) {
               console.error('Failed to render HTML fragment:', e);
             }
-              } else if (data.type === 'exit') {
+          } else if (data.type === 'system') {
+            if (data.data) {
+              appendSystemMessage(String(data.data));
+            }
+          } else if (data.type === 'error') {
+            sawTerminalEvent = true;
+            sawErrorEvent = true;
+            const msg = data.data ? String(data.data) : 'Execution error';
+            appendSystemMessage(`✗ ${msg}`, 'error');
+          } else if (data.type === 'exit') {
+            sawTerminalEvent = true;
             if (!(localController && localController.signal.aborted)) {
               appendSystemMessage('');
               appendSystemMessage(`✓ Process exited with code ${data.code}`);
+              if (Number(data.code) !== 0) {
+                sawErrorEvent = true;
+              }
             }
           }
         } catch (e) {
@@ -1121,8 +1138,16 @@ function AudionutsUAGUI() {
       /* eslint-enable no-constant-condition */
       // Only append the final completion message when not aborted.
       if (!(localController && localController.signal.aborted)) {
-        appendSystemMessage('✓ Execution completed');
-        appendSystemMessage('');
+        if (sawErrorEvent) {
+          appendSystemMessage('✗ Execution finished with errors', 'error');
+          appendSystemMessage('');
+        } else if (!sawTerminalEvent && !sawOutputEvent) {
+          appendSystemMessage('✗ Execution ended without output', 'error');
+          appendSystemMessage('');
+        } else {
+          appendSystemMessage('✓ Execution completed');
+          appendSystemMessage('');
+        }
       }
     } catch (error) {
       // Suppress abort errors as they are expected when a user cancels.


### PR DESCRIPTION
Fixes #1276.

## What changed
- Handle SSE `error` events in Web UI execution stream and display them in terminal output.
- Handle SSE `system` events so server-side status messages are visible.
- Track terminal/output states per run.
- Avoid showing false `✓ Execution completed` on error/empty-output termination.
- Mark non-zero `exit` codes as error outcomes.

## Why
The backend can emit SSE `error` events (for example lock contention: "Another in-process run is active").
The frontend previously ignored these events and unconditionally printed `✓ Execution completed` when the stream ended, causing false-success runs with no useful output.

## Validation
- Linted frontend after dependency install; existing unrelated lint errors remain in `app.js` (`react/no-unescaped-entities` lines 1690, 2212).
- Verified patch scope is limited to `web_ui/static/js/app.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience during template parsing and rendering operations.
  * Better handling of error scenarios in output display.

* **Improvements**
  * Refined execution completion messaging to clearly indicate success, errors, or missing output.
  * Enhanced monitoring of data stream events for accurate execution state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->