### PR TITLE
feat(trackers): add VietMediaF (VMF) tracker support

### DIFF
--- a/src/trackers/VMF.py
+++ b/src/trackers/VMF.py
@@ -1,0 +1,76 @@
+# Upload Assistant — VietMediaF (UNIT3D based)
+from typing import Any, Optional
+
+from src.trackers.COMMON import COMMON
+from src.trackers.UNIT3D import UNIT3D
+
+Meta = dict[str, Any]
+Config = dict[str, Any]
+
+
+class VMF(UNIT3D):
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, tracker_name='VMF')
+        self.config = config
+        self.common = COMMON(config)
+        self.tracker = 'VMF'
+        self.base_url = 'https://tracker.vietmediaf.store'
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
+        self.banned_groups = [""]
+        pass
+
+    async def get_category_id(
+        self,
+        meta: Meta,
+        category: Optional[str] = None,
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = (category, reverse, mapping_only)
+        category_id = {
+            'MOVIE': '1',
+            'TV': '2',
+        }.get(meta['category'], '0')
+        return {'category_id': category_id}
+
+    async def get_type_id(
+        self,
+        meta: Meta,
+        type: Optional[str] = None,
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = (type, reverse, mapping_only)
+        type_id = {
+            'DISC': '1',
+            'REMUX': '2',
+            'ENCODE': '3',
+            'WEBDL': '4',
+            'WEBRIP': '5',
+            'HDTV': '6',
+        }.get(meta['type'], '0')
+        return {'type_id': type_id}
+
+    async def get_resolution_id(
+        self,
+        meta: Meta,
+        resolution: Optional[str] = None,
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = (resolution, reverse, mapping_only)
+        resolution_id = {
+            '4320p': '1',
+            '2160p': '2',
+            '1080p': '3',
+            '1080i': '4',
+            '720p': '5',
+            '576p': '6',
+            '576i': '7',
+            '480p': '8',
+            '480i': '9',
+        }.get(meta['resolution'], '10')
+        return {'resolution_id': resolution_id}

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -81,6 +81,7 @@ from src.trackers.TTR import TTR
 from src.trackers.TVC import TVC
 from src.trackers.ULCX import ULCX
 from src.trackers.UTP import UTP
+from src.trackers.VMF import VMF
 from src.trackers.YOINK import YOINK
 from src.trackers.YUS import YUS
 
@@ -1341,12 +1342,12 @@ tracker_class_map: dict[str, type[Any]] = {
     'CZ': CZ, 'DC': DC, 'DP': DP, 'DT': DT, 'EMUW': EMUW, 'FNP': FNP, 'FF': FF, 'FL': FL, 'FRIKI': FRIKI, 'GPW': GPW, 'HDB': HDB, 'HDS': HDS, 'HDT': HDT, 'HHD': HHD, 'HUNO': HUNO, 'ITT': ITT,
     'IHD': IHD, 'IS': IS, 'LCD': LCD, 'LDU': LDU, 'LST': LST, 'LT': LT, 'LUME': LUME, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PHD': PHD, 'PT': PT, 'PTP': PTP, 'PTER': PTER, 'PTS': PTS, 'PTT': PTT,
     'R4E': R4E, 'RAS': RAS, 'RF': RF, 'RTF': RTF, 'SAM': SAM, 'SHRI': SHRI, 'SN': SN, 'SP': SP, 'SPD': SPD, 'STC': STC, 'THR': THR,
-    'TIK': TIK, 'TL': TL, 'TLZ': TLZ, 'TOS': TOS, 'TVC': TVC, 'TTG': TTG, 'TTR': TTR, 'ULCX': ULCX, 'UTP': UTP, 'YOINK': YOINK, 'YUS': YUS
+    'TIK': TIK, 'TL': TL, 'TLZ': TLZ, 'TOS': TOS, 'TVC': TVC, 'TTG': TTG, 'TTR': TTR, 'ULCX': ULCX, 'UTP': UTP, 'VMF': VMF, 'YOINK': YOINK, 'YUS': YUS
 }
 
 api_trackers = {
     'A4K', 'ACM', 'AITHER', 'BHD', 'BLU', 'CBR', 'DP', 'DT', 'EMUW', 'FNP', 'FRIKI', 'HHD', 'HUNO', 'IHD', 'ITT', 'LCD', 'LDU', 'LST', 'LT', 'LUME',
-    'OE', 'OTW', 'PT', 'PTT', 'RAS', 'RF', 'R4E', 'SAM', 'SHRI', 'SP', 'STC', 'TIK', 'TLZ', 'TOS', 'TTR', 'ULCX', 'UTP', 'YOINK', 'YUS'
+    'OE', 'OTW', 'PT', 'PTT', 'RAS', 'RF', 'R4E', 'SAM', 'SHRI', 'SP', 'STC', 'TIK', 'TLZ', 'TOS', 'TTR', 'ULCX', 'UTP', 'VMF', 'YOINK', 'YUS'
 }
 
 other_api_trackers = {


### PR DESCRIPTION
Add VietMediaF tracker (UNIT3D-based Vietnamese private tracker). Includes VMF.py with category/type/resolution mappings and trackersetup.py integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the VMF tracker with automatic metadata mapping for categories, types, and resolutions to ensure compatible formatting for tracker operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->