### PR TITLE
feat: support new Aither DV HDR flags

### DIFF
--- a/src/trackers/AITHER.py
+++ b/src/trackers/AITHER.py
@@ -24,7 +24,6 @@ class AITHER(UNIT3D):
         self.requests_url = f'{self.base_url}/api/requests/filter'
         self.trumping_url = f'{self.base_url}/api/trumping-reports/filter'
         self.banned_groups: list[str] = []
-        pass
 
     async def get_additional_checks(self, meta: dict[str, Any]):
         should_continue = True
@@ -42,7 +41,7 @@ class AITHER(UNIT3D):
 
     async def get_additional_data(self, meta: dict[str, Any]):
         hdr_value = meta.get('hdr', '')
-        
+
         data = {
             'mod_queue_opt_in': await self.get_flag(meta, 'modq'),
             'hdr': any(flag in hdr_value for flag in ['HDR', 'HLG']),


### PR DESCRIPTION
Aither introduced new uploads flags that can be set for DV and HDR content. See: https://aither.cc/articles/126

This PR adds supports for those flags.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects HDR and Dolby Vision from content metadata and exposes HDR and DV flags so playback/display can adapt.
* **Refactor**
  * Minor internal cleanup with no user-visible behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->