### PR TITLE
Fix broken ScanType and resolution detection

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -294,7 +294,7 @@ class VideoManager:
         else:
             framerate = "24.000"
 
-        scan = str(video_track.get('ScanType', "Progressive"))
+        scan = video_track.get('ScanType', "Progressive")
         if (not scan or scan == "Progressive") and dvd_mi_text:
             scan_match = re.search(r'Scan type\s*:\s*([^\r\n]+)', dvd_mi_text, re.IGNORECASE)
             if scan_match:


### PR DESCRIPTION
String type conversion added in #1270 made all these conditions incorrect: https://github.com/Audionut/Upload-Assistant/blob/38ce348520f5e076ef48b4842d9ff50c69a97ceb/src/video.py#L297-L303
Because `ScanType` is `{}` if it's empty and it gets converted into `"{}"` (a string) that is always `True`:

<img width="381" height="165" alt="mi-scan" src="https://github.com/user-attachments/assets/f7d0dc0b-4182-459e-b5bc-363918c0bbbe" />

This lead to values like 3840**i** in my case, so `mi_resolution()` returned `OTHER` here instead of `2160p`: https://github.com/Audionut/Upload-Assistant/blob/38ce348520f5e076ef48b4842d9ff50c69a97ceb/src/exportmi.py#L145-L149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan type value handling to preserve original data and prevent forced conversions, addressing potential edge-case behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->