### PR TITLE
fix(LUME): enforce MKV container requirement for non-disc uploads

### DIFF
--- a/src/trackers/LUME.py
+++ b/src/trackers/LUME.py
@@ -50,6 +50,10 @@ class LUME(UNIT3D):
             else:
                 return False
 
+        if not meta.get("is_disc", False) and meta.get("container", "") != "mkv":
+            console.print(f"[bold red]{self.tracker} only allows MKV containers for non-disc uploads.[/bold red]")
+            return False
+
         if not meta['valid_mi_settings']:
             console.print(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
             return False


### PR DESCRIPTION
https://github.com/Audionut/Upload-Assistant/issues/1230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for non-disc uploads to ensure they use MKV format only; unsupported formats will be rejected with an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->