### PR TITLE
fix(AvistaZ): mediainfo for DVDs

### DIFF
--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -375,7 +375,7 @@ class AZTrackerBase:
             summary_file = 'BD_SUMMARY_EXT_00' if self.tracker == 'CZ' else 'BD_SUMMARY_00'
             info_file_path = f"{meta.get('base_dir')}/tmp/{meta.get('uuid')}/{summary_file}.txt"
         elif meta.get("is_disc") == "DVD":
-            vob_files = glob.glob(os.path.join(meta["path"], "**/*.vob"), recursive=True)
+            vob_files = glob.glob(os.path.join(meta["path"], "VTS_*.VOB"), recursive=True)
             if vob_files:
                 largest_vob = max(vob_files, key=os.path.getsize)
                 vob_mi_obj = MediaInfo.parse(largest_vob, output="STRING")

--- a/src/trackers/AVISTAZ_NETWORK.py
+++ b/src/trackers/AVISTAZ_NETWORK.py
@@ -1,5 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 import asyncio
+import glob
 import importlib
 import json
 import os
@@ -14,6 +15,7 @@ import aiofiles
 import cli_ui
 import httpx
 from bs4 import BeautifulSoup
+from pymediainfo import MediaInfo
 
 import bbcode
 from cogs.redaction import Redaction
@@ -372,6 +374,12 @@ class AZTrackerBase:
         if meta.get('is_disc') == 'BDMV':
             summary_file = 'BD_SUMMARY_EXT_00' if self.tracker == 'CZ' else 'BD_SUMMARY_00'
             info_file_path = f"{meta.get('base_dir')}/tmp/{meta.get('uuid')}/{summary_file}.txt"
+        elif meta.get("is_disc") == "DVD":
+            vob_files = glob.glob(os.path.join(meta["path"], "**/*.vob"), recursive=True)
+            if vob_files:
+                largest_vob = max(vob_files, key=os.path.getsize)
+                vob_mi_obj = MediaInfo.parse(largest_vob, output="STRING")
+                return vob_mi_obj
         else:
             info_file_path = f"{meta.get('base_dir')}/tmp/{meta.get('uuid')}/MEDIAINFO_CLEANPATH.txt"
 


### PR DESCRIPTION
> the AvistaZ network would prefer the largest VOB file as MediaInfo for full DVD uploads:

> I noticed you recently uploaded a DVD torrent and used "VTS_01_0.IFO" to generate the MediaInfo. While this is technically not wrong and allowed, sometimes MediaInfo shows less information about the video/audio this way.
> Therefore I want to ask you to please use the largest .VOB file to generate the MI report for future DVD uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media-info extraction for DVD discs: the app now locates the primary DVD video file on disc and extracts metadata directly for more reliable media details; Blu-ray and other disc behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->