### PR TITLE
Only allow MKV for non-disc on BLU

### DIFF
--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -34,6 +34,18 @@ class BLU(UNIT3D):
 
     async def get_additional_checks(self, meta: dict[str, Any]) -> bool:
         should_continue = True
+
+        if not meta.get('is_disc'):
+            container = meta.get('container', '').lower()
+            if container != 'mkv':
+                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
+                    console.print(f"[bold red]Container '{container.upper()}' is generally not allowed for non-disc releases on {self.tracker}.[/bold red]")
+                    console.print("[bold red]Rules: Remuxes, Encodes, WEB-DL and untouched HDTV must be MKV. Exceptions: DV P5 (MP4), HDTV (.ts).[/bold red]")
+                    if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
+                        return False
+                else:
+                    return False
+        
         if (
             meta['type'] in ['ENCODE', 'REMUX']
             and 'HDR' in meta.get('hdr', '')

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -37,15 +37,17 @@ class BLU(UNIT3D):
 
         if not meta.get('is_disc'):
             container = meta.get('container', '').lower()
-            if container != 'mkv':
-                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
-                    console.print(f"[bold red]Container '{container.upper()}' is generally not allowed for non-disc releases on {self.tracker}.[/bold red]")
-                    console.print("[bold red]Rules: Remuxes, Encodes, WEB-DL and untouched HDTV must be MKV. Exceptions: DV P5 (MP4), HDTV (.ts).[/bold red]")
-                    if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
-                        return False
-                else:
-                    return False
-        
+            type_name = meta.get('type', '').upper()
+            allowed = ['mkv']
+            if type_name == 'HDTV':
+                allowed.append('ts')
+            if type_name in ['WEBDL', 'HDTV'] and "DV" in meta.get('hdr', '') and "HDR" not in meta.get('hdr', ''):
+                allowed.append('mp4')
+
+            if container not in allowed:
+                console.print(f"[bold red]For this release, {self.tracker} requires one of the following containers: {', '.join([a.upper() for a in allowed])}[/bold red]")
+                return False
+
         if (
             meta['type'] in ['ENCODE', 'REMUX']
             and 'HDR' in meta.get('hdr', '')


### PR DESCRIPTION
There are exceptions, so prompts the user if they want to continue.

> 5.1 General rules for discs 
> 5.1.1 Must use one of the following containers: BDMV, HDDVD_TS, or VIDEO_TS folders.
> 5.3 Remuxes
>   5.3.2 Must be in an MKV container.
> 5.4 WEB-DL and untouched HDTV 
>   5.4.2 Must use an MKV container. 
>     5.4.2.1 Exception: Dolby Vision profile 5 content may use an MP4 container.
>     5.4.2.2 Exception: HDTV may use .ts.
> 5.5 Encodes
>   5.5.4 Must be in an MKV container.