### PR TITLE
Add NOGROUP suffix if not disc for BHD

### DIFF
--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -510,5 +510,10 @@ class BHD:
             audio = str(meta.get('audio', ''))
             audio = ' '.join(audio.split())
             name = name.replace(audio, f"{meta.get('video_codec')} {audio}")
+
         name = name.replace("DD+", "DDP")
+
+        if not meta.get('tag') and meta.get('type') in ['REMUX', 'ENCODE', 'WEBDL', 'WEBRIP']:
+            name = f"{name}-NOGROUP"
+
         return name

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -513,7 +513,7 @@ class BHD:
 
         name = name.replace("DD+", "DDP")
 
-        if not meta.get('tag') and meta.get('type') in ['REMUX', 'ENCODE', 'WEBDL', 'WEBRIP']:
+        if not meta.get('tag') and not meta.get('is_disc'):
             name = f"{name}-NOGROUP"
 
         return name


### PR DESCRIPTION
Adheres to rule 3.3.9. _Technically_ they don't specify WEBRIP should have `NOGROUP` but I would be surprised if that was really the case, it's probably just missed off the rule.

Note this does not solve for rule 3.3.8 - that would require inspection of the folder names. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Torrent names now include an identifying suffix for items without tags that are not disc releases, enhancing library organization and discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->