### PR TITLE
feat: add MidnightScene (MNS) tracker support

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -350,7 +350,7 @@ config = {
 
     "TRACKERS": {
         # Which trackers do you want to upload to?
-        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, CBR, CZ, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
+        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, CBR, CZ, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MNS, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
         # Only add the trackers you want to upload to on a regular basis
         "default_trackers": "",
 
@@ -674,6 +674,14 @@ config = {
             "api_key": "",
             "anon": False,
             # Send uploads to LUME modq for staff approval
+            "modq": False,
+        },
+        "MNS": {
+            # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
+            "link_dir_name": "",
+            "api_key": "",
+            "anon": False,
+            # Send uploads to MNS modq for staff approval
             "modq": False,
         },
         "MTV": {

--- a/src/trackers/MNS.py
+++ b/src/trackers/MNS.py
@@ -1,0 +1,85 @@
+# Upload Assistant — MidnightScene (UNIT3D based)
+from typing import Any
+
+from src.trackers.COMMON import COMMON
+from src.trackers.UNIT3D import UNIT3D
+
+Meta = dict[str, Any]
+Config = dict[str, Any]
+
+
+class MNS(UNIT3D):
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, tracker_name='MNS')
+        self.config = config
+        self.common = COMMON(config)
+        self.tracker = 'MNS'
+        self.base_url = 'https://midnightscene.cc'
+        self.id_url = f'{self.base_url}/api/torrents/'
+        self.upload_url = f'{self.base_url}/api/torrents/upload'
+        self.search_url = f'{self.base_url}/api/torrents/filter'
+        self.torrent_url = f'{self.base_url}/torrents/'
+        self.banned_groups = [""]
+
+    async def get_additional_data(self, meta: Meta) -> dict[str, str]:
+        return {
+            'mod_queue_opt_in': await self.get_flag(meta, 'modq'),
+        }
+
+    async def get_category_id(
+        self,
+        meta: Meta,
+        category: str = "",
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = reverse
+        category_map = {
+            'MOVIE': '1',
+            'TV': '2',
+        }
+        if mapping_only:
+            return category_map
+        selected = category or meta['category']
+        return {'category_id': category_map.get(selected, '0')}
+
+    async def get_type_id(
+        self,
+        meta: Meta,
+        type: str = "",
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = reverse
+        type_map = {
+            'DISC': '1',
+            'REMUX': '2',
+            'ENCODE': '3',
+            'WEBDL': '4',
+            'WEBRIP': '5',
+            'HDTV': '6',
+        }
+        if mapping_only:
+            return type_map
+        selected = type or meta['type']
+        return {'type_id': type_map.get(selected, '0')}
+
+    async def get_resolution_id(
+        self,
+        meta: Meta,
+        resolution: str = "",
+        reverse: bool = False,
+        mapping_only: bool = False,
+    ) -> dict[str, str]:
+        _ = reverse
+        resolution_map = {
+            '4320p': '1',
+            '2160p': '2',
+            '1080p': '3',
+            '1080i': '4',
+            '720p': '5',
+        }
+        if mapping_only:
+            return resolution_map
+        selected = resolution or meta['resolution']
+        return {'resolution_id': resolution_map.get(selected, '10')}

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -51,6 +51,7 @@ from src.trackers.LDU import LDU
 from src.trackers.LST import LST
 from src.trackers.LT import LT
 from src.trackers.LUME import LUME
+from src.trackers.MNS import MNS
 from src.trackers.MTV import MTV
 from src.trackers.NBL import NBL
 from src.trackers.OE import OE
@@ -1339,14 +1340,14 @@ class TRACKER_SETUP:
 tracker_class_map: dict[str, type[Any]] = {
     'A4K': A4K, 'ACM': ACM, 'AITHER': AITHER, 'ANT': ANT, 'AR': AR, 'ASC': ASC, 'AZ': AZ, 'BHD': BHD, 'BHDTV': BHDTV, 'BJS': BJS, 'BLU': BLU, 'BT': BT, 'CBR': CBR,
     'CZ': CZ, 'DC': DC, 'DP': DP, 'DT': DT, 'EMUW': EMUW, 'FNP': FNP, 'FF': FF, 'FL': FL, 'FRIKI': FRIKI, 'GPW': GPW, 'HDB': HDB, 'HDS': HDS, 'HDT': HDT, 'HHD': HHD, 'HUNO': HUNO, 'ITT': ITT,
-    'IHD': IHD, 'IS': IS, 'LCD': LCD, 'LDU': LDU, 'LST': LST, 'LT': LT, 'LUME': LUME, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PHD': PHD, 'PT': PT, 'PTP': PTP, 'PTER': PTER, 'PTS': PTS, 'PTT': PTT,
+    'IHD': IHD, 'IS': IS, 'LCD': LCD, 'LDU': LDU, 'LST': LST, 'LT': LT, 'LUME': LUME, 'MNS': MNS, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PHD': PHD, 'PT': PT, 'PTP': PTP, 'PTER': PTER, 'PTS': PTS, 'PTT': PTT,
     'R4E': R4E, 'RAS': RAS, 'RF': RF, 'RTF': RTF, 'SAM': SAM, 'SHRI': SHRI, 'SN': SN, 'SP': SP, 'SPD': SPD, 'STC': STC, 'THR': THR,
     'TIK': TIK, 'TL': TL, 'TLZ': TLZ, 'TOS': TOS, 'TVC': TVC, 'TTG': TTG, 'TTR': TTR, 'ULCX': ULCX, 'UTP': UTP, 'YOINK': YOINK, 'YUS': YUS
 }
 
 api_trackers = {
     'A4K', 'ACM', 'AITHER', 'BHD', 'BLU', 'CBR', 'DP', 'DT', 'EMUW', 'FNP', 'FRIKI', 'HHD', 'HUNO', 'IHD', 'ITT', 'LCD', 'LDU', 'LST', 'LT', 'LUME',
-    'OE', 'OTW', 'PT', 'PTT', 'RAS', 'RF', 'R4E', 'SAM', 'SHRI', 'SP', 'STC', 'TIK', 'TLZ', 'TOS', 'TTR', 'ULCX', 'UTP', 'YOINK', 'YUS'
+    'MNS', 'OE', 'OTW', 'PT', 'PTT', 'RAS', 'RF', 'R4E', 'SAM', 'SHRI', 'SP', 'STC', 'TIK', 'TLZ', 'TOS', 'TTR', 'ULCX', 'UTP', 'YOINK', 'YUS'
 }
 
 other_api_trackers = {


### PR DESCRIPTION
- Add MNS.py UNIT3D-based tracker module for midnightscene.cc
- Register MNS in tracker_class_map and api_trackers
- Add MNS configuration section to example-config.py
- Supports Movie/TV categories, DISC/REMUX/ENCODE/WEBDL/WEBRIP/HDTV types
- Supports 4320p/2160p/1080p/1080i/720p resolutions
- Includes modq opt-in support