### PR TITLE
fix: dolby vision and hlg tonemapping

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1027,7 +1027,7 @@ async def screenshots(
                     hdr_tonemap = False
                     console.print("[yellow]FFMPEG failed tonemap checking.[/yellow]")
                     await asyncio.sleep(2)
-                if not libplacebo and "HDR" not in meta.get('hdr', ''):
+                if not libplacebo and not any(x in meta.get('hdr', '') for x in ['HDR', 'DV', 'HLG']):
                     hdr_tonemap = False
             else:
                 hdr_tonemap = True
@@ -1336,9 +1336,10 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
                         console.print("[cyan]Using libplacebo tonemapping[/cyan]")
                 else:
                     vf_filters.extend([
-                        "zscale=transfer=linear",
+                        "format=yuv420p10le", # Ensure 10-bit handling
+                        "zscale=tin=smpte2084:pin=bt2020:t=linear",
                         f"tonemap=tonemap={algorithm}:desat={desat}",
-                        "zscale=transfer=bt709",
+                        "zscale=t=bt709:p=bt709",
                         "format=rgb24",
                     ])
                     if loglevel == 'verbose' or (meta and meta.get('debug', False)):
@@ -1690,45 +1691,29 @@ async def check_libplacebo_compatibility(w_sar: float, h_sar: float, width: floa
 
     async def run_check(w_sar: float, h_sar: float, width: float, height: float, path: str, ss_time: str, _image_path: str, loglevel: str, meta: dict[str, Any], try_libplacebo: bool = False, test_image_path: str = "") -> bool:
         filter_parts: list[str] = []
-        input_label = "[0:v]"
-        output_map = "0:v"  # Default output mapping
-
-        if w_sar != 1 or h_sar != 1:
-            scaled_w = round_to_even(width * w_sar)
-            scaled_h = round_to_even(height * h_sar)
-            filter_parts.append(f"{input_label}scale={scaled_w}:{scaled_h}[scaled]")
-            input_label = "[scaled]"
-            output_map = "[scaled]"
-
-        # Add libplacebo filter with output label
+        
+        # Ensure we handle the input format for HDR/DV sources
+        vf_chain = ""
         if try_libplacebo:
-            filter_parts.append(f"{input_label}libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:range=tv[out]")
-            output_map = "[out]"
+            # libplacebo check
+            filter_parts.append("zscale=t=linear:npl=100") # Pre-conversion help
+            filter_parts.append("libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:range=tv")
+            vf_chain = ",".join(filter_parts)
         else:
-            # Use -vf for zscale/tonemap chain, no output label or -map needed
-            vf_chain = f"zscale=transfer=linear,tonemap=tonemap={algorithm}:desat={desat},zscale=transfer=bt709,format=rgb24"
+            # zscale check - Explicitly define input transfer for DV/HDR10 (smpte2084)
+            vf_chain = f"zscale=tin=smpte2084:pin=bt2020:t=linear,tonemap=tonemap={algorithm}:desat={desat},zscale=t=bt709:p=bt709,format=rgb24"
 
-        # Build ffmpeg-python command and run
         if try_libplacebo:
-            info_cmd: Any = cast(Any, ffmpeg).input(path, ss=str(ss_time)).output(
-                test_image_path,
-                vframes=1,
-                pix_fmt='rgb24'
-            ).global_args('-y', '-loglevel', 'quiet', '-init_hw_device', 'vulkan', '-filter_complex', ','.join(filter_parts), '-map', output_map)
+            info_cmd = cast(Any, ffmpeg).input(path, ss=str(ss_time)).output(
+                test_image_path, vframes=1, pix_fmt='rgb24'
+            ).global_args('-y', '-loglevel', 'quiet', '-init_hw_device', 'vulkan', '-vf', vf_chain)
         else:
-            vf_chain = f"zscale=transfer=linear,tonemap=tonemap={algorithm}:desat={desat},zscale=transfer=bt709,format=rgb24"
-            info_cmd: Any = cast(Any, ffmpeg).input(path, ss=str(ss_time)).output(
-                test_image_path,
-                vframes=1,
-                vf=vf_chain,
-                pix_fmt='rgb24'
+            info_cmd = cast(Any, ffmpeg).input(path, ss=str(ss_time)).output(
+                test_image_path, vframes=1, vf=vf_chain
             ).global_args('-y', '-loglevel', 'quiet')
 
-        if loglevel == 'verbose' or (meta and meta.get('debug', False)):
-            console.print(f"[cyan]libplacebo compatibility test command: {' '.join(info_cmd.compile())}[/cyan]")
-
         try:
-            retcode, _stdout, _stderr = await run_ffmpeg(info_cmd)
+            retcode, _, _ = await run_ffmpeg(info_cmd)
             return retcode == 0
         except Exception:
             return False

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -391,10 +391,12 @@ async def capture_disc_task(index: int, file: str, ss_time: str, image_path: str
         vf_filters: list[str] = []
 
         if hdr_tonemap:
+            transfer_in = "arib-std-b67" if "HLG" in meta.get('hdr', '') else "smpte2084"
             vf_filters.extend([
-                "zscale=transfer=linear",
+                "format=yuv420p10le",
+                f"zscale=tin={transfer_in}:pin=bt2020:t=linear",
                 f"tonemap=tonemap={algorithm}:desat={desat}",
-                "zscale=transfer=bt709",
+                "zscale=t=bt709:p=bt709",
                 "format=rgb24"
             ])
 
@@ -1317,36 +1319,35 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
 
             threads_value = set_ffmpeg_threads()
             threads_val = threads_value[1]
+                
+            # Determine Input Transfer
+            if "HLG" in meta.get('hdr', ''):
+                transfer_in = "arib-std-b67"
+            elif any(x in meta.get('hdr', '') for x in ["PQ", "HDR", "DV"]):
+                transfer_in = "smpte2084"
+            else:
+                transfer_in = "bt709"
+
             vf_filters: list[str] = []
 
+            # Handle Scaling
             if w_sar != 1 or h_sar != 1:
-                scaled_w = round_to_even(width * w_sar)
-                scaled_h = round_to_even(height * h_sar)
-                vf_filters.append(f"scale={scaled_w}:{scaled_h}")
-                if loglevel == 'verbose' or (meta and meta.get('debug', False)):
-                    console.print(f"[cyan]Applied PAR scale -> {scaled_w}x{scaled_h}[/cyan]")
+                vf_filters.append(f"scale={round_to_even(width * w_sar)}:{round_to_even(height * h_sar)}")
 
+            # Handle Tonemapping
             if hdr_tonemap:
                 if meta.get('libplacebo', False):
-                    vf_filters.append(
-                        "libplacebo=tonemapping=hable:colorspace=bt709:"
-                        "color_primaries=bt709:color_trc=bt709:range=tv"
-                    )
-                    if loglevel == 'verbose' or (meta and meta.get('debug', False)):
-                        console.print("[cyan]Using libplacebo tonemapping[/cyan]")
+                    vf_filters.append("libplacebo=tonemapping=hable:colorspace=bt709:color_primaries=bt709:color_trc=bt709:range=tv")
                 else:
                     vf_filters.extend([
-                        "format=yuv420p10le", # Ensure 10-bit handling
-                        "zscale=tin=smpte2084:pin=bt2020:t=linear",
+                        "format=yuv420p10le",
+                        f"zscale=tin={transfer_in}:pin=bt2020:t=linear",
                         f"tonemap=tonemap={algorithm}:desat={desat}",
                         "zscale=t=bt709:p=bt709",
-                        "format=rgb24",
                     ])
-                    if loglevel == 'verbose' or (meta and meta.get('debug', False)):
-                        console.print(f"[cyan]Using zscale tonemap chain (algo={algorithm}, desat={desat})[/cyan]")
 
             vf_filters.append("format=rgb24")
-            vf_chain = ",".join(vf_filters) if vf_filters else "format=rgb24"
+            vf_chain = ",".join(vf_filters)
 
             if loglevel == 'verbose' or (meta and meta.get('debug', False)):
                 console.print(f"[cyan]Final -vf chain: {vf_chain}[/cyan]")
@@ -1448,10 +1449,13 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
             vf_filters.append(f"scale={scaled_w}:{scaled_h}")
 
         if hdr_tonemap:
+            # Explicitly define input transfer for HLG vs HDR10/DV
+            transfer_in = "arib-std-b67" if "HLG" in meta.get('hdr', '') else "smpte2084"
             vf_filters.extend([
-                "zscale=transfer=linear",
+                "format=yuv420p10le",
+                f"zscale=tin={transfer_in}:pin=bt2020:t=linear",
                 f"tonemap=tonemap={algorithm}:desat={desat}",
-                "zscale=transfer=bt709",
+                "zscale=t=bt709:p=bt709",
                 "format=rgb24",
             ])
 
@@ -1700,8 +1704,9 @@ async def check_libplacebo_compatibility(w_sar: float, h_sar: float, width: floa
             filter_parts.append("libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:range=tv")
             vf_chain = ",".join(filter_parts)
         else:
-            # zscale check - Explicitly define input transfer for DV/HDR10 (smpte2084)
-            vf_chain = f"zscale=tin=smpte2084:pin=bt2020:t=linear,tonemap=tonemap={algorithm}:desat={desat},zscale=t=bt709:p=bt709,format=rgb24"
+            # zscale check - Handle HLG vs HDR10/DV
+            transfer_in = "arib-std-b67" if "HLG" in meta.get('hdr', '') else "smpte2084"
+            vf_chain = f"zscale=tin={transfer_in}:pin=bt2020:t=linear,tonemap=tonemap={algorithm}:desat={desat},zscale=t=bt709:p=bt709,format=rgb24"
 
         if try_libplacebo:
             info_cmd = cast(Any, ffmpeg).input(path, ss=str(ss_time)).output(


### PR DESCRIPTION
### **Problem**

DV (and HLG I assume, never tested) were failing straight out of the gate, resulting in an "ffmpeg tonemap check fail" message and, on DV content, green-tinted images. So I tried to fix myself with the help of workik. It's now working; however, I'm not sure if I've completely butchered the takescreens.py file and broken anything else.

### Attempted Changes (with help from 'workik')

The screenshots function has been updated to include "DV" and "HLG".  Originally, the code was disabling tonemapping due to DV or HLG not being present, resulting in a "Tonemap check fail" error message and UA failing the compatibility check.

Improved the check_libplacebo_compatibility function by updating the run_check inner function to better handle high-bit-depth DV sources during the test.

Fixed the capture_screenshot filter chain to ensure the zscale fallback (used when libplacebo fails) explicitly handles the PQ transfer function (smpte2084) used by Dolby Vision.

HLG tonemapping improvements were also added by including an "arib-std-b67" check.