### PR TITLE
chore: update qbittorrent-api dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pycountry==24.6.1
 pyimgbox==1.0.7
 pymediainfo==7.0.1
 pyotp==2.9.0
-qbittorrent-api==2025.7.0
+qbittorrent-api==2026.5.0
 regex==2025.11.3
 requests==2.32.5
 rich==13.9.4


### PR DESCRIPTION
qBittorrent authentication isn't working properly in the new version (v5.2.0) released yesterday.