### PR TITLE
fix: Uploading FraMeSToR releases from BHD to Aither

### DIFF
--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -582,7 +582,13 @@ class DescriptionBuilder:
                 desc_parts.append(f"[center][pre]{episode_overview}[/pre][/center]\n")
 
         # Description that may come from API requests
-        meta_description = meta.get("description", "")
+        meta_description_value = meta.get("description", "")
+        if isinstance(meta_description_value, str):
+            meta_description = meta_description_value
+        elif meta_description_value is None:
+            meta_description = ""
+        else:
+            meta_description = str(meta_description_value)
         # Add FraMeSToR NFO to Aither
         if self.tracker == "AITHER" and "framestor" in meta and meta["framestor"]:
             nfo_content = meta.get("description_nfo_content", "")


### PR DESCRIPTION
When grabbing data from BHD for a FraMeSToR release and discarding the description this error would occur:

Upload failed: expected string or bytes-like object Traceback (most recent call last):
  File "/Upload-Assistant/src/trackerhandle.py", line 141, in process_single_tracker
    is_uploaded = await tracker_class.upload(meta, disctype_value)
  File "/Upload-Assistant/src/trackers/UNIT3D.py", line 455, in upload
    data = await self.get_data(meta)
  File "/Upload-Assistant/src/trackers/UNIT3D.py", line 393, in get_data
    results = await asyncio.gather(
  File "/Upload-Assistant/src/trackers/UNIT3D.py", line 191, in get_description
    "description": await DescriptionBuilder(self.tracker, self.config).unit3d_edit_desc(
  File "/Upload-Assistant/src/get_desc.py", line 599, in unit3d_edit_desc
    meta_description = re.sub(
  File "/usr/lib/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object