### PR TITLE
Fix key type for frame_info retrieval

### DIFF
--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -1456,7 +1456,7 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
 
         if meta.get('frame_overlay', False):
             # Get frame info from pre-collected data if available
-            frame_info = meta.get('frame_info_map', {}).get(ss_time, {})
+            frame_info = meta.get('frame_info_map', {}).get(str(ss_time), {})
 
             frame_rate = meta.get('frame_rate', 24.0)
             frame_number = int(ss_time * frame_rate)

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -400,7 +400,7 @@ async def capture_disc_task(index: int, file: str, ss_time: str, image_path: str
 
         if meta.get('frame_overlay', False):
             # Get frame info from pre-collected data if available
-            frame_info = meta.get('frame_info_map', {}).get(ss_time, {})
+            frame_info = meta.get('frame_info_map', {}).get(str(ss_time), {})
 
             frame_rate = meta.get('frame_rate', 24.0)
             frame_number = int(float(ss_time) * frame_rate)
@@ -785,7 +785,7 @@ async def capture_dvd_screenshot(task: tuple[int, str, str, str, dict[str, Any],
 
         if meta.get('frame_overlay', False):
             # Get frame info from pre-collected data if available
-            frame_info = meta.get('frame_info_map', {}).get(seek_time, {})
+            frame_info = meta.get('frame_info_map', {}).get(str(seek_time), {})
 
             frame_rate = meta.get('frame_rate', 24.0)
             frame_number = int(seek_time * frame_rate)


### PR DESCRIPTION
I had noticed that the screenshot overlay make by ffmpeg was no longer able to retrieve the frame type and was systematically printing:
`Frame Type: Unknown`
Found the reason for that and fixed it.
I tested that the fix works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed frame overlay text display to correctly match pre-collected frame metadata, ensuring timestamp information is properly synchronized when capturing and displaying video frames.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1363)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->