### PR TITLE
Fix SP modq not being applied

### DIFF
--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -140,3 +140,10 @@ class SP(UNIT3D):
                 return False
 
         return should_continue
+
+    async def get_additional_data(self, meta: Meta) -> dict[str, Any]:
+        data = {
+            'mod_queue_opt_in': await self.get_flag(meta, 'modq'),
+        }
+
+        return data


### PR DESCRIPTION
There was a PR #1291 that fixed a lot of trackers, but apparently not enough :)

Learned that modq option isn't applied to SP the hard way (using v7.1.6). I checked with `--debug` and, indeed, `mod_queue_opt_in` was missing from the request payload despite `"modq": True` in the config.

I just added `get_additional_data` method to the SP class, hopefully it's fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced upload process with new moderator queue configuration options

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1364)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->