### PR TITLE
Add CZTeam (CZT) tracker

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -350,7 +350,7 @@ config = {
 
     "TRACKERS": {
         # Which trackers do you want to upload to?
-        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, CBR, CZ, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
+        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, CBR, CZ, CZT, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
         # Only add the trackers you want to upload to on a regular basis
         "default_trackers": "",
 
@@ -488,6 +488,24 @@ config = {
             # If True, the script performs a basic rules compliance check (e.g., codecs, region).
             # This does not cover all tracker rules. Set to False to disable.
             "check_for_rules": True,
+        },
+        "CZT": {
+            # CZTeam (czteam.me) — Romanian private tracker, BTSource lineage.
+            # Auth is session-cookie based: provide username + password and the
+            # plugin will log in via /takelogin.php (CSRF token is fetched
+            # automatically) and persist the session in data/cookies/CZT.json.
+            "link_dir_name": "",
+            "username": "",
+            "password": "",
+            # Leave totp empty unless your account has 2FA enabled.
+            "totp": "",
+            # CZTeam whitelists ONLY the bare announce URL on takeupload.php —
+            # the user's passkey gets injected by download.php when they pull
+            # the .torrent back, so DON'T put your passkey here.
+            "announce_url": "https://tracker.czteam.me/announce",
+            "anon": False,
+            # Override only if you proxy the site via a different hostname.
+            "base_url": "https://czteam.me",
         },
         "DC": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name

--- a/docs/CZTEAM.md
+++ b/docs/CZTEAM.md
@@ -1,0 +1,298 @@
+# Uploading to CZTeam with Upload Assistant
+
+CZTeam (czteam.me) is a Romanian private tracker. This fork of
+Upload-Assistant adds CZTeam support via a new tracker plugin (`CZT`),
+which slots in alongside every other tracker UA already supports — so
+you can include CZTeam in any multi-tracker upload.
+
+This guide walks through setup and your first upload.
+
+---
+
+## 1. Prerequisites
+
+You need:
+
+- **A CZTeam account** in good standing. Upload is open to all logged-in
+  users (you don't need uploader class).
+- **The CZT fork of Upload-Assistant.** If you have an existing UA install,
+  switch its remote; otherwise clone fresh.
+- **Browser-exported cookies for czteam.me.** CZTeam protects the login
+  form with Cloudflare Turnstile, so UA cannot log in for you — you log
+  in once in a real browser, export the cookies, and hand them to UA.
+  After that everything runs unattended until the cookies expire.
+
+The rest of the UA prerequisites (Python ≥ 3.9, ffmpeg, mediainfo, TMDb
+key, image host config) are unchanged — see the project README.
+
+## 2. Install the fork
+
+```sh
+git clone -b czteam https://github.com/<you>/Upload-Assistant.git
+cd Upload-Assistant
+python3 -m venv venv
+venv/bin/pip install -r requirements.txt
+cp data/example-config.py data/config.py
+```
+
+If you already had UA installed, add this fork as a remote and check out
+the `czteam` branch instead:
+
+```sh
+cd Upload-Assistant
+git remote add czteam https://github.com/<you>/Upload-Assistant.git
+git fetch czteam
+git checkout -b czteam czteam/czteam
+```
+
+## 3. Configure `data/config.py`
+
+Find the `CZT` block inside `TRACKERS` and fill it in:
+
+```python
+"CZT": {
+    # Optional sym/hard-link subdirectory name.
+    "link_dir_name": "",
+    "username": "your_czteam_username",
+    "password": "your_czteam_password",  # used as a fallback; cookies are preferred
+    "totp": "",                           # leave empty unless you have 2FA enabled
+    # CZTeam whitelists ONLY the bare announce URL on upload — the
+    # passkey gets injected by download.php when the .torrent is fetched.
+    # Don't put your passkey in here.
+    "announce_url": "https://tracker.czteam.me/announce",
+    "anon": False,
+    "base_url": "https://czteam.me",
+},
+```
+
+Then add `CZT` to `default_trackers` if you want it picked up by default:
+
+```python
+"default_trackers": "BLU, AITHER, HUNO, CZT",
+```
+
+## 4. Export your cookies (one-time per ~30 days)
+
+CZTeam's login page uses Cloudflare Turnstile, which a script can't
+solve. UA's plugin works around this by reading cookies a real browser
+already obtained, the same way UA already handles FileList, HDB, and
+other login-captcha trackers.
+
+**Steps:**
+
+1. Log in to https://czteam.me in your browser. Solve the Turnstile
+   widget. Make sure "Remember me" is checked so the cookies persist.
+2. Install a "Cookies.txt" extension that exports cookies in JSON form:
+    - Chrome / Edge: *Get cookies.txt LOCALLY* — pick "JSON" output
+    - Firefox: *cookies.txt one click* — choose JSON
+    - Any tool that produces an object keyed by cookie name will work.
+3. Visit czteam.me in the active tab, click the extension, **Export →
+   JSON**. Save the file as:
+
+   ```
+   <Upload-Assistant>/data/cookies/CZT.json
+   ```
+
+   The file should look like (the three cookies CZTeam uses):
+
+   ```json
+   {
+     "uid":   {"value": "276913"},
+     "pass":  {"value": "..."},
+     "hashv": {"value": "..."}
+   }
+   ```
+
+   If your extension exports a flat object `{"uid": "276913", ...}`,
+   wrap each value in `{"value": "..."}` — that's the shape UA's
+   `CookieValidator` expects.
+
+4. (Optional but recommended) Restrict the file: `chmod 600
+   data/cookies/CZT.json`. It contains a credential equivalent to your
+   password until it expires.
+
+You'll re-export when UA reports "cookie validation failed" — typically
+once a month or after a password change.
+
+## 5. First upload — dry run
+
+Always start with `--debug` so UA prints the request shape without
+actually posting it:
+
+```sh
+venv/bin/python upload.py \
+    "/path/to/Some.Release.2024.1080p.WEB-DL.H.264-GROUP.mkv" \
+    --trackers CZT \
+    --debug
+```
+
+You should see something like:
+
+```
+[CZT] Validating credentials … logged in
+[CZT] https://czteam.me/takeupload.php
+[CZT] {
+  'name':       'Some.Release.2024.1080p.WEB-DL.H.264-GROUP',
+  'type':       '29',
+  'descr':      '<MediaInfo paste …>',
+  'user_descr': '<your BBCode body …>',
+  'resolution': '1080p',
+  'codec':      'H.264',
+  'container':  'MKV',
+  'source':     'WEB-DL',
+  'url':        'https://www.imdb.com/title/tt1234567/',
+  …
+}
+Debug mode enabled, not uploading.
+```
+
+Sanity-check the values. If something looks off (wrong category, bad
+codec mapping, etc.), see the troubleshooting section below.
+
+## 6. Real upload
+
+Drop `--debug` to go live:
+
+```sh
+venv/bin/python upload.py \
+    "/path/to/Some.Release.2024.1080p.WEB-DL.H.264-GROUP.mkv" \
+    --trackers CZT
+```
+
+UA will:
+
+1. Generate mediainfo + screenshots + BBCode description (using its
+   normal pipeline).
+2. Build a fresh `.torrent` with the bare announce URL.
+3. Fetch the upload form, mint a CSRF token, and POST to
+   `https://czteam.me/takeupload.php`.
+4. Parse `details.php?id=N` from the response — that's your new
+   torrent.
+5. Re-download the .torrent via `download.php?torrent=N` (with your
+   passkey baked into the announce URL) and hand it to your client for
+   fast-resume cross-seed.
+
+The console will print:
+
+```
+[ok] CZT upload: https://czteam.me/details.php?id=219234
+```
+
+## 7. Multi-tracker uploads
+
+This is where UA earns its keep. With `default_trackers = "BLU, AITHER,
+HUNO, CZT"`, a single command uploads to all four:
+
+```sh
+venv/bin/python upload.py "/path/to/Release.mkv"
+```
+
+Each tracker's plugin runs concurrently; CZT uses its own cookies and
+csrf_token mint, independent of the others.
+
+---
+
+## Category mapping
+
+The plugin maps UA's `meta` to CZTeam categories like this:
+
+| UA category | UA hints | CZTeam id | Name |
+|---|---|---:|---|
+| MOVIE | `is_disc=BDMV`, RO audio/sub | 36 | Full BluRay-RO |
+| MOVIE | `is_disc=BDMV` | 29 | Movies/HD |
+| MOVIE | `is_disc=DVD`, RO audio/sub | 28 | Movies/DVD-RO |
+| MOVIE | `is_disc=DVD` | 20 | Movies/DVD-R |
+| MOVIE | WEB-DL/WEBRip/HDTV/ENCODE/REMUX 720p+ + RO | 33 | Movies/HDTV-RO |
+| MOVIE | WEB-DL/WEBRip/HDTV/ENCODE/REMUX 720p+ | 29 | Movies/HD |
+| MOVIE | XviD or SD | 19 | Movies/XviD |
+| MOVIE | (default) | 29 | Movies/HD |
+| TV | 720p+ + RO | 34 | TvEps/HD-RO |
+| TV | 720p+ | 5 | TvEps/HD |
+| TV | (default) | 7 | TvEps |
+| Anime | (any) | 23 | Anime |
+
+Romanian audio/subs are auto-detected from `mediainfo` (`Language=ro`,
+`Language=rum`, `Language=ron`) and from BluRay BDInfo's subtitle/audio
+language lists.
+
+If the plugin picks the wrong bucket, edit `get_category_id()` in
+`src/trackers/CZT.py` and PR upstream (this fork).
+
+---
+
+## Troubleshooting
+
+### `Captcha check failed (HTTP 403)` on validate_credentials
+
+UA tried to log in (no cookie file present, or the existing one is
+stale) and hit Turnstile. Re-export cookies from your browser as
+described in step 4.
+
+### `Invalid announce URL` on upload
+
+Your `announce_url` in `data/config.py` has a passkey or extra path in
+it. CZTeam whitelists only `https://tracker.czteam.me/announce`. The
+passkey is injected by `download.php` when you fetch the .torrent
+back — you never put it in the upload-side announce URL.
+
+### `This torrent has already been uploaded (id N)`
+
+CZTeam dedupes by info_hash. Someone (often you, on a previous attempt)
+already uploaded the same release. Pull the existing one via
+`download.php?torrent=N` if you want to seed it.
+
+### `Category is not valid`
+
+The plugin produced a `type` field that doesn't match a live category
+on CZTeam. Either the category was retired, or `get_category_id()`
+returned something odd. Run with `--debug` and check the `'type'` value
+against the table above; file an issue with the meta dump.
+
+### `Captcha check failed` returned but I'm logged in
+
+That's actually CSRF, not Turnstile — they share the 403 status. The
+plugin re-fetches `/upload.php` before every upload to get a fresh
+`csrf_token`. If you see this repeatedly, your `PHPSESSID` cookie is
+not being sent. Make sure the export included `PHPSESSID` (some
+extensions skip session cookies by default).
+
+### Upload "succeeded" but the torrent isn't in my profile
+
+CZTeam torrents only become **visible** once at least one seeder is
+connected to the tracker. Open your client, add the re-issued
+`.torrent` UA dropped (it landed in your usual UA tmp dir), and
+announce. The torrent appears in browse within seconds.
+
+---
+
+## How the plugin works (for the curious)
+
+The plugin is `src/trackers/CZT.py` (~290 lines). It does **not** use
+the UNIT3D base class — CZTeam isn't a UNIT3D site. It's modeled on
+`FL.py` (FileList), which is the closest cousin: same BTSource/NVTracker
+lineage, same form-POST-to-takeupload.php upload mechanic.
+
+End-to-end flow:
+
+1. **`validate_credentials`** — checks `data/cookies/CZT.json` exists
+   and that hitting `/index.php` with those cookies returns a logged-in
+   page. If not, falls back to `login()` (which will fail on Turnstile —
+   that's the user's cue to re-export).
+2. **`upload`** —
+    a. `COMMON.create_torrent_for_upload()` writes a fresh
+       `[CZT].torrent` with `announce = https://tracker.czteam.me/announce`
+       and `info.source = CzT`.
+    b. GET `/upload.php` — parse `<input name="csrf_token" value="…">`.
+    c. POST multipart `/takeupload.php` with `file`, `name`, `type`,
+       `descr` (MediaInfo paste), `user_descr` (BBCode), `url` (IMDB
+       URL — server extracts the tt-id), `resolution`, `codec`,
+       `container`, `source`, `csrf_token`.
+    d. Regex `details\.php\?id=(\d+)` on the response. Surface
+       `<p style="color:red">…</p>` errors verbatim if the upload was
+       rejected.
+3. **`download_new_torrent`** — GET `/download.php?torrent=N`, write
+   the result to `[CZT].torrent` for client injection. The .torrent
+   that comes back has the user's passkey baked into the announce URL.
+
+The plugin is registered in `src/trackersetup.py` (in
+`tracker_class_map` and `http_trackers`).

--- a/src/trackers/CZT.py
+++ b/src/trackers/CZT.py
@@ -1,0 +1,336 @@
+# Upload Assistant — CZTeam (czteam.me) tracker plugin
+#
+# CZTeam is BTSource/NVTracker-lineage, same family as FileList. Login + upload
+# go through the regular user-facing endpoints (login.php → takelogin.php,
+# upload.php → takeupload.php) using session cookies and a per-form CSRF token.
+import asyncio
+import os
+import re
+from typing import Any, Optional, cast
+from urllib.parse import urljoin
+
+import aiofiles
+import cli_ui
+import httpx
+from bs4 import BeautifulSoup
+
+from src.console import console
+from src.cookie_auth import CookieValidator
+from src.exceptions import *  # noqa F403
+from src.trackers.COMMON import COMMON
+
+
+class CZT:
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.config: dict[str, Any] = config
+        self.tracker = 'CZT'
+        self.source_flag = 'CzT'
+        tracker_cfg = config['TRACKERS'][self.tracker]
+        self.username: str = str(tracker_cfg.get('username', '')).strip()
+        self.password: str = str(tracker_cfg.get('password', '')).strip()
+        self.totp: str = str(tracker_cfg.get('totp', '')).strip()
+        self.base_url: str = str(tracker_cfg.get('base_url', 'https://czteam.me')).rstrip('/')
+        self.anon: bool = self._is_true(tracker_cfg.get('anon', False))
+        self.banned_groups: list[str] = []
+        self.cookie_validator = CookieValidator(config)
+
+    @staticmethod
+    def _is_true(value: Any) -> bool:
+        return str(value).strip().lower() in {"true", "1", "yes"}
+
+    # CZTeam category ids (see `categories` table)
+    async def get_category_id(self, meta: dict[str, Any]) -> int:
+        has_ro_audio, has_ro_sub = self._detect_ro_tracks(meta)
+        ro = has_ro_audio or has_ro_sub
+
+        if meta.get('anime', False) is True:
+            return 23  # Anime
+
+        if meta['category'] == 'MOVIE':
+            if meta.get('is_disc') == 'BDMV':
+                return 36 if ro else 29  # Full BluRay-RO / Movies/HD
+            if meta.get('is_disc') == 'DVD':
+                return 28 if ro else 20  # Movies/DVD-RO / Movies/DVD-R
+            if str(meta.get('type', '')).upper() in {'WEBDL', 'WEBRIP', 'HDTV', 'ENCODE', 'REMUX'}:
+                if meta.get('resolution') in ('720p', '1080p', '2160p'):
+                    return 33 if ro else 29  # Movies/HDTV-RO / Movies/HD
+            # SD / XviD bucket
+            if str(meta.get('video_codec', '')).lower() in {'xvid', 'divx'} or meta.get('sd', 0) == 1:
+                return 19  # Movies/XviD
+            return 29  # default HD
+
+        if meta['category'] == 'TV':
+            if meta.get('resolution') in ('720p', '1080p', '2160p'):
+                return 34 if ro else 5  # TvEps/HD-RO / TvEps/HD
+            return 7  # TvEps
+
+        return 29
+
+    @staticmethod
+    def _meta_resolution(meta: dict[str, Any]) -> str:
+        allowed = {'480p', '576p', '720p', '1080p', '2160p'}
+        r = str(meta.get('resolution', '')).lower()
+        return r if r in allowed else ''
+
+    @staticmethod
+    def _meta_codec(meta: dict[str, Any]) -> str:
+        vc = str(meta.get('video_codec', '')).upper().replace(' ', '')
+        mapping = {
+            'H264': 'H.264', 'AVC': 'H.264', 'X264': 'x264',
+            'H265': 'H.265', 'HEVC': 'H.265', 'X265': 'x265',
+            'XVID': 'XviD', 'AV1': 'AV1',
+        }
+        return mapping.get(vc, '')
+
+    @staticmethod
+    def _meta_container(meta: dict[str, Any]) -> str:
+        allowed = {'MKV', 'AVI', 'MP4', 'TS', 'ISO'}
+        c = str(meta.get('container', '')).upper()
+        return c if c in allowed else ''
+
+    @staticmethod
+    def _meta_source(meta: dict[str, Any]) -> str:
+        t = str(meta.get('type', '')).upper()
+        mapping = {
+            'DISC': 'BluRay', 'REMUX': 'BluRay', 'ENCODE': 'BluRay',
+            'WEBDL': 'WEB-DL', 'WEBRIP': 'WEBRip',
+            'HDTV': 'HDTV', 'DVDRIP': 'DVDRip',
+        }
+        if meta.get('is_disc') == 'BDMV':
+            return 'BluRay'
+        if meta.get('is_disc') == 'DVD':
+            return 'DVD'
+        return mapping.get(t, '')
+
+    @staticmethod
+    def _detect_ro_tracks(meta: dict[str, Any]) -> tuple[bool, bool]:
+        has_ro_audio = has_ro_sub = False
+        mi = meta.get('mediainfo')
+        if isinstance(mi, dict):
+            media = mi.get('media') if isinstance(mi.get('media'), dict) else {}
+            tracks = media.get('track') if isinstance(media, dict) else None
+            if isinstance(tracks, list):
+                for track in tracks:
+                    if not isinstance(track, dict):
+                        continue
+                    lang = str(track.get('Language', '')).lower()
+                    if track.get('@type') == 'Text' and lang in ('ro', 'rum', 'ron', 'romanian'):
+                        has_ro_sub = True
+                    if track.get('@type') == 'Audio' and lang in ('ro', 'rum', 'ron', 'romanian'):
+                        has_ro_audio = True
+        bdinfo = meta.get('bdinfo')
+        if isinstance(bdinfo, dict):
+            subs = bdinfo.get('subtitles')
+            if isinstance(subs, list) and 'Romanian' in subs:
+                has_ro_sub = True
+            audio_tracks = bdinfo.get('audio')
+            if isinstance(audio_tracks, list):
+                for a in audio_tracks:
+                    if isinstance(a, dict) and a.get('language') == 'Romanian':
+                        has_ro_audio = True
+                        break
+        return has_ro_audio, has_ro_sub
+
+    @staticmethod
+    def _extract_csrf(html: str) -> Optional[str]:
+        soup = BeautifulSoup(html, 'html.parser')
+        tag = soup.find('input', {'name': 'csrf_token'})
+        if tag is None:
+            return None
+        value = tag.get('value')
+        return value if isinstance(value, str) else None
+
+    def _cookie_paths(self, meta: dict[str, Any]) -> tuple[str, str]:
+        base = meta['base_dir']
+        return (
+            os.path.abspath(f"{base}/data/cookies/CZT.json"),
+            os.path.abspath(f"{base}/data/cookies/CZT.pkl"),
+        )
+
+    def _load_cookie_dict(self, cookiefile_json: str, _cookiefile_pkl: str) -> dict[str, str]:
+        if os.path.exists(cookiefile_json):
+            raw = self.cookie_validator._load_cookies_dict_secure(cookiefile_json)  # pyright: ignore[reportPrivateUsage]
+            return {name: str(data.get('value', '')) for name, data in raw.items()}
+        return {}
+
+    async def validate_credentials(self, meta: dict[str, Any]) -> bool:
+        cookiefile_json, cookiefile_pkl = self._cookie_paths(meta)
+        if not os.path.exists(cookiefile_json):
+            await self.login(cookiefile_json)
+        ok = await self.validate_cookies(meta, cookiefile_json)
+        if not ok:
+            console.print('[red]CZT: cookie validation failed. The site may be down, the account locked, or rate-limited.')
+            try:
+                retry = cli_ui.ask_yes_no("Log in again and create a new session?")
+            except Exception:
+                retry = False
+            if retry:
+                if os.path.exists(cookiefile_json):
+                    os.remove(cookiefile_json)
+                await self.login(cookiefile_json)
+                ok = await self.validate_cookies(meta, cookiefile_json)
+        return ok
+
+    async def validate_cookies(self, meta: dict[str, Any], _cookiefile: str) -> bool:
+        cookiefile_json, cookiefile_pkl = self._cookie_paths(meta)
+        cookies = self._load_cookie_dict(cookiefile_json, cookiefile_pkl)
+        if not cookies:
+            return False
+        async with httpx.AsyncClient(cookies=cookies, timeout=30.0, follow_redirects=True) as client:
+            resp = await client.get(f'{self.base_url}/index.php')
+        if meta.get('debug'):
+            console.print(resp.url)
+        # logout.php link is rendered in the header for every authenticated page
+        return 'logout.php' in resp.text or 'Logout' in resp.text
+
+    async def login(self, cookiefile: str) -> None:
+        login_url = f'{self.base_url}/login.php'
+        takelogin_url = f'{self.base_url}/takelogin.php'
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            r = await client.get(login_url)
+            token = self._extract_csrf(r.text)
+            if not token:
+                raise LoginException('CZT: unable to locate csrf_token on login page.')  # noqa F405
+            data: dict[str, str] = {
+                'csrf_token': token,
+                'username': self.username,
+                'password': self.password,
+                'returnto': '/index.php',
+            }
+            if self.totp:
+                data['totp'] = self.totp
+            await client.post(takelogin_url, data=data)
+            await asyncio.sleep(0.5)
+            check = await client.get(f'{self.base_url}/index.php')
+            if 'logout.php' in check.text or 'Logout' in check.text:
+                console.print('[green]CZT: logged in successfully.')
+                self.cookie_validator._save_cookies_secure(client.cookies.jar, cookiefile)  # pyright: ignore[reportPrivateUsage]
+            else:
+                console.print('[bold red]CZT: login failed (check username/password, totp, or rate-limit).')
+
+    async def search_existing(self, meta: dict[str, Any], _disctype: str) -> list[str]:
+        dupes: list[str] = []
+        cookiefile_json, cookiefile_pkl = self._cookie_paths(meta)
+        cookies = self._load_cookie_dict(cookiefile_json, cookiefile_pkl)
+        imdb_id_value = str(meta.get('imdb_id', '0'))
+        if imdb_id_value.isdigit() and int(imdb_id_value) != 0:
+            params: dict[str, Any] = {'search': f"tt{int(imdb_id_value):07d}"}
+        else:
+            params = {'search': meta.get('title', '')}
+        try:
+            async with httpx.AsyncClient(cookies=cookies, timeout=15.0) as client:
+                resp = await client.get(f'{self.base_url}/browse.php', params=params)
+            if resp.status_code != 200:
+                console.print(f"[bold red]CZT: search returned HTTP {resp.status_code}")
+                return dupes
+            soup = BeautifulSoup(resp.text, 'html.parser')
+            for a in soup.find_all('a', href=True):
+                href = a['href']
+                if isinstance(href, str) and re.match(r'details\.php\?id=\d+', href):
+                    title = a.get('title') or a.get_text(strip=True)
+                    if title:
+                        dupes.append(str(title))
+        except httpx.RequestError as e:
+            console.print(f"[bold red]CZT search error: {e}")
+        return dupes
+
+    async def upload(self, meta: dict[str, Any], _disctype: str) -> bool:
+        common = COMMON(config=self.config)
+        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
+
+        cookiefile_json, cookiefile_pkl = self._cookie_paths(meta)
+        cookies = self._load_cookie_dict(cookiefile_json, cookiefile_pkl)
+
+        # MediaInfo paste (descr field on CZTeam holds MediaInfo)
+        if meta.get('bdinfo') is not None:
+            mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt"
+        else:
+            mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt"
+        async with aiofiles.open(mi_path, encoding='utf-8') as f:
+            mi_dump = await f.read()
+
+        # Free-form body (user_descr — BBCode); reuse UA's generated description
+        desc_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/DESCRIPTION.txt"
+        user_descr = ''
+        if os.path.exists(desc_path):
+            async with aiofiles.open(desc_path, encoding='utf-8') as f:
+                user_descr = (await f.read()).strip()
+
+        torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent"
+        async with aiofiles.open(torrent_path, 'rb') as f:
+            torrent_bytes = await f.read()
+
+        torrent_name = str(meta.get('name', '')).strip().replace(' ', '.')
+        cat_id = await self.get_category_id(meta)
+
+        files = {'file': (f"{torrent_name}.torrent", torrent_bytes, 'application/x-bittorrent')}
+        data: dict[str, str] = {
+            'name': torrent_name,
+            'type': str(cat_id),
+            'descr': mi_dump,
+            'user_descr': user_descr,
+            'resolution': self._meta_resolution(meta),
+            'codec': self._meta_codec(meta),
+            'container': self._meta_container(meta),
+            'source': self._meta_source(meta),
+            # url is the IMDB URL; takeupload.php extracts the tt-id from it
+            'url': f"https://www.imdb.com/title/tt{int(meta['imdb_id']):07d}/" if str(meta.get('imdb_id', '0')).isdigit() and int(meta.get('imdb_id', 0)) != 0 else '',
+            'poster': '',
+            'tube': '',
+            'genre': '',
+            'ripnfo': '0',
+            'stripasciiart': '0',
+        }
+
+        if meta.get('debug'):
+            console.print(f"{self.base_url}/takeupload.php")
+            scrubbed = {k: ('<binary>' if k == 'file' else (v[:120] + '…') if isinstance(v, str) and len(v) > 120 else v) for k, v in data.items()}
+            console.print(scrubbed)
+            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
+            await common.create_torrent_for_upload(meta, f"{self.tracker}_DEBUG", f"{self.tracker}_DEBUG", announce_url="https://fake.tracker")
+            return True
+
+        upload_form_url = f'{self.base_url}/upload.php'
+        takeupload_url = f'{self.base_url}/takeupload.php'
+        async with httpx.AsyncClient(cookies=cookies, timeout=120.0, follow_redirects=True) as client:
+            # Re-fetch the upload form to mint a fresh csrf_token
+            form_resp = await client.get(upload_form_url)
+            token = self._extract_csrf(form_resp.text)
+            if not token:
+                console.print('[bold red]CZT: could not extract csrf_token from upload.php (session expired?).')
+                return False
+            data['csrf_token'] = token
+            up = await client.post(takeupload_url, data=data, files=files)
+
+        # Word boundary on "details" so the header's userdetails.php link
+        # doesn't false-match the upload result.
+        m = re.search(r'(?<![a-z])details\.php\?id=(\d+)', up.text)
+        if m:
+            torrent_id = m.group(1)
+            details_url = urljoin(f'{self.base_url}/', f'details.php?id={torrent_id}')
+            meta['tracker_status'][self.tracker]['status_message'] = details_url
+            await self.download_new_torrent(cookies, torrent_id, torrent_path)
+            return True
+
+        # Server-rendered error path: takeupload.php's abort() echoes
+        # <p style="color:red">$msg</p> — surface that to the user.
+        err = re.search(r'<p style="color:red">(.*?)</p>', up.text, flags=re.DOTALL)
+        reason = err.group(1).strip() if err else f"unexpected response (HTTP {up.status_code})"
+        console.print(f"[bold red]CZT upload failed: {reason}")
+        if meta.get('debug'):
+            console.print(up.text[:2000])
+        raise UploadException(f"Upload to CZT failed: {reason}", 'red')  # noqa F405
+
+    async def download_new_torrent(self, cookies: dict[str, str], torrent_id: str, torrent_path: str) -> None:
+        # CZTeam's download.php accepts ?torrent=<id> (legacy form) or the
+        # /download/<id>/<name>.torrent rewrite path. The ?id= shape returns
+        # "Invalid id". The query-string form is the simplest for cross-seed.
+        url = f'{self.base_url}/download.php?torrent={torrent_id}'
+        async with httpx.AsyncClient(cookies=cookies, timeout=30.0, follow_redirects=True) as client:
+            r = await client.get(url)
+        if r.status_code == 200 and r.content[:1] == b'd':
+            async with aiofiles.open(torrent_path, 'wb') as f:
+                await f.write(r.content)
+        else:
+            console.print(f"[red]CZT: failed to download replacement .torrent (HTTP {r.status_code})")

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -29,6 +29,7 @@ from src.trackers.BT import BT
 from src.trackers.CBR import CBR
 from src.trackers.COMMON import COMMON
 from src.trackers.CZ import CZ
+from src.trackers.CZT import CZT
 from src.trackers.DC import DC
 from src.trackers.DP import DP
 from src.trackers.DT import DT
@@ -1338,7 +1339,7 @@ class TRACKER_SETUP:
 
 tracker_class_map: dict[str, type[Any]] = {
     'A4K': A4K, 'ACM': ACM, 'AITHER': AITHER, 'ANT': ANT, 'AR': AR, 'ASC': ASC, 'AZ': AZ, 'BHD': BHD, 'BHDTV': BHDTV, 'BJS': BJS, 'BLU': BLU, 'BT': BT, 'CBR': CBR,
-    'CZ': CZ, 'DC': DC, 'DP': DP, 'DT': DT, 'EMUW': EMUW, 'FNP': FNP, 'FF': FF, 'FL': FL, 'FRIKI': FRIKI, 'GPW': GPW, 'HDB': HDB, 'HDS': HDS, 'HDT': HDT, 'HHD': HHD, 'HUNO': HUNO, 'ITT': ITT,
+    'CZ': CZ, 'CZT': CZT, 'DC': DC, 'DP': DP, 'DT': DT, 'EMUW': EMUW, 'FNP': FNP, 'FF': FF, 'FL': FL, 'FRIKI': FRIKI, 'GPW': GPW, 'HDB': HDB, 'HDS': HDS, 'HDT': HDT, 'HHD': HHD, 'HUNO': HUNO, 'ITT': ITT,
     'IHD': IHD, 'IS': IS, 'LCD': LCD, 'LDU': LDU, 'LST': LST, 'LT': LT, 'LUME': LUME, 'MTV': MTV, 'NBL': NBL, 'OE': OE, 'OTW': OTW, 'PHD': PHD, 'PT': PT, 'PTP': PTP, 'PTER': PTER, 'PTS': PTS, 'PTT': PTT,
     'R4E': R4E, 'RAS': RAS, 'RF': RF, 'RTF': RTF, 'SAM': SAM, 'SHRI': SHRI, 'SN': SN, 'SP': SP, 'SPD': SPD, 'STC': STC, 'THR': THR,
     'TIK': TIK, 'TL': TL, 'TLZ': TLZ, 'TOS': TOS, 'TVC': TVC, 'TTG': TTG, 'TTR': TTR, 'ULCX': ULCX, 'UTP': UTP, 'YOINK': YOINK, 'YUS': YUS
@@ -1354,5 +1355,5 @@ other_api_trackers = {
 }
 
 http_trackers = {
-    'AR', 'ASC', 'AZ', 'BJS', 'BT', 'CZ', 'FF', 'FL', 'HDB', 'HDS', 'HDT', 'IS', 'MTV', 'PHD', 'PTER', 'PTS', 'TTG'
+    'AR', 'ASC', 'AZ', 'BJS', 'BT', 'CZ', 'CZT', 'FF', 'FL', 'HDB', 'HDS', 'HDT', 'IS', 'MTV', 'PHD', 'PTER', 'PTS', 'TTG'
 }


### PR DESCRIPTION
Hey — I know UA is in development freeze and only critical bugs are
being looked at right now. Totally fine to close this as out of scope
or shelve it; opening in case it's useful anyway.

Adds CZTeam (czteam.me) — Romanian private tracker on the
BTSource/NVTracker lineage, so the plugin is modeled on FL.py:
multipart POST to takeupload.php with a per-form csrf_token,
browser-exported cookies for auth (Turnstile on login = no programmatic
login, same as FL). One new plugin, two registry lines, a config
stanza, and a setup doc at docs/CZTEAM.md.

Tested end-to-end against the live tracker — torrent landed, the
re-issued .torrent comes back with the passkey injected into the
announce URL for cross-seed.

Thanks for UA either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CZTeam tracker support with session-cookie authentication, optional TOTP, duplicate detection, and automated category mapping from release metadata (movie/TV, resolution, codec, language).
  * Downloads and records replacement torrents after successful uploads.

* **Documentation**
  * Added a comprehensive CZTeam integration guide: setup, cookie export/format, configuration, debug dry-run vs real upload, category mapping, multi-tracker behavior, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->