### PR TITLE
feat(DP): add prompt to include Hybrid in release names

### DIFF
--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -122,9 +122,28 @@ class DP(UNIT3D):
             dp_name = dp_name.replace("Dual-Audio", audio)
 
         # Handle Hybrid tag — DarkPeers requires it when audio/video are from different sources
-        if re.search(r'\bHybrid\b', dp_name, re.IGNORECASE):
-            # Already present: normalize casing to "Hybrid"
-            dp_name = re.sub(r'\bHybrid\b', 'Hybrid', dp_name, flags=re.IGNORECASE)
+        # Only look for "Hybrid" in the technical portion (after title + year) to avoid
+        # false positives from titles like "Hybrid the Monster 2025"
+        title = str(meta.get('title', ''))
+        year = str(meta.get('year', ''))
+        # Build a prefix to skip: find where the technical tags start
+        technical_suffix = dp_name
+        if title:
+            title_idx = dp_name.find(title)
+            if title_idx != -1:
+                technical_suffix = dp_name[title_idx + len(title):]
+        if year and year in technical_suffix:
+            year_idx = technical_suffix.find(year)
+            technical_suffix = technical_suffix[year_idx + len(year):]
+
+        has_hybrid_tag = bool(re.search(r'\bHybrid\b', technical_suffix, re.IGNORECASE))
+
+        if has_hybrid_tag:
+            # Already present in technical portion: normalize casing to "Hybrid"
+            # Replace only in the technical portion to avoid touching the title
+            prefix = dp_name[:len(dp_name) - len(technical_suffix)]
+            technical_suffix = re.sub(r'\bHybrid\b', 'Hybrid', technical_suffix, flags=re.IGNORECASE)
+            dp_name = prefix + technical_suffix
         elif not meta.get('unattended') or meta.get('unattended_confirm', False):
             console.print(
                 f'[bold yellow][{self.tracker}] DarkPeers requires "Hybrid" in the name '

--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -121,12 +121,8 @@ class DP(UNIT3D):
         if audio and audio != "SKIPPED" and "Dual-Audio" in dp_name:
             dp_name = dp_name.replace("Dual-Audio", audio)
 
-        # Handle Hybrid tag — DarkPeers requires it when audio/video are from different sources
-        # Only look for "Hybrid" in the technical portion (after title + year) to avoid
-        # false positives from titles like "Hybrid the Monster 2025"
         title = str(meta.get('title', ''))
         year = str(meta.get('year', ''))
-        # Build a prefix to skip: find where the technical tags start
         technical_suffix = dp_name
         if title:
             title_idx = dp_name.find(title)
@@ -139,8 +135,6 @@ class DP(UNIT3D):
         has_hybrid_tag = bool(re.search(r'\bHybrid\b', technical_suffix, re.IGNORECASE))
 
         if has_hybrid_tag:
-            # Already present in technical portion: normalize casing to "Hybrid"
-            # Replace only in the technical portion to avoid touching the title
             prefix = dp_name[:len(dp_name) - len(technical_suffix)]
             technical_suffix = re.sub(r'\bHybrid\b', 'Hybrid', technical_suffix, flags=re.IGNORECASE)
             dp_name = prefix + technical_suffix
@@ -156,7 +150,6 @@ class DP(UNIT3D):
                 elif resolution and dp_name.endswith(f' {resolution}'):
                     dp_name = dp_name[: -len(resolution)] + f'Hybrid {resolution}'
                 else:
-                    # Fallback: append at the end
                     dp_name = f'{dp_name} Hybrid'
 
         return {'name': dp_name}

--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+import re
 from typing import Any, cast
 
 import cli_ui
@@ -119,5 +120,24 @@ class DP(UNIT3D):
         audio = await self.get_audio(meta)
         if audio and audio != "SKIPPED" and "Dual-Audio" in dp_name:
             dp_name = dp_name.replace("Dual-Audio", audio)
+
+        # Handle Hybrid tag — DarkPeers requires it when audio/video are from different sources
+        if re.search(r'\bHybrid\b', dp_name, re.IGNORECASE):
+            # Already present: normalize casing to "Hybrid"
+            dp_name = re.sub(r'\bHybrid\b', 'Hybrid', dp_name, flags=re.IGNORECASE)
+        elif not meta.get('unattended') or meta.get('unattended_confirm', False):
+            console.print(
+                f'[bold yellow][{self.tracker}] DarkPeers requires "Hybrid" in the name '
+                'when audio and video come from different sources.'
+            )
+            if cli_ui.ask_yes_no('Does this release require "Hybrid" in the name?', default=False):
+                resolution = str(meta.get('resolution', ''))
+                if resolution and f' {resolution} ' in dp_name:
+                    dp_name = dp_name.replace(f' {resolution} ', f' Hybrid {resolution} ', 1)
+                elif resolution and dp_name.endswith(f' {resolution}'):
+                    dp_name = dp_name[: -len(resolution)] + f'Hybrid {resolution}'
+                else:
+                    # Fallback: append at the end
+                    dp_name = f'{dp_name} Hybrid'
 
         return {'name': dp_name}

--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -12,7 +12,10 @@ from src.trackers.UNIT3D import UNIT3D
 
 
 class DP(UNIT3D):
+    """Tracker class for DarkPeers (DP), a UNIT3D-based Nordic tracker."""
+
     def __init__(self, config: dict[str, Any]):
+        """Initialize the DarkPeers tracker with API endpoints and banned groups."""
         super().__init__(config, tracker_name='DP')
         self.config = config
         self.tmdb_manager = TmdbManager(config)
@@ -35,6 +38,7 @@ class DP(UNIT3D):
         pass
 
     async def get_additional_checks(self, meta: dict[str, Any]) -> bool:
+        """Validate DP-specific upload rules: folder structure, Nordic languages, EVO, and hardcoded subs."""
         should_continue = True
         if meta.get('keep_folder'):
             if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
@@ -64,6 +68,7 @@ class DP(UNIT3D):
         return should_continue
 
     async def get_description(self, meta: dict[str, Any]) -> dict[str, str]:
+        """Build the upload description, fetching a Nordic-language logo from TMDB if needed."""
         if meta.get('logo', "") == "":
             TMDB_API_KEY = self.config['DEFAULT'].get('tmdb_api')
             TMDB_BASE_URL = "https://api.themoviedb.org/3"
@@ -88,6 +93,7 @@ class DP(UNIT3D):
         return {'description': await DescriptionBuilder(self.tracker, self.config).unit3d_edit_desc(meta)}
 
     async def get_additional_data(self, meta: dict[str, Any]) -> dict[str, Any]:
+        """Return additional upload fields including mod queue opt-in."""
         data = {
             'mod_queue_opt_in': await self.get_flag(meta, 'modq'),
         }
@@ -95,6 +101,7 @@ class DP(UNIT3D):
         return data
 
     async def get_audio(self, meta: dict[str, Any]) -> str:
+        """Determine the audio language tag: single language, Dual-Audio, or MULTi."""
         languages_result = "SKIPPED"
 
         if not meta.get('language_checked', False):
@@ -115,6 +122,7 @@ class DP(UNIT3D):
         return f'{languages_result}'
 
     async def get_name(self, meta: dict[str, Any]) -> dict[str, str]:
+        """Build the release name with audio language normalization and Hybrid tag handling."""
         dp_name = str(meta.get('name', ''))
 
         audio = await self.get_audio(meta)


### PR DESCRIPTION
If it's on the name, it just adds. If not, ask the user. On --unattended just skips it

#1336 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently standardizes release names to normalize "Hybrid" capitalization.
  * Prompts users during interactive runs to add "Hybrid" when appropriate, inserting it near resolution tokens or appending it for clearer names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->