### PR TITLE
feat: Add Argument-Embedded Text Queue with Global Defaults Preservation

### DIFF
--- a/docs/cli-args.md
+++ b/docs/cli-args.md
@@ -30,6 +30,19 @@ upload.py [path...] [options]
 - `-su`, `--site-upload TRACKER`: Process site searches and upload to a single tracker (tracker acronym is uppercased).
 - `--unit3d`: Parse a text output file from `UNIT3D-Upload-Checker`.
 
+### Argument-Embedded Text Queue (.txt)
+
+If you pass a `.txt` file as the main positional input path (without specifying `--unit3d`), Upload Assistant will treat it as a batch queue of independent upload tasks, where each line represents a separate command.
+
+- **Format**: Each line contains the path to the directory/file to upload, followed by any custom arguments/flags you want to apply to that specific task:
+  ```text
+  "F:\Movies\Fun.Movie.2026.1080p.BluRay-Group" -tk AITHER -df "desc_filename.txt" -imdb tt00000000 --anon
+  "D:\TV Shows\Fun.TV.Show.2026.1080p.WEB-DL-Group" -tk LST -df "desc_filename.txt" -tvdb 00000000 -pr
+  ```
+- **Comments and Empty Lines**: You can add comments starting with `#` or leave empty lines; they are automatically skipped.
+- **Queue Progress & Resume**: Progress is isolated and tracked automatically based on the `.txt` filename (e.g., `my_queue.txt` uses `tmp/my_queue_processed_files.log`). If you stop and restart, Upload Assistant will skip already completed lines, allowing you to easily resume or append new items to the file.
+- **Global Defaults & Overrides**: Any arguments passed to the initial command (e.g., `python upload.py my_queue.txt -debug --anon`) act as **global defaults** for all items in the queue. Line-specific arguments inside the `.txt` file will override these defaults for that specific task. For example, passing `-debug` globally is a great way to dry-run your entire queue!
+
 ## Screenshots / images
 
 - `-s`, `--screens N`: Number of screenshots.

--- a/src/queuemanage.py
+++ b/src/queuemanage.py
@@ -5,6 +5,7 @@ import glob
 import json
 import os
 import re
+import shlex
 from collections.abc import Mapping, MutableMapping, Sequence
 from pathlib import Path
 from typing import Any, Optional, Union, cast
@@ -432,8 +433,6 @@ class QueueManager:
                     if not line_stripped or line_stripped.startswith("#"):
                         continue
 
-                    import shlex
-
                     try:
                         args_list = shlex.split(line_stripped, posix=False)
                         cleaned_args = []
@@ -451,8 +450,10 @@ class QueueManager:
 
                         if line_stripped not in processed_files and item_path not in processed_files:
                             queue.append(queue_item)
+                    except ValueError as e:
+                        console.print(f"[red]Error parsing line (shlex) in queue file: {line_stripped}. Error: {e}[/red]")
                     except Exception as e:
-                        console.print(f"[red]Error parsing line in queue file: {line_stripped}. Error: {e}[/red]")
+                        console.print(f"[red]Unexpected error processing line in queue file: {line_stripped}. Error: {e}[/red]")
 
                 if not queue:
                     console.print(f"[bold yellow]All items in the {queue_name} queue have already been processed.[/bold yellow]")
@@ -748,7 +749,7 @@ async def extract_safe_file_locations(log_file: str) -> list[str]:
 
 
 async def display_queue(
-    queue: Sequence[str],
+    queue: Sequence[Any],
     base_dir: Optional[str] = None,
     queue_name: Optional[str] = None,
     save_to_log: bool = True,

--- a/src/queuemanage.py
+++ b/src/queuemanage.py
@@ -353,13 +353,20 @@ class QueueManager:
 
     @staticmethod
     async def display_queue(
-        queue: Sequence[str],
+        queue: Sequence[Any],
         base_dir: Optional[str] = None,
         queue_name: Optional[str] = None,
         save_to_log: bool = True,
     ) -> None:
         """Displays the queued files in markdown format and optionally saves them to a log file in the tmp directory."""
-        md_text = "\n - ".join(queue)
+        paths_or_lines = []
+        for item in queue:
+            if isinstance(item, dict):
+                paths_or_lines.append(item.get("line") or item.get("path", ""))
+            else:
+                paths_or_lines.append(str(item))
+
+        md_text = "\n - ".join(paths_or_lines)
         console.print("\n[bold green]Queuing these files:[/bold green]", end='')
         console.print(Markdown(f"- {md_text.rstrip()}\n\n", style=Style(color='cyan')))
         console.print("\n\n")
@@ -377,7 +384,7 @@ class QueueManager:
             log_file = os.path.join(tmp_dir, f"{queue_name}_queue.log")
 
             try:
-                await _write_json_file(log_file, list(queue), indent=4)
+                await _write_json_file(log_file, paths_or_lines, indent=4)
                 console.print(f"[bold green]Queue successfully saved to log file: {log_file}")
             except Exception as e:
                 console.print(f"[bold red]Failed to save queue to log file: {e}")
@@ -408,7 +415,64 @@ class QueueManager:
 
         log_file = os.path.join(base_dir, "tmp", f"{meta.get('queue', 'default')}_queue.log")
 
-        if path.endswith('.txt') and meta.get('unit3d'):
+        if path.endswith(".txt") and not meta.get("unit3d"):
+            console.print(f"[bold yellow]Detected a text file for queue input: {path}[/bold yellow]")
+            if os.path.exists(path):
+                queue_name = os.path.splitext(os.path.basename(path))[0]
+                meta["queue"] = queue_name
+                meta["args_line_queue"] = True
+
+                log_file = await QueueManager.get_log_file(base_dir, queue_name)
+                processed_files = await QueueManager.load_processed_files(log_file)
+
+                lines = await _read_text_lines(path)
+                queue = []
+                for line in lines:
+                    line_stripped = line.strip()
+                    if not line_stripped or line_stripped.startswith("#"):
+                        continue
+
+                    import shlex
+
+                    try:
+                        args_list = shlex.split(line_stripped, posix=False)
+                        cleaned_args = []
+                        for arg in args_list:
+                            if (arg.startswith('"') and arg.endswith('"')) or (arg.startswith("'") and arg.endswith("'")):
+                                arg = arg[1:-1]
+                            cleaned_args.append(arg)
+
+                        if not cleaned_args:
+                            continue
+
+                        item_path = cleaned_args[0]
+
+                        queue_item: QueueItem = {"path": item_path, "args": cleaned_args, "line": line_stripped}
+
+                        if line_stripped not in processed_files and item_path not in processed_files:
+                            queue.append(queue_item)
+                    except Exception as e:
+                        console.print(f"[red]Error parsing line in queue file: {line_stripped}. Error: {e}[/red]")
+
+                if not queue:
+                    console.print(f"[bold yellow]All items in the {queue_name} queue have already been processed.[/bold yellow]")
+                    exit(0)
+
+                queue_log = os.path.join(base_dir, "tmp", f"{queue_name}_queue.log")
+                try:
+                    await _write_json_file(queue_log, [item["line"] for item in queue], indent=4)
+                except OSError as e:
+                    console.print(f"[bold red]Failed to save the queue log file: {e}[/bold red]")
+
+                if meta.get("debug"):
+                    await QueueManager.display_queue(queue, base_dir, queue_name, save_to_log=False)
+
+                return queue, log_file
+            else:
+                console.print(f"[bold red]Text file not found: {path}. Exiting.[/bold red]")
+                exit(1)
+
+        elif path.endswith(".txt") and meta.get("unit3d"):
             console.print(f"[bold yellow]Detected a text file for queue input: {path}[/bold yellow]")
             if os.path.exists(path):
                 safe_file_locations = await QueueManager.extract_safe_file_locations(path)

--- a/upload.py
+++ b/upload.py
@@ -1551,7 +1551,7 @@ async def do_the_thing(base_dir: str) -> None:
                     for key, val in base_meta.items():
                         if val not in (None, False, []):
                             option_strings = dest_to_options.get(key, [])
-                            if option_strings and not any(opt in args_list for opt in option_strings):
+                            if option_strings and not any(arg == opt or arg.startswith(opt + "=") for opt in option_strings for arg in args_list):
                                 meta[key] = val
 
                     path = meta.get("path")

--- a/upload.py
+++ b/upload.py
@@ -1535,6 +1535,27 @@ async def do_the_thing(base_dir: str) -> None:
                     queue_item_mapping = cast(Mapping[str, Any], queue_item)
                     path = await QueueManager.process_site_upload_item(queue_item_mapping, meta)
                     current_item_path = path  # Store for logging
+                elif meta.get("args_line_queue") and isinstance(queue_item, dict) and "args" in queue_item:
+                    # Extract path and arguments from custom args queue item
+                    args_list = queue_item["args"]
+                    # We parse the arguments for this specific item using the parser, updating the cloned meta dict.
+                    meta, parser_obj, _before_args = cast(tuple[Meta, Any, Any], parser.parse(args_list, meta))
+
+                    # Preserve global defaults from base_meta if they were not explicitly overridden in args_list
+                    dest_to_options = {}
+                    if parser_obj and hasattr(parser_obj, "_actions"):
+                        for action in parser_obj._actions:
+                            if action.dest and action.option_strings:
+                                dest_to_options[action.dest] = action.option_strings
+
+                    for key, val in base_meta.items():
+                        if val not in (None, False, []):
+                            option_strings = dest_to_options.get(key, [])
+                            if option_strings and not any(opt in args_list for opt in option_strings):
+                                meta[key] = val
+
+                    path = meta.get("path")
+                    current_item_path = queue_item.get("line") or path
                 else:
                     # Regular queue processing
                     path = queue_item if isinstance(queue_item, str) else str(queue_item)
@@ -1651,7 +1672,7 @@ async def do_the_thing(base_dir: str) -> None:
                             if meta.get('site_upload_queue'):
                                 await QueueManager.save_processed_path(log_file, current_item_path)
                             else:
-                                await save_processed_file(log_file, path)
+                                await save_processed_file(log_file, current_item_path)
 
             else:
                 meta = cast(Meta, meta)
@@ -1744,7 +1765,7 @@ async def do_the_thing(base_dir: str) -> None:
                             if meta.get('site_upload_queue'):
                                 await QueueManager.save_processed_path(log_file, current_item_path)
                             else:
-                                await save_processed_file(log_file, path)
+                                await save_processed_file(log_file, current_item_path)
 
             if meta['debug']:
                 finish_time = time.time()
@@ -1822,7 +1843,7 @@ async def do_the_thing(base_dir: str) -> None:
                     if meta.get('site_upload_queue'):
                         await QueueManager.save_processed_path(log_file, current_item_path)
                     else:
-                        await save_processed_file(log_file, path)
+                        await save_processed_file(log_file, current_item_path)
 
             if meta.get('delete_tmp', False) and tmp_path and os.path.exists(tmp_path) and meta.get('emby', False):
                 try:


### PR DESCRIPTION
This Pull Request introduces a feature allowing batch-uploading from various locations using a single `.txt` queue file, where each line can contain its own independent command-line overrides and arguments.

## Key Changes
- **Argument-Embedded `.txt` Queue Parsing**: Passing a `.txt` file as the main positional input path (without `--unit3d`) automatically triggers this queue mode.
- **Robust Argument Parsing (`shlex`)**: Uses Python's standard `shlex` library with double-quotes handling to cleanly parse Windows paths containing backslashes and spaces, as well as line-level argument tokens.
- **Global Defaults Inheritance**: Designed a robust mechanism where global flags passed in the main command (e.g., `-ua`, `-debug`, `--anon`) are automatically preserved and inherited as baseline defaults for all items.
- **Progress Tracking & Isolation**: Progress is tracked and logged in a file named after the `.txt` file (e.g., `my_queue_processed_files.log`). Re-running the command skips completed lines, permitting easy resume and text append.
- **Comments and Empty Lines**: Supports comment lines starting with `#` and skips blank lines.
- **Detailed Documentation**: Added clear instructions in `docs/cli-args.md` explaining the format, globality of arguments, and state isolation.

## Example Queue File (`my_uploads.txt`):
```text
# This is a comment
"F:\Movies\Adventure.Movie.2026.1080p-Group" -tk AITHER -imdb tt00000000 --anon
"D:\TV Shows\Special.Show.S01.1080p-Group" -tk CBR -tvdb 00000000 -pr
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-line text-queue support: each non-empty, non-# line can include per-item arguments that override defaults for that upload task.

* **Bug Fixes**
  * Queue processing now skips already-processed items and exits cleanly when no new items remain.
  * Processed-path logging is more consistent so resumed queues reflect the actual uploaded items.

* **Documentation**
  * CLI docs updated to explain the text-queue format, per-line args, and resume/progress tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Audionut/Upload-Assistant/pull/1379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->